### PR TITLE
Fix crash when init_modules_system throws

### DIFF
--- a/reframe/core/modules.py
+++ b/reframe/core/modules.py
@@ -513,7 +513,7 @@ def init_modules_system(modules_kind=None):
     elif modules_kind == 'lmod':
         _modules_system = ModulesSystem(LModImpl())
     else:
-        raise ConfigError('unknown module system')
+        raise ConfigError('unknown module system: %s' % modules_kind)
 
 
 def get_modules_system():

--- a/reframe/frontend/cli.py
+++ b/reframe/frontend/cli.py
@@ -226,8 +226,12 @@ def main():
             list_supported_systems(site_config.systems.values(), printer)
             sys.exit(1)
 
-    # Init modules system
-    init_modules_system(system.modules_system)
+    try:
+        # Init modules system
+        init_modules_system(system.modules_system)
+    except ReframeError as e:
+        printer.error('could not initialize the modules system: %s' % e)
+        sys.exit(1)
 
     if options.mode:
         try:

--- a/unittests/test_cli.py
+++ b/unittests/test_cli.py
@@ -1,3 +1,4 @@
+import copy
 import itertools
 import os
 import re
@@ -292,6 +293,17 @@ class TestFrontend(unittest.TestCase):
         self.assertNotIn('FAILED', stdout)
         self.assertIn('PASSED', stdout)
         self.assertIn('Ran 1 test case', stdout)
+
+    def test_unknown_modules_system(self):
+        # Monkey patch site configuration to trigger a module systems error
+        site_config_save = copy.deepcopy(settings._site_configuration)
+        systems = list(settings._site_configuration['systems'].keys())
+        for s in systems:
+            settings._site_configuration['systems'][s]['modules_system'] = 'foo'
+
+        returncode, stdout, stderr = self._run_reframe()
+        self.assertNotEqual(0, returncode)
+        settings._site_configuration = site_config_save
 
     def tearDown(self):
         shutil.rmtree(self.prefix)


### PR DESCRIPTION
- Catch errors raised by `init_modules_system` in the CLI and report
  nicely to user