### PR TITLE
use --force when purging all loaded modules with Lmod, to ensure sticky modules also get unloaded

### DIFF
--- a/reframe/core/modules.py
+++ b/reframe/core/modules.py
@@ -575,6 +575,9 @@ class LModImpl(TModImpl):
 
         return ret
 
+    def unload_all(self):
+        self._exec_module_command('--force', 'purge')
+
 
 class NoModImpl(ModulesSystemImpl):
     """A convenience class that implements a no-op a modules system."""


### PR DESCRIPTION
When running `./test_reframe.py -v`, one test was failing on our system:

```
FAIL: test_module_unload_all (unittests.test_modules.TestLModModulesSystem)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/user/scratchphanpy/gent/gvo000/gvo00002/vsc40023/easybuild_REGTEST/CO7/sandybridge/software/ReFrame/2.12-foss-2018a-Python-3.6.4/unittests/test_modules.py", line 58, in test_module_unload_all
    self.assertEqual(0, len(self.modules_system.loaded_modules()))
AssertionError: 0 != 1

----------------------------------------------------------------------
Ran 404 tests in 771.699s

FAILED (SKIP=24, failures=1)
```

This occurs because we are using Lmod and we have one "sticky" module (cfr.https://lmod.readthedocs.io/en/latest/240_sticky_modules.html) loaded, which only gets unloaded with `module --force purge`, see below.

I'm not sure whether this is the correct fix though, it depends for what purpose `unload_all` is actually being used... The sticky `cluster` module we have sets up `$MODULEPATH` for example, so if it's unloaded the modules we provide centrally will no longer be available...

Another way to fix this would be to check differently in the test whether `unload_all` unloads the previously loaded modules...

```
$ module list

Currently Loaded Modules:
  1) cluster/delcatty (S)

  Where:
   S:  Module is Sticky, requires --force to unload or purge

$ module purge
The following modules were not unloaded:
  (Use "module --force purge" to unload all):

  1) cluster/delcatty

$ module list

Currently Loaded Modules:
  1) cluster/delcatty (S)

  Where:
   S:  Module is Sticky, requires --force to unload or purge

$ module --force purge
$ module list
No modules loaded
```