### PR TITLE
Print filename if a test file contains syntax errors

### DIFF
--- a/reframe/frontend/loader.py
+++ b/reframe/frontend/loader.py
@@ -11,8 +11,7 @@ from importlib.machinery import SourceFileLoader
 import reframe.core.debug as debug
 import reframe.utility as util
 from reframe.core.exceptions import (NameConflictError,
-                                     RegressionTestLoadError,
-                                     ReframeSyntaxError)
+                                     RegressionTestLoadError)
 from reframe.core.logging import getlogger
 
 
@@ -81,12 +80,7 @@ class RegressionCheckLoader:
         further tests and finalizes and validation."""
 
         with open(filename, 'r') as f:
-            try:
-                source_tree = ast.parse(f.read())
-            except SyntaxError as e:
-                message = ('\nRegression check syntax error:\n{0}Line: {1}\n'
-                           'File: {2}'.format(e.text, e.lineno, filename))
-                raise ReframeSyntaxError(message)
+            source_tree = ast.parse(f.read(), filename)
 
         validator = RegressionCheckValidator()
         validator.visit(source_tree)

--- a/reframe/frontend/loader.py
+++ b/reframe/frontend/loader.py
@@ -10,8 +10,7 @@ from importlib.machinery import SourceFileLoader
 
 import reframe.core.debug as debug
 import reframe.utility as util
-from reframe.core.exceptions import (NameConflictError,
-                                     RegressionTestLoadError)
+from reframe.core.exceptions import NameConflictError, RegressionTestLoadError
 from reframe.core.logging import getlogger
 
 

--- a/reframe/frontend/loader.py
+++ b/reframe/frontend/loader.py
@@ -10,7 +10,9 @@ from importlib.machinery import SourceFileLoader
 
 import reframe.core.debug as debug
 import reframe.utility as util
-from reframe.core.exceptions import NameConflictError, RegressionTestLoadError
+from reframe.core.exceptions import (NameConflictError,
+                                     RegressionTestLoadError,
+                                     ReframeSyntaxError)
 from reframe.core.logging import getlogger
 
 
@@ -79,7 +81,12 @@ class RegressionCheckLoader:
         further tests and finalizes and validation."""
 
         with open(filename, 'r') as f:
-            source_tree = ast.parse(f.read())
+            try:
+                source_tree = ast.parse(f.read())
+            except SyntaxError as e:
+                message = ('\nRegression check syntax error:\n{0}Line: {1}\n'
+                           'File: {2}'.format(e.text, e.lineno, filename))
+                raise ReframeSyntaxError(message)
 
         validator = RegressionCheckValidator()
         validator.visit(source_tree)

--- a/unittests/resources/checks_unlisted/invalid_syntax_check.py
+++ b/unittests/resources/checks_unlisted/invalid_syntax_check.py
@@ -1,0 +1,6 @@
+import reframe as rfm
+
+
+@rfm.simple_test
+class InvalidSyntaxTest(rfm.RegressionTest:
+    pass

--- a/unittests/test_loader.py
+++ b/unittests/test_loader.py
@@ -2,7 +2,8 @@ import os
 import unittest
 
 from reframe.core.exceptions import (ConfigError, NameConflictError,
-                                     RegressionTestLoadError)
+                                     RegressionTestLoadError,
+                                     ReframeSyntaxError)
 from reframe.core.systems import System
 from reframe.frontend.loader import RegressionCheckLoader
 
@@ -58,3 +59,8 @@ class TestRegressionCheckLoader(unittest.TestCase):
     def test_load_error(self):
         self.assertRaises(OSError, self.loader.load_from_file,
                           'unittests/resources/checks/foo.py')
+
+    def test_load_invalid_sytax(self):
+        self.assertRaises(ReframeSyntaxError, self.loader.load_from_file,
+                          'unittests/resources/checks_unlisted/'
+                          'invalid_syntax_check.py')

--- a/unittests/test_loader.py
+++ b/unittests/test_loader.py
@@ -2,8 +2,7 @@ import os
 import unittest
 
 from reframe.core.exceptions import (ConfigError, NameConflictError,
-                                     RegressionTestLoadError,
-                                     ReframeSyntaxError)
+                                     RegressionTestLoadError)
 from reframe.core.systems import System
 from reframe.frontend.loader import RegressionCheckLoader
 
@@ -61,6 +60,9 @@ class TestRegressionCheckLoader(unittest.TestCase):
                           'unittests/resources/checks/foo.py')
 
     def test_load_invalid_sytax(self):
-        self.assertRaises(ReframeSyntaxError, self.loader.load_from_file,
-                          'unittests/resources/checks_unlisted/'
-                          'invalid_syntax_check.py')
+        invalid_check = ('unittests/resources/checks_unlisted/'
+                         'invalid_syntax_check.py')
+        with self.assertRaises(SyntaxError) as e:
+            self.loader.load_from_file(invalid_check)
+
+        self.assertEqual(e.exception.filename, invalid_check)


### PR DESCRIPTION
* Raise a `ReframeSyntaxError` with a descriptive message if parsing of
  a `RegressionTest` fails.

* Create the corresponding unittest

Fixes #267 