### PR TITLE
Bugfix: Treat '--timestamp' option

### DIFF
--- a/reframe/frontend/cli.py
+++ b/reframe/frontend/cli.py
@@ -279,6 +279,9 @@ def main():
                       "`--keep-stage-files' option.")
         sys.exit(1)
 
+    if options.timestamp:
+        rt.resources.timefmt = options.timestamp
+
     # Setup the check loader
     if options.checkpath:
         load_path = []

--- a/unittests/test_cli.py
+++ b/unittests/test_cli.py
@@ -25,7 +25,6 @@ def run_command_inline(argv, funct, *args, **kwargs):
 
     captured_stdout = StringIO()
     captured_stderr = StringIO()
-    print(sys.argv)
     with redirect_stdout(captured_stdout):
         with redirect_stderr(captured_stderr):
             try:
@@ -305,3 +304,16 @@ class TestFrontend(unittest.TestCase):
         self.action = 'list'
         returncode, *_ = self._run_reframe()
         self.assertNotEqual(0, returncode)
+
+    def test_timestamp_option(self):
+        from datetime import datetime
+
+        self.checkpath = ['unittests/resources/checks']
+        self.more_options = ['-R']
+        self.ignore_check_conflicts = False
+        self.action = 'list'
+        self.more_options = ['--timestamp=xxx_%F']
+        timefmt = datetime.now().strftime('xxx_%F')
+        returncode, stdout, _ = self._run_reframe()
+        self.assertNotEqual(0, returncode)
+        self.assertIn(timefmt, stdout)


### PR DESCRIPTION
Also:
- Add a unit test exposing the bug.

Fixes #315.

The option was completely ignored!