### PR TITLE
Fix infinite recursion bug in 'copytree_virtual'

### DIFF
--- a/reframe/utility/os_ext.py
+++ b/reframe/utility/os_ext.py
@@ -81,6 +81,10 @@ def copytree(src, dst, symlinks=False, ignore=None, copy_function=shutil.copy2,
 
     In this case it will first remove it and then call the standard
     shutil.copytree()."""
+    if src == os.path.commonpath([src, dst]):
+        raise ValueError("cannot copy recursively the parent directory "
+                         "`%s' into one of its descendants `%s'" % (src, dst))
+
     if os.path.exists(dst):
         shutil.rmtree(dst)
 
@@ -104,10 +108,6 @@ def copytree_virtual(src, dst, file_links=[],
     # Work with absolute paths
     src = os.path.abspath(src)
     dst = os.path.abspath(dst)
-
-    if src == os.path.commonpath([src, dst]):
-        raise ValueError("copytree_virtual() failed: "
-                         "`%s' is a parent directory of `%s'" % (src, dst))
 
     # 1. Check that the link targets are valid
     # 2. Convert link targets to absolute paths

--- a/reframe/utility/os_ext.py
+++ b/reframe/utility/os_ext.py
@@ -105,6 +105,10 @@ def copytree_virtual(src, dst, file_links=[],
     src = os.path.abspath(src)
     dst = os.path.abspath(dst)
 
+    if src == os.path.commonpath([src, dst]):
+        raise ValueError("copytree_virtual() failed: "
+                         "`%s' is a parent directory of `%s'" % (src, dst))
+
     # 1. Check that the link targets are valid
     # 2. Convert link targets to absolute paths
     # 3. Store them in a set for quick look up inside the ignore function

--- a/unittests/test_utility.py
+++ b/unittests/test_utility.py
@@ -62,6 +62,15 @@ class TestOSTools(unittest.TestCase):
         shutil.rmtree(dir_src)
         shutil.rmtree(dir_dst)
 
+    def test_copytree_src_parent_of_dst(self):
+        dst_path = tempfile.mkdtemp()
+        src_path = os.path.abspath(os.path.join(dst_path, '..'))
+
+        self.assertRaises(ValueError, os_ext.copytree,
+                          src_path, dst_path)
+
+        shutil.rmtree(dst_path)
+
     def test_inpath(self):
         self.assertTrue(os_ext.inpath('/foo/bin', '/bin:/foo/bin:/usr/bin'))
         self.assertFalse(os_ext.inpath('/foo/bin', '/bin:/usr/local/bin'))

--- a/unittests/test_utility.py
+++ b/unittests/test_utility.py
@@ -234,12 +234,6 @@ class TestCopyTree(unittest.TestCase):
         self.assertRaises(OSError, os_ext.copytree_virtual,
                           self.prefix, self.target, file_links)
 
-    def test_virtual_copy_src_parent_of_dst(self):
-        src_path = os.path.join(self.prefix, 'bar', '..')
-        dst_path = os.path.join(self.prefix, 'bar')
-        self.assertRaises(ValueError, os_ext.copytree_virtual,
-                          src_path, dst_path)
-
     def tearDown(self):
         shutil.rmtree(self.prefix)
         shutil.rmtree(self.target)

--- a/unittests/test_utility.py
+++ b/unittests/test_utility.py
@@ -225,6 +225,12 @@ class TestCopyTree(unittest.TestCase):
         self.assertRaises(OSError, os_ext.copytree_virtual,
                           self.prefix, self.target, file_links)
 
+    def test_virtual_copy_src_parent_of_dst(self):
+        src_path = os.path.join(self.prefix, 'bar', '..')
+        dst_path = os.path.join(self.prefix, 'bar')
+        self.assertRaises(ValueError, os_ext.copytree_virtual,
+                          src_path, dst_path)
+
     def tearDown(self):
         shutil.rmtree(self.prefix)
         shutil.rmtree(self.target)


### PR DESCRIPTION
* Check that the source path is not a parent path of
  the destination one.
* Create the corresponding unittest.

Fixes #221.