### PR TITLE
Fix sanity checking for GROMACS test

### DIFF
--- a/cscs-checks/apps/gromacs/gromacs_check.py
+++ b/cscs-checks/apps/gromacs/gromacs_check.py
@@ -18,9 +18,9 @@ class GromacsBaseCheck(RunOnlyRegressionTest):
         self.keep_files = [output_file]
 
         energy = sn.extractsingle(r'\s+Potential\s+Kinetic En\.\s+Total Energy'
-                                  r'\s+Temperature\s+Pressure \(bar\)\n'
+                                  r'\sConserved En\.\s+Temperature\n'
                                   r'(\s+\S+){2}\s+(?P<energy>\S+)(\s+\S+){2}\n'
-                                  r'\s+Constr\. rmsd',
+                                  r'\sPressure \(bar\)\s+Constr\. rmsd',
                                   output_file, 'energy', float, item=-1)
         energy_reference = -3270799.9
         energy_diff = sn.abs(energy - energy_reference)

--- a/cscs-checks/apps/gromacs/gromacs_check.py
+++ b/cscs-checks/apps/gromacs/gromacs_check.py
@@ -18,9 +18,9 @@ class GromacsBaseCheck(RunOnlyRegressionTest):
         self.keep_files = [output_file]
 
         energy = sn.extractsingle(r'\s+Potential\s+Kinetic En\.\s+Total Energy'
-                                  r'\sConserved En\.\s+Temperature\n'
+                                  r'\s+Conserved En\.\s+Temperature\n'
                                   r'(\s+\S+){2}\s+(?P<energy>\S+)(\s+\S+){2}\n'
-                                  r'\sPressure \(bar\)\s+Constr\. rmsd',
+                                  r'\s+Pressure \(bar\)\s+Constr\. rmsd',
                                   output_file, 'energy', float, item=-1)
         energy_reference = -3270799.9
         energy_diff = sn.abs(energy - energy_reference)


### PR DESCRIPTION
The new default version of `GROMACS` on Dom and Piz Daint is `2018` since April 24th and the output format of the energy line has slightly changed with respect to previous versions.

Fixes #270.