### PR TITLE
Fix 'git_repo_exists' bug causing a deadlock

### DIFF
--- a/reframe/utility/os.py
+++ b/reframe/utility/os.py
@@ -227,7 +227,8 @@ def git_repo_exists(url, timeout=5):
     """Check if URL refers to git valid repository."""
     try:
         os.environ['GIT_TERMINAL_PROMPT'] = '0'
-        run_command('git ls-remote %s' % url, check=True, timeout=timeout)
+        run_command('git ls-remote --exit-code -h %s' % url, check=True,
+                    timeout=timeout)
     except (SpawnedProcessTimeout, SpawnedProcessError):
         return False
     else:

--- a/reframe/utility/os.py
+++ b/reframe/utility/os.py
@@ -227,7 +227,7 @@ def git_repo_exists(url, timeout=5):
     """Check if URL refers to git valid repository."""
     try:
         os.environ['GIT_TERMINAL_PROMPT'] = '0'
-        run_command('git ls-remote --exit-code -h %s' % url, check=True,
+        run_command('git ls-remote -h %s' % url, check=True,
                     timeout=timeout)
     except (SpawnedProcessTimeout, SpawnedProcessError):
         return False


### PR DESCRIPTION
* Use command option `-h` with `git ls-remote` to list only
  refs/heads reducing the size of the output.