### PR TITLE
Correcting the position of the EOF-check in the parser example

### DIFF
--- a/writing_checks/README.md
+++ b/writing_checks/README.md
@@ -675,9 +675,9 @@ self.sanity_patterns = {
         '(?P<line>Hello, World\!)' : [
             ('line',
              str, parser.match_line)
-        ]
-    },
-    '\e' : parser.match_eof
+        ],
+        '\e' : parser.match_eof
+    }
 }
 ```
 


### PR DESCRIPTION
Fixes Gitlab issue #336