### PR TITLE
Terminate pending task upon abort in serial policy

### DIFF
--- a/reframe/frontend/executors/policies.py
+++ b/reframe/frontend/executors/policies.py
@@ -54,8 +54,8 @@ class SerialExecutionPolicy(ExecutionPolicy):
 
         except TaskExit:
             return
-        except ABORT_REASONS:
-            task.fail(sys.exc_info())
+        except ABORT_REASONS as e:
+            task.abort(e)
             raise
         except BaseException:
             task.fail(sys.exc_info())

--- a/reframe/frontend/statistics.py
+++ b/reframe/frontend/statistics.py
@@ -19,6 +19,11 @@ class TestStats:
     def __repr__(self):
         return debug.repr(self)
 
+    def alltasks(self):
+        for tlist in self._tasks_bypart.values():
+            for t in tlist:
+                yield t
+
     def num_failures(self, partition=None):
         num_fails = 0
         if partition:


### PR DESCRIPTION
- Also add unit tests to verify this behaviour in both the serial and
  async execution policy.

Fixes #151.