### PR TITLE
Support wildcards in valid_prog_environs

### DIFF
--- a/reframe/core/pipeline.py
+++ b/reframe/core/pipeline.py
@@ -2,6 +2,7 @@
 # Basic functionality for regression tests
 #
 
+import fnmatch
 import os
 import shutil
 
@@ -54,10 +55,14 @@ class RegressionTest:
     #: :type: Alphanumeric string.
     name = fields.AlphanumericField('name')
 
-    #: List of programming environmets supported by this test.
+    #: List of programming environments supported by this test.
     #:
     #: :type: :class:`list[str]`
     #: :default: ``[]``
+    #:
+    #: .. note::
+    #:     .. versionchanged:: 2.12
+    #:        Programming environments can now be specified using wildcards.
     valid_prog_environs = fields.TypedListField('valid_prog_environs', str)
 
     #: List of systems supported by this test.
@@ -676,10 +681,10 @@ class RegressionTest:
         return partition_name in self.valid_systems
 
     def supports_environ(self, env_name):
-        if '*' in self.valid_prog_environs:
-            return True
-
-        return env_name in self.valid_prog_environs
+        for env in self.valid_prog_environs:
+            if fnmatch.fnmatch(env_name, env):
+                return True
+        return False
 
     def is_local(self):
         """Check if the test will execute locally.

--- a/reframe/core/pipeline.py
+++ b/reframe/core/pipeline.py
@@ -684,6 +684,7 @@ class RegressionTest:
         for env in self.valid_prog_environs:
             if fnmatch.fnmatch(env_name, env):
                 return True
+
         return False
 
     def is_local(self):

--- a/unittests/test_pipeline.py
+++ b/unittests/test_pipeline.py
@@ -242,6 +242,27 @@ class TestRegressionTest(unittest.TestCase):
         self.assertFalse(test.supports_system('testsys:gpu'))
         self.assertFalse(test.supports_system('testsys:login'))
 
+    def test_supports_environ(self):
+        test = self.loader.load_from_file(
+            'unittests/resources/hellocheck.py',
+            system=self.system, resources=self.resources
+        )[0]
+
+        test.valid_prog_environs = ['*']
+        self.assertTrue(test.supports_environ('foo1'))
+        self.assertTrue(test.supports_environ('foo-env'))
+        self.assertTrue(test.supports_environ('*'))
+
+        test.valid_prog_environs = ['PrgEnv-foo-*']
+        self.assertTrue(test.supports_environ('PrgEnv-foo-version1'))
+        self.assertTrue(test.supports_environ('PrgEnv-foo-version2'))
+        self.assertFalse(test.supports_environ('PrgEnv-boo-version1'))
+
+        test.valid_prog_environs = ['PrgEnv-*']
+        self.assertTrue(test.supports_environ('PrgEnv-foo1'))
+        self.assertTrue(test.supports_environ('PrgEnv-foo2'))
+        self.assertFalse(test.supports_environ('Prgenv-foo'))
+
     def test_sourcesdir_none(self):
         test = RegressionTest('hellocheck',
                               'unittests/resources',

--- a/unittests/test_pipeline.py
+++ b/unittests/test_pipeline.py
@@ -257,11 +257,7 @@ class TestRegressionTest(unittest.TestCase):
         self.assertTrue(test.supports_environ('PrgEnv-foo-version1'))
         self.assertTrue(test.supports_environ('PrgEnv-foo-version2'))
         self.assertFalse(test.supports_environ('PrgEnv-boo-version1'))
-
-        test.valid_prog_environs = ['PrgEnv-*']
-        self.assertTrue(test.supports_environ('PrgEnv-foo1'))
-        self.assertTrue(test.supports_environ('PrgEnv-foo2'))
-        self.assertFalse(test.supports_environ('Prgenv-foo'))
+        self.assertFalse(test.supports_environ('Prgenv-foo-version1'))
 
     def test_sourcesdir_none(self):
         test = RegressionTest('hellocheck',


### PR DESCRIPTION
* Add support for wildcards in `valid_prog_environs` of a `RegressionTest`.
* Create the corresponding unit tests.
* Update doc for the `valid_prog_environs` field.

Closes #224 