### PR TITLE
Fix default 'settings.py' path

### DIFF
--- a/reframe/__init__.py
+++ b/reframe/__init__.py
@@ -1,8 +1,10 @@
+import os
 import sys
 
 
 VERSION = '2.12-dev1'
 _required_pyver = (3, 5, 0)
+INSTALL_PREFIX = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 
 # Check python version
 if sys.version_info[:3] < _required_pyver:

--- a/reframe/frontend/cli.py
+++ b/reframe/frontend/cli.py
@@ -1,4 +1,5 @@
 import os
+import pathlib
 import socket
 import sys
 
@@ -178,11 +179,16 @@ def main():
     misc_options.add_argument(
         '--system', action='store',
         help='Load SYSTEM configuration explicitly')
+
+    filepath = pathlib.Path(__file__)
+    reframe_dir = filepath.parent.parent.absolute()
+    default_settings = reframe_dir / 'settings.py'
     misc_options.add_argument(
         '-C', '--config-file', action='store', dest='config_file',
-        metavar='FILE', default='reframe/settings.py',
+        metavar='FILE', default=str(default_settings),
         help='Specify a custom config-file for the machine. '
-             '(default: ./reframe/settings.py)')
+             '(default: %s' % default_settings)
+
     misc_options.add_argument('-V', '--version', action='version',
                               version=reframe.VERSION)
 

--- a/reframe/frontend/cli.py
+++ b/reframe/frontend/cli.py
@@ -18,6 +18,9 @@ from reframe.frontend.loader import RegressionCheckLoader
 from reframe.frontend.printer import PrettyPrinter
 from reframe.frontend.resources import ResourcesManager
 
+DEFAULT_SETTINGS_FILE = os.path.abspath(os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), '../settings.py'))
+
 
 def list_supported_systems(systems, printer):
     printer.info('List of supported systems:')
@@ -179,16 +182,11 @@ def main():
     misc_options.add_argument(
         '--system', action='store',
         help='Load SYSTEM configuration explicitly')
-
-    filepath = pathlib.Path(__file__)
-    reframe_dir = filepath.parent.parent.absolute()
-    default_settings = reframe_dir / 'settings.py'
     misc_options.add_argument(
         '-C', '--config-file', action='store', dest='config_file',
-        metavar='FILE', default=str(default_settings),
+        metavar='FILE', default=DEFAULT_SETTINGS_FILE,
         help='Specify a custom config-file for the machine. '
-             '(default: %s' % default_settings)
-
+             '(default: %s' % DEFAULT_SETTINGS_FILE)
     misc_options.add_argument('-V', '--version', action='version',
                               version=reframe.VERSION)
 

--- a/reframe/frontend/cli.py
+++ b/reframe/frontend/cli.py
@@ -1,5 +1,4 @@
 import os
-import pathlib
 import socket
 import sys
 
@@ -17,9 +16,6 @@ from reframe.frontend.executors.policies import (SerialExecutionPolicy,
 from reframe.frontend.loader import RegressionCheckLoader
 from reframe.frontend.printer import PrettyPrinter
 from reframe.frontend.resources import ResourcesManager
-
-DEFAULT_SETTINGS_FILE = os.path.abspath(os.path.join(
-    os.path.dirname(os.path.abspath(__file__)), '../settings.py'))
 
 
 def list_supported_systems(systems, printer):
@@ -184,9 +180,11 @@ def main():
         help='Load SYSTEM configuration explicitly')
     misc_options.add_argument(
         '-C', '--config-file', action='store', dest='config_file',
-        metavar='FILE', default=DEFAULT_SETTINGS_FILE,
+        metavar='FILE', default=os.path.join(reframe.INSTALL_PREFIX,
+                                             'reframe/settings.py'),
         help='Specify a custom config-file for the machine. '
-             '(default: %s' % DEFAULT_SETTINGS_FILE)
+             '(default: %s' % os.path.join(reframe.INSTALL_PREFIX,
+                                           'reframe/settings.py'))
     misc_options.add_argument('-V', '--version', action='version',
                               version=reframe.VERSION)
 
@@ -293,11 +291,8 @@ def main():
     else:
         loader = RegressionCheckLoader(
             load_path=settings.checks_path,
-            prefix=os.path.abspath(
-                os.path.join(os.path.dirname(__file__), '..', '..')
-            ),
-            recurse=settings.checks_path_recurse,
-        )
+            prefix=reframe.INSTALL_PREFIX,
+            recurse=settings.checks_path_recurse)
 
     # Adjust system directories
     if options.prefix:


### PR DESCRIPTION
* Use `__file__` to get the absolute path of the `cli.py` path and define the default `settings.py` path 
  according to it.

Closes #238 