### PR TITLE
Fix paths for Boost Python check

### DIFF
--- a/cscs-checks/libraries/boost/boost_python_check.py
+++ b/cscs-checks/libraries/boost/boost_python_check.py
@@ -1,20 +1,18 @@
 import os
 
+import reframe as rfm
 import reframe.utility.sanity as sn
-from reframe.core.pipeline import RegressionTest
 
 
-class BoostCrayGnuPythonTest(RegressionTest):
-
-    def __init__(self, boost_version, cray_gnu_version, python_version,
-                 **kwargs):
-
+@rfm.parameterized_test(['1.65.0', '17.08', '2.7'], ['1.65.0', '17.08', '3.6'])
+class BoostCrayGnuPythonTest(rfm.RegressionTest):
+    def __init__(self, boost_version, cray_gnu_version, python_version):
         def normalize(s):
             return s.replace('.', '_')
 
         super().__init__('boost_%s_cray_gnu_%s_python_%s_check' % (
             normalize(boost_version), normalize(cray_gnu_version),
-            normalize(python_version)), os.path.dirname(__file__), **kwargs)
+            normalize(python_version)))
         self.descr = ('Test for Boost-%s for CrayGnu-%s with python %s '
                       'support') % (boost_version, cray_gnu_version,
                                     python_version)
@@ -34,8 +32,3 @@ class BoostCrayGnuPythonTest(RegressionTest):
         }
         self.maintainers = ['JB', 'AJ']
         self.tags = {'scs', 'production'}
-
-
-def _get_checks(**kwargs):
-    return [BoostCrayGnuPythonTest('1.65.0', '17.08', '2.7', **kwargs),
-            BoostCrayGnuPythonTest('1.65.0', '17.08', '3.6', **kwargs)]

--- a/cscs-checks/libraries/boost/boost_python_check.py
+++ b/cscs-checks/libraries/boost/boost_python_check.py
@@ -1,5 +1,3 @@
-import os
-
 import reframe as rfm
 import reframe.utility.sanity as sn
 
@@ -7,12 +5,7 @@ import reframe.utility.sanity as sn
 @rfm.parameterized_test(['1.65.0', '17.08', '2.7'], ['1.65.0', '17.08', '3.6'])
 class BoostCrayGnuPythonTest(rfm.RegressionTest):
     def __init__(self, boost_version, cray_gnu_version, python_version):
-        def normalize(s):
-            return s.replace('.', '_')
-
-        super().__init__('boost_%s_cray_gnu_%s_python_%s_check' % (
-            normalize(boost_version), normalize(cray_gnu_version),
-            normalize(python_version)))
+        super().__init__()
         self.descr = ('Test for Boost-%s for CrayGnu-%s with python %s '
                       'support') % (boost_version, cray_gnu_version,
                                     python_version)

--- a/cscs-checks/libraries/boost/boost_python_check.py
+++ b/cscs-checks/libraries/boost/boost_python_check.py
@@ -28,7 +28,7 @@ class BoostCrayGnuPythonTest(RegressionTest):
         python_include_suffix = 'm' if python_major_version == '3' else ''
         python_lib_suffix = '3' if python_major_version == '3' else ''
         self.variables = {
-            'PYTHON_INCLUDE': (r'${PYTHON_PATH}/include/python%s%s') % (
+            'PYTHON_INCLUDE': r'include/python%s%s' % (
                 python_version, python_include_suffix),
             'PYTHON_BOOST_LIB': 'boost_python' + python_lib_suffix
         }
@@ -38,4 +38,4 @@ class BoostCrayGnuPythonTest(RegressionTest):
 
 def _get_checks(**kwargs):
     return [BoostCrayGnuPythonTest('1.65.0', '17.08', '2.7', **kwargs),
-            BoostCrayGnuPythonTest('1.65.0', '17.08', '3.5', **kwargs)]
+            BoostCrayGnuPythonTest('1.65.0', '17.08', '3.6', **kwargs)]

--- a/cscs-checks/libraries/boost/src/Makefile
+++ b/cscs-checks/libraries/boost/src/Makefile
@@ -1,7 +1,8 @@
 TARGET = hello_boost_python
+PYTHONDIR=$(shell echo $(PYTHONPATH) | cut -d ':' -f 1)
 
 $(TARGET).so: $(TARGET).o
 	$(CXX) -shared -Wl,--export-dynamic $^ -l$(PYTHON_BOOST_LIB) -o $@
  
 $(TARGET).o: $(TARGET).cpp
-	$(CXX) -fPIC -c -I$(PYTHON_INCLUDE) $^ -o $@
+	$(CXX) -fPIC -c -I"$(PYTHONDIR)/$(PYTHON_INCLUDE)" $^ -o $@


### PR DESCRIPTION
* Update python3 test from python3.5 to python3.6.

* Use the PYTHONPATH environment variable to extract the python dir.