### PR TITLE
Remove 'pre_run' and 'post_run' access from 'job'

### DIFF
--- a/cscs-checks/apps/openfoam-extend/check_openfoam_extend.py
+++ b/cscs-checks/apps/openfoam-extend/check_openfoam_extend.py
@@ -32,10 +32,7 @@ class OpenfoamExtendBaseTest(RunOnlyRegressionTest):
         self.maintainers = ['MaKra']
         self.tags = {'scs', 'production'}
 
-    def setup(self, partition, environ, **job_opts):
-        super().setup(partition, environ, **job_opts)
-        self.job.pre_run = [
-            'source $FOAM_INST_DIR/foam-extend-4.0/etc/bashrc']
+        self.pre_run = ['source $FOAM_INST_DIR/foam-extend-4.0/etc/bashrc']
 
 
 class BlockMesh(OpenfoamExtendBaseTest):

--- a/cscs-checks/apps/openfoam/check_openfoam.py
+++ b/cscs-checks/apps/openfoam/check_openfoam.py
@@ -27,9 +27,7 @@ class OpenFOAMBaseTest(RunOnlyRegressionTest):
         self.maintainers = ['MaKra']
         self.tags = {'scs', 'production'}
 
-    def setup(self, partition, environ, **job_opts):
-        super().setup(partition, environ, **job_opts)
-        self.job.pre_run = ['source $FOAM_BASH']
+        self.pre_run = ['source $FOAM_BASH']
 
 
 class BlockMesh(OpenFOAMBaseTest):

--- a/cscs-checks/libraries/io/hdf5_compile_run.py
+++ b/cscs-checks/libraries/io/hdf5_compile_run.py
@@ -75,9 +75,7 @@ class HDF5Test(RegressionTest):
         self.maintainers = ['SO']
         self.tags = {'production'}
 
-    def setup(self, partition, environ, **job_opts):
-        super().setup(partition, environ, **job_opts)
-        self.job.post_run = ['h5dump h5ex_d_chunk.h5 > h5dump_out.txt']
+        self.post_run = ['h5dump h5ex_d_chunk.h5 > h5dump_out.txt']
 
     def compile(self):
         self.current_environ.cflags = self.flags

--- a/cscs-checks/tools/io/cdo.py
+++ b/cscs-checks/tools/io/cdo.py
@@ -32,9 +32,13 @@ class CDOBaseCheck(RunOnlyRegressionTest):
         self.valid_systems = ['daint:gpu', 'daint:mc', 'dom:gpu', 'dom:mc',
                               'kesch:pn', 'kesch:cn']
         self.valid_prog_environs = ['PrgEnv-gnu']
-        self.modules  = ['CDO']
         self.maintainers = ['SO']
         self.tags = {'production'}
+
+    def setup(self, partition, environ, **job_opts):
+        cdo_name = 'cdo' if self.current_system.name == 'kesch' else 'CDO'
+        self.modules = [cdo_name]
+        super().setup(partition, environ, **job_opts)
 
 
 # Check that the netCDF loaded by the CDO module supports the nc4 filetype
@@ -73,12 +77,17 @@ class NCOModuleCompatibilityCheck(CDOBaseCheck):
         super().__init__('nco_module_compat', **kwargs)
         self.descr = ('verifies compatibility with the NCO module')
         self.sourcesdir = None
+        output_file = 'cdo_nco_check.out'
+        self.executable = 'echo > %s' % output_file
         self.executable = 'echo'
         self.sanity_patterns = sn.all([
-            sn.assert_not_found(r'.+', self.stdout),
+            sn.assert_not_found(r'.+', output_file),
             sn.assert_not_found(r'.+', self.stderr)])
 
-        self.pre_run = ['module load NCO']
+    def setup(self, partition, environ, **job_opts):
+        nco_name = 'nco' if self.current_system.name == 'kesch' else 'NCO'
+        self.pre_run = ['module load %s' % nco_name]
+        super().setup(partition, environ, **job_opts)
 
 
 class InfoNCCheck(CDOBaseCheck):

--- a/cscs-checks/tools/io/cdo.py
+++ b/cscs-checks/tools/io/cdo.py
@@ -77,11 +77,8 @@ class NCOModuleCompatibilityCheck(CDOBaseCheck):
         super().__init__('nco_module_compat', **kwargs)
         self.descr = ('verifies compatibility with the NCO module')
         self.sourcesdir = None
-        output_file = 'cdo_nco_check.out'
-        self.executable = 'echo > %s' % output_file
         self.executable = 'echo'
         self.sanity_patterns = sn.all([
-            sn.assert_not_found(r'.+', output_file),
             sn.assert_not_found(r'.+', self.stderr)])
 
     def setup(self, partition, environ, **job_opts):

--- a/cscs-checks/tools/io/cdo.py
+++ b/cscs-checks/tools/io/cdo.py
@@ -78,9 +78,7 @@ class NCOModuleCompatibilityCheck(CDOBaseCheck):
             sn.assert_not_found(r'.+', self.stdout),
             sn.assert_not_found(r'.+', self.stderr)])
 
-    def setup(self, partition, environ, **job_opts):
-        super().setup(partition, environ, **job_opts)
-        self.job.pre_run = ['module load NCO']
+        self.pre_run = ['module load NCO']
 
 
 class InfoNCCheck(CDOBaseCheck):
@@ -170,11 +168,13 @@ class MergeNC4CCheck(CDOBaseCheck):
         self.descr = ('verifies merging and compressing of 3 compressed '
                       'netCDF-4 files')
         self.executable = 'cdo'
-        self.executable_opts = ['-O', '-z', 'zip', 'merge',
-                                'test_echam_spectral-deflated_wind10.nc4c',
-                                'test_echam_spectral-deflated_wl.nc4c',
-                                'test_echam_spectral-deflated_ws.nc4c',
-                                'test_echam_spectral-deflated_wind10_wl_ws.nc4c']
+        self.executable_opts = [
+            '-O', '-z', 'zip', 'merge',
+            'test_echam_spectral-deflated_wind10.nc4c',
+            'test_echam_spectral-deflated_wl.nc4c',
+            'test_echam_spectral-deflated_ws.nc4c',
+            'test_echam_spectral-deflated_wind10_wl_ws.nc4c'
+        ]
         self.sanity_patterns = sn.all([
             sn.assert_not_found(r'(?i)unsupported|error', self.stderr),
             sn.assert_found(r'cdo merge: Processed 442368 values from 3 '
@@ -190,4 +190,3 @@ def _get_checks(**kwargs):
         MergeNCCheck(**kwargs), MergeNC4Check(**kwargs),
         MergeNC4CCheck(**kwargs)
     ]
-

--- a/cscs-checks/tools/io/nco.py
+++ b/cscs-checks/tools/io/nco.py
@@ -73,10 +73,8 @@ class CDOModuleCompatibilityCheck(NCOBaseCheck):
         super().__init__('cdo_module_compat', **kwargs)
         self.descr = ('verifies compatibility with the CDO module')
         self.sourcesdir = None
-        output_file = 'nco_cdo_check.out'
-        self.executable = 'echo > %s' % output_file
+        self.executable = 'echo'
         self.sanity_patterns = sn.all([
-            sn.assert_not_found(r'.+', output_file),
             sn.assert_not_found(r'.+', self.stderr)
         ])
 

--- a/cscs-checks/tools/io/nco.py
+++ b/cscs-checks/tools/io/nco.py
@@ -38,7 +38,7 @@ class DependencyCheck(NCOBaseCheck):
     def __init__(self, **kwargs):
         super().__init__('dependency', **kwargs)
         self.descr = ('verifies that the netCDF loaded by the NCO module '
-                     'supports the nc4 filetype')
+                      'supports the nc4 filetype')
         self.sourcesdir = None
         self.executable = 'nc-config'
         self.executable_opts = ['--has-nc4']
@@ -75,9 +75,7 @@ class CDOModuleCompatibilityCheck(NCOBaseCheck):
             sn.assert_not_found(r'.+', self.stderr)
         ])
 
-    def setup(self, partition, environ, **job_opts):
-        super().setup(partition, environ, **job_opts)
-        self.job.pre_run = ['module load CDO']
+        self.pre_run = ['module load CDO']
 
 
 class InfoNCCheck(NCOBaseCheck):
@@ -155,8 +153,8 @@ class MergeNC4Check(NCOBaseCheck):
         # verify the resulting file. Verifying would not be straight forward
         # as the following does not work (it seems that there is a timestamp
         # of file creation inserted in the metadata or similar):
-        #diff test_echam_spectral - deflated_wl.nc4 \
-        #     test_echam_spectral - deflated_wind10_wl.nc4
+        # diff test_echam_spectral - deflated_wl.nc4 \
+        #      test_echam_spectral - deflated_wind10_wl.nc4
         self.sanity_patterns = sn.all([
             sn.assert_not_found(r'(?i)unsupported|error', self.stderr),
             sn.assert_not_found(r'(?i)unsupported|error', self.stdout)

--- a/cscs-checks/tools/profiling_and_debugging/notool.py
+++ b/cscs-checks/tools/profiling_and_debugging/notool.py
@@ -71,6 +71,8 @@ class JacobiNoToolHybrid(RegressionTest):
         self.maintainers = ['VH', 'JG']
         self.tags = {'production'}
 
+        self.post_run = ['module list -t']
+
     def compile(self):
         prgenv_flags = self.prgenv_flags[self.current_environ.name]
         self.current_environ.cflags = prgenv_flags
@@ -92,7 +94,6 @@ class JacobiNoToolHybrid(RegressionTest):
             sn.assert_found('SUCCESS', self.stdout),
         ])
 
-        self.job.post_run = ['module list -t']
         self.reference['*:elapsed_time'] = self.reference_prgenv[self.current_environ.name]
 
 

--- a/cscs-checks/tools/profiling_and_debugging/scorep_mpi_omp.py
+++ b/cscs-checks/tools/profiling_and_debugging/scorep_mpi_omp.py
@@ -57,6 +57,12 @@ class ScorepHybrid(RegressionTest):
         self.maintainers = ['MK', 'JG']
         self.tags = {'production'}
 
+        # additional program call in order to generate the tracing output for
+        # the sanity check
+        self.post_run = [
+            'otf2-print scorep-*/traces.otf2 > %s' % self.otf2_file
+        ]
+
     def compile(self):
         prgenv_flags = self.prgenv_flags[self.current_environ.name]
         self.current_environ.cflags   = prgenv_flags
@@ -75,11 +81,6 @@ class ScorepHybrid(RegressionTest):
 
         self.modules = self.scorep_modules[environ.name]
         super().setup(partition, environ, **job_opts)
-        # additional program call in order to generate the tracing output for
-        # the sanity check
-        self.job.post_run = [
-            'otf2-print scorep-*/traces.otf2 > %s' % self.otf2_file
-        ]
 
 
 def _get_checks(**kwargs):


### PR DESCRIPTION
* Remove the `setup` method when used only to access the `pre_run`
  and `post_run` from `job`.

Fixes #112 
Fixes #136 