### PR TITLE
Remove 'post_run' and 'pre_run' from 'Job'

### DIFF
--- a/reframe/core/schedulers/__init__.py
+++ b/reframe/core/schedulers/__init__.py
@@ -41,34 +41,6 @@ class Job(abc.ABC):
     #: :default: ``[]``
     options = fields.TypedListField('options', str)
 
-    #: List of shell commands to execute before launching this job.
-    #:
-    #: :type: :class:`list` of :class:`str`
-    #: :default: ``[]``
-    #:
-    #: .. note::
-    #:    .. deprecated:: 2.10
-    #:       Please use the :attr:`reframe.core.pipeline.RegressionTest.pre_run`
-    #:       field instead.
-    pre_run = fields.DeprecatedField(
-        fields.TypedListField('_pre_run', str),
-        'Use of the pre_run field of Job is deprecated. '
-        'Please use the pre_run field of RegressionTest instead.')
-
-    #: List of shell commands to execute after launching this job.
-    #:
-    #: :type: :class:`list` of :class:`str`
-    #: :default: ``[]``
-    #:
-    #: .. note::
-    #:    .. deprecated:: 2.10
-    #:       Please use the :attr:`reframe.core.pipeline.RegressionTest.post_run`
-    #:       field instead.
-    post_run = fields.DeprecatedField(
-        fields.TypedListField('_post_run', str),
-        'Use of the post_run field of Job is deprecated. '
-        'Please use the post_run field of RegressionTest instead.')
-
     #: The parallel program launcher that will be used to launch the parallel
     #: executable of this job.
     #:

--- a/unittests/test_schedulers.py
+++ b/unittests/test_schedulers.py
@@ -225,16 +225,6 @@ class TestLocalJob(_TestJob):
         # Verify that the spawned sleep is killed, too
         self.assertProcessDied(sleep_pid)
 
-    def test_deprecated_pre_run_and_post_run(self):
-        from reframe.core.exceptions import ReframeDeprecationWarning
-
-        self.assertWarns(ReframeDeprecationWarning, exec,
-                         'self.testjob.pre_run = []',
-                         globals(), locals())
-        self.assertWarns(ReframeDeprecationWarning, exec,
-                         'self.testjob.post_run = []',
-                         globals(), locals())
-
 
 class TestSlurmJob(_TestJob):
     @property


### PR DESCRIPTION
* Remove the `pre_run` and `post_run` fields from class `Job`.

* Remove the corresponding deprecation unit tests.

Fixes #62 