### PR TITLE
Make '--exclude' work with flexible allocation

### DIFF
--- a/reframe/core/schedulers/slurm.py
+++ b/reframe/core/schedulers/slurm.py
@@ -184,15 +184,15 @@ class SlurmJob(sched.Job):
     def _get_reservation_nodes(self):
         command = 'scontrol show res %s' % self.sched_reservation
         completed = os_ext.run_command(command, check=True)
-        node_match = reservation_nodes = re.search('(Nodes=\S+)',
-                                                   completed.stdout)
+        node_match = re.search('(Nodes=\S+)', completed.stdout)
         if node_match:
             reservation_nodes = node_match[1]
         else:
             raise JobError("could not extract the nodes names for "
                            "reservation '%s'" % self.sched_reservation)
+
         completed = os_ext.run_command(
-            'scontrol show -o -a %s' % reservation_nodes, check=True)
+            'scontrol show -o %s' % reservation_nodes, check=True)
         node_descriptions = completed.stdout.splitlines()
         return (SlurmNode(descr) for descr in node_descriptions)
 
@@ -200,7 +200,7 @@ class SlurmJob(sched.Job):
         if not self.sched_exclude_nodelist:
             return set()
 
-        command = 'scontrol show -o -a %s' % self.sched_exclude_nodelist
+        command = 'scontrol show -o node %s' % self.sched_exclude_nodelist
         try:
             completed = os_ext.run_command(command, check=True)
         except SpawnedProcessError as e:

--- a/reframe/core/schedulers/slurm.py
+++ b/reframe/core/schedulers/slurm.py
@@ -157,7 +157,7 @@ class SlurmJob(sched.Job):
         constraints = set()
         partitions = (set(self.sched_partition.split())
                       if self.sched_partition else set())
-        excluded_node_names = self._get_excluded_nodes()
+        excluded_node_names = self._get_excluded_node_names()
 
         if self.options:
             for optstr in self.options:
@@ -196,7 +196,7 @@ class SlurmJob(sched.Job):
         node_descriptions = completed.stdout.splitlines()
         return (SlurmNode(descr) for descr in node_descriptions)
 
-    def _get_excluded_nodes(self):
+    def _get_excluded_node_names(self):
         if not self.sched_exclude_nodelist:
             return set()
 
@@ -206,7 +206,8 @@ class SlurmJob(sched.Job):
         except SpawnedProcessError as e:
             raise JobError('could not retrieve the node description '
                            'of nodes: %s' % self.sched_exclude_nodelist) from e
-        node_descriptions_output = completed.stdout
+
+        node_descriptions = completed.stdout.splitlines()
         slurm_nodes = (SlurmNode(descr) for descr in node_descriptions)
         return {n.name for n in slurm_nodes}
 

--- a/reframe/core/schedulers/slurm.py
+++ b/reframe/core/schedulers/slurm.py
@@ -157,6 +157,8 @@ class SlurmJob(sched.Job):
         constraints = set()
         partitions = (set(self.sched_partition.split())
                       if self.sched_partition else set())
+        excluded_nodes = (set(self.sched_exclude_nodelist.split())
+                          if self.sched_exclude_nodelist else set())
 
         if self.options:
             for optstr in self.options:
@@ -173,8 +175,10 @@ class SlurmJob(sched.Job):
 
         num_nodes = 0
         for n in nodes:
-            if n.active_features >= constraints and n.partitions >= partitions:
-                num_nodes += 1
+            if (n.active_features >= constraints and
+                n.partitions >= partitions and
+                n.name not in excluded_nodes):
+                    num_nodes += 1
 
         return num_nodes
 

--- a/unittests/test_schedulers.py
+++ b/unittests/test_schedulers.py
@@ -481,6 +481,55 @@ class TestSlurmFlexibleNodeAllocation(unittest.TestCase):
         self.testjob.prepare(self.builder)
 
 
+class TestSlurmFlexibleNodeAllocationExclude(TestSlurmFlexibleNodeAllocation):
+
+    def setUp(self):
+        super().setUp()
+        self.testjob._sched_exclude_nodelist = 'nid00001'
+
+    def test_valid_constraint(self):
+        self.testjob._sched_reservation = 'Foo'
+        self.testjob.options = ['-C f1']
+        self.prepare_job()
+        self.assertEquals(self.testjob.num_tasks, 4)
+
+    def test_valid_multiple_constraints(self):
+        self.testjob._sched_reservation = 'Foo'
+        self.testjob.options = ['-C f1 f3']
+        self.prepare_job()
+        self.assertEquals(self.testjob.num_tasks, 4)
+
+    def test_valid_partition(self):
+        self.testjob._sched_reservation = 'Foo'
+        self.testjob._sched_partition = 'p2'
+        self.prepare_job()
+        self.assertEquals(self.testjob.num_tasks, 4)
+
+    def test_valid_multiple_partitions(self):
+        self.testjob._sched_reservation = 'Foo'
+        self.testjob.options = ['-p p1 p2']
+        self.assertRaises(JobError, self.prepare_job)
+
+    def test_valid_constraint_partition(self):
+        self.testjob._sched_reservation = 'Foo'
+        self.testjob.options = ['-C f1 f2', '--partition=p1 p2']
+        self.assertRaises(JobError, self.prepare_job)
+
+    def test_not_valid_partition(self):
+        self.testjob._sched_reservation = 'Foo'
+        self.testjob._sched_partition = 'Invalid'
+        self.assertRaises(JobError, self.prepare_job)
+
+    def test_not_valid_constraint(self):
+        self.testjob._sched_reservation = 'Foo'
+        self.testjob.options = ['--constraint=invalid']
+        self.assertRaises(JobError, self.prepare_job)
+
+    def test_noreservation(self):
+        self.testjob._num_tasks = 0
+        self.assertRaises(JobError, self.prepare_job)
+
+
 class TestSqueueJob(TestSlurmJob):
     @property
     def job_type(self):

--- a/unittests/test_schedulers.py
+++ b/unittests/test_schedulers.py
@@ -493,7 +493,7 @@ class TestSlurmFlexibleNodeAllocationExclude(TestSlurmFlexibleNodeAllocation):
 
     def setUp(self):
         super().setUp()
-        self.testjob._sched_exclude_nodelist = 'Nodes=[nid00001]'
+        self.testjob._sched_exclude_nodelist = 'nid00001'
         # monkey patch `_get_exclude_nodes` to simulate extraction of
         # slurm nodes through the use of `scontrol show`
         self.testjob._get_excluded_node_names = self.create_dummy_exclude_nodes

--- a/unittests/test_schedulers.py
+++ b/unittests/test_schedulers.py
@@ -433,35 +433,41 @@ class TestSlurmFlexibleNodeAllocation(unittest.TestCase):
     def tearDown(self):
         shutil.rmtree(self.workdir)
 
-    def test_valid_constraint(self):
+    def test_valid_constraint(self, expected_num_tasks=8):
         self.testjob._sched_reservation = 'Foo'
         self.testjob.options = ['-C f1']
         self.prepare_job()
-        self.assertEquals(self.testjob.num_tasks, 8)
+        self.assertEquals(self.testjob.num_tasks, expected_num_tasks)
 
-    def test_valid_multiple_constraints(self):
+    def test_valid_multiple_constraints(self, expected_num_tasks=4):
         self.testjob._sched_reservation = 'Foo'
         self.testjob.options = ['-C f1 f3']
         self.prepare_job()
-        self.assertEquals(self.testjob.num_tasks, 4)
+        self.assertEquals(self.testjob.num_tasks, expected_num_tasks)
 
-    def test_valid_partition(self):
+    def test_valid_partition(self, expected_num_tasks=8):
         self.testjob._sched_reservation = 'Foo'
         self.testjob._sched_partition = 'p2'
         self.prepare_job()
-        self.assertEquals(self.testjob.num_tasks, 8)
+        self.assertEquals(self.testjob.num_tasks, expected_num_tasks)
 
-    def test_valid_multiple_partitions(self):
+    def test_valid_multiple_partitions(self, expected_num_tasks=4):
         self.testjob._sched_reservation = 'Foo'
         self.testjob.options = ['-p p1 p2']
-        self.prepare_job()
-        self.assertEquals(self.testjob.num_tasks, 4)
+        if expected_num_tasks:
+            self.prepare_job()
+            self.assertEquals(self.testjob.num_tasks, expected_num_tasks)
+        else:
+            self.assertRaises(JobError, self.prepare_job)
 
-    def test_valid_constraint_partition(self):
+    def test_valid_constraint_partition(self, expected_num_tasks=4):
         self.testjob._sched_reservation = 'Foo'
         self.testjob.options = ['-C f1 f2', '--partition=p1 p2']
-        self.prepare_job()
-        self.assertEquals(self.testjob.num_tasks, 4)
+        if expected_num_tasks:
+            self.prepare_job()
+            self.assertEquals(self.testjob.num_tasks, expected_num_tasks)
+        else:
+            self.assertRaises(JobError, self.prepare_job)
 
     def test_not_valid_partition(self):
         self.testjob._sched_reservation = 'Foo'
@@ -474,7 +480,6 @@ class TestSlurmFlexibleNodeAllocation(unittest.TestCase):
         self.assertRaises(JobError, self.prepare_job)
 
     def test_noreservation(self):
-        self.testjob._num_tasks = 0
         self.assertRaises(JobError, self.prepare_job)
 
     def prepare_job(self):
@@ -488,46 +493,20 @@ class TestSlurmFlexibleNodeAllocationExclude(TestSlurmFlexibleNodeAllocation):
         self.testjob._sched_exclude_nodelist = 'nid00001'
 
     def test_valid_constraint(self):
-        self.testjob._sched_reservation = 'Foo'
-        self.testjob.options = ['-C f1']
-        self.prepare_job()
+        super().test_valid_constraint(expected_num_tasks=4)
         self.assertEquals(self.testjob.num_tasks, 4)
 
     def test_valid_multiple_constraints(self):
-        self.testjob._sched_reservation = 'Foo'
-        self.testjob.options = ['-C f1 f3']
-        self.prepare_job()
-        self.assertEquals(self.testjob.num_tasks, 4)
+        super().test_valid_multiple_constraints(expected_num_tasks=4)
 
     def test_valid_partition(self):
-        self.testjob._sched_reservation = 'Foo'
-        self.testjob._sched_partition = 'p2'
-        self.prepare_job()
-        self.assertEquals(self.testjob.num_tasks, 4)
+        super().test_valid_partition(expected_num_tasks=4)
 
     def test_valid_multiple_partitions(self):
-        self.testjob._sched_reservation = 'Foo'
-        self.testjob.options = ['-p p1 p2']
-        self.assertRaises(JobError, self.prepare_job)
+        super().test_valid_multiple_partitions(expected_num_tasks=None)
 
     def test_valid_constraint_partition(self):
-        self.testjob._sched_reservation = 'Foo'
-        self.testjob.options = ['-C f1 f2', '--partition=p1 p2']
-        self.assertRaises(JobError, self.prepare_job)
-
-    def test_not_valid_partition(self):
-        self.testjob._sched_reservation = 'Foo'
-        self.testjob._sched_partition = 'Invalid'
-        self.assertRaises(JobError, self.prepare_job)
-
-    def test_not_valid_constraint(self):
-        self.testjob._sched_reservation = 'Foo'
-        self.testjob.options = ['--constraint=invalid']
-        self.assertRaises(JobError, self.prepare_job)
-
-    def test_noreservation(self):
-        self.testjob._num_tasks = 0
-        self.assertRaises(JobError, self.prepare_job)
+        super().test_valid_constraint_partition(expected_num_tasks=None)
 
 
 class TestSqueueJob(TestSlurmJob):

--- a/unittests/test_schedulers.py
+++ b/unittests/test_schedulers.py
@@ -489,7 +489,7 @@ class TestSlurmFlexibleNodeAllocation(unittest.TestCase):
 class TestSlurmFlexibleNodeAllocationExclude(TestSlurmFlexibleNodeAllocation):
 
     def create_dummy_exclude_nodes(obj):
-        return [obj.create_dummy_nodes()[0]]
+        return [obj.create_dummy_nodes()[0].name]
 
     def setUp(self):
         super().setUp()
@@ -550,12 +550,4 @@ class TestSlurmNode(unittest.TestCase):
                          {'f1', 'f2'})
 
     def test_str(self):
-        base_slurm_string = ('Slurm node {{name: nid00001, '
-                             'partitions: {0}, '
-                             'active features: {1}}}')
-        possible_partitions_str = ({'p1', 'p2'}, {'p2', 'p1'})
-        possible_features_str = ({'f1', 'f2'}, {'f2', 'f1'})
-        self.assertIn(str(self.node),
-                      {base_slurm_string.format(p, f)
-                       for p in possible_partitions_str
-                       for f in possible_features_str})
+        self.assertEqual('nid00001', str(self.node))

--- a/unittests/test_schedulers.py
+++ b/unittests/test_schedulers.py
@@ -496,7 +496,7 @@ class TestSlurmFlexibleNodeAllocationExclude(TestSlurmFlexibleNodeAllocation):
         self.testjob._sched_exclude_nodelist = 'Nodes=[nid00001]'
         # monkey patch `_get_exclude_nodes` to simulate extraction of
         # slurm nodes through the use of `scontrol show`
-        self.testjob._get_excluded_nodes = self.create_dummy_exclude_nodes
+        self.testjob._get_excluded_node_names = self.create_dummy_exclude_nodes
 
     def test_valid_constraint(self):
         super().test_valid_constraint(expected_num_tasks=4)


### PR DESCRIPTION
* Check that the node name is not included in the excluded
  node list when counting compatible nodes.

* Create a unittest class to test the flexible node allocation
  combined with the `--exclude` option.

Fixes #104 