### PR TITLE
Add log hander attributes for retrieving the OS user and group

### DIFF
--- a/docs/running.rst
+++ b/docs/running.rst
@@ -567,6 +567,8 @@ All handlers accept the following set of attributes (keys) in their configuratio
   - ``check_stagedir``: The stage directory associated with the currently executing test.
   - ``check_system``: The host system where this test is currently executing.
   - ``check_tags``: The tags associated with this test.
+  - ``osuser``: The name of the OS user running ReFrame.
+  - ``osgroup``: The group name of the OS user running ReFrame.
   - ``version``: The ReFrame version.
 
 * ``datefmt`` (default: ``'%FT%T'``) The format that will be used for outputting timestamps (i.e., the ``%(asctime)s`` field).

--- a/reframe/core/logging.py
+++ b/reframe/core/logging.py
@@ -343,7 +343,6 @@ class LoggerAdapter(logging.LoggerAdapter):
                 'check_perf_ref': None,
                 'check_perf_lower_thres': None,
                 'check_perf_upper_thres': None,
-                'check_perf_upper_thres': None,
                 'username': None,
                 'group': None,
                 'check_tags': None,

--- a/reframe/core/logging.py
+++ b/reframe/core/logging.py
@@ -12,6 +12,7 @@ from datetime import datetime
 
 import reframe
 import reframe.core.debug as debug
+import reframe.utility.os_ext as os_ext
 from reframe.core.exceptions import ConfigError, LoggingError
 
 
@@ -343,8 +344,8 @@ class LoggerAdapter(logging.LoggerAdapter):
                 'check_perf_ref': None,
                 'check_perf_lower_thres': None,
                 'check_perf_upper_thres': None,
-                'username': None,
-                'group': None,
+                'osuser':  os_ext.osuser()  or '<unknown>',
+                'osgroup': os_ext.osgroup() or '<unknown>',
                 'check_tags': None,
                 'version': reframe.VERSION,
             }
@@ -380,24 +381,6 @@ class LoggerAdapter(logging.LoggerAdapter):
         if self.check.job:
             self.extra['check_jobid'] = self.check.job.jobid
 
-        try:
-            import pwd
-            self.extra['username'] = pwd.getpwuid(os.geteuid()).pw_name
-        except:
-            try:
-                import getpass
-                self.extra['username'] = getpass.getuser()
-            except:
-                pass
-
-        try:
-            import grp
-            import pwd
-            gid = pwd.getpwnam(self.extra['username']).pw_gid
-            self.extra['group'] = grp.getgrgid(gid).gr_name
-        except:
-            pass
-
     def log_performance(self, level, tag, value, ref,
                         low_thres, upper_thres, msg=None):
 
@@ -408,7 +391,7 @@ class LoggerAdapter(logging.LoggerAdapter):
         self.extra['check_perf_lower_thres'] = low_thres
         self.extra['check_perf_upper_thres'] = upper_thres
         if msg is None:
-            msg = 'sent by ' + os.environ['USER']
+            msg = 'sent by ' + self.extra['osuser']
 
         self.log(level, msg)
 

--- a/reframe/core/logging.py
+++ b/reframe/core/logging.py
@@ -343,6 +343,9 @@ class LoggerAdapter(logging.LoggerAdapter):
                 'check_perf_ref': None,
                 'check_perf_lower_thres': None,
                 'check_perf_upper_thres': None,
+                'check_perf_upper_thres': None,
+                'username': None,
+                'group': None,
                 'check_tags': None,
                 'version': reframe.VERSION,
             }
@@ -377,6 +380,24 @@ class LoggerAdapter(logging.LoggerAdapter):
 
         if self.check.job:
             self.extra['check_jobid'] = self.check.job.jobid
+
+        try:
+            import pwd
+            self.extra['username'] = pwd.getpwuid(os.geteuid()).pw_name
+        except:
+            try:
+                import getpass
+                self.extra['username'] = getpass.getuser()
+            except:
+                pass
+
+        try:
+            import grp
+            import pwd
+            gid = pwd.getpwnam(self.extra['username']).pw_gid
+            self.extra['group'] = grp.getgrgid(gid).gr_name
+        except:
+            pass
 
     def log_performance(self, level, tag, value, ref,
                         low_thres, upper_thres, msg=None):

--- a/reframe/frontend/cli.py
+++ b/reframe/frontend/cli.py
@@ -336,7 +336,7 @@ def main():
     # Print command line
     printer.info('Command line: %s' % ' '.join(sys.argv))
     printer.info('Reframe version: '  + reframe.VERSION)
-    printer.info('Launched by user: ' + os.environ['USER'])
+    printer.info('Launched by user: ' + (os_ext.osuser() or '<unknown>'))
     printer.info('Launched on host: ' + socket.gethostname())
 
     # Print important paths

--- a/reframe/frontend/printer.py
+++ b/reframe/frontend/printer.py
@@ -118,7 +118,7 @@ class PrettyPrinter:
     def error(self, msg):
         msg = AnsiColorizer.colorize('%s: %s' % (sys.argv[0], msg),
                                      AnsiColorizer.red)
-        self._logger.error('%s: %s' % (sys.argv[0], msg))
+        self._logger.error(msg)
 
     def log_config(self, options):
         opt_list = ['    %s=%s' % (attr, val)

--- a/reframe/utility/os_ext.py
+++ b/reframe/utility/os_ext.py
@@ -2,6 +2,8 @@
 # OS and shell utility functions
 #
 
+import getpass
+import grp
 import os
 import re
 import shlex
@@ -13,7 +15,6 @@ from urllib.parse import urlparse
 
 from reframe.core.exceptions import (ReframeError, SpawnedProcessError,
                                      SpawnedProcessTimeout)
-from reframe.core.logging import getlogger
 
 
 def run_command(cmd, check=False, timeout=None, shell=False):
@@ -63,6 +64,9 @@ def run_command_async(cmd,
                       stderr=subprocess.PIPE,
                       shell=False,
                       **popen_args):
+    # Import logger here to avoid unnecessary circular dependencies
+    from reframe.core.logging import getlogger
+
     getlogger().debug('executing OS command: ' + cmd)
     if not shell:
         cmd = shlex.split(cmd)
@@ -73,6 +77,28 @@ def run_command_async(cmd,
                             universal_newlines=True,
                             shell=shell,
                             **popen_args)
+
+
+def osuser():
+    """Return the name of the current OS user.
+
+    If the name cannot be retrieved, :class:`None` will be returned.
+    """
+    try:
+        return getpass.getuser()
+    except BaseException:
+        return None
+
+
+def osgroup():
+    """Return the group name of the current OS user.
+
+    If the name cannot be retrieved, :class:`None` will be returned.
+    """
+    try:
+        return grp.getgrgid(os.getgid()).gr_name
+    except KeyError:
+        return None
 
 
 def copytree(src, dst, symlinks=False, ignore=None, copy_function=shutil.copy2,


### PR DESCRIPTION
This PR attempts to add the username and group to perf logging.
This is especially good for grafana logging.

This should capture the name and primary group of the user that has
executed reframe.

REMARKS:
* capturing the username and group is not portable across OSes
* The fields were updated inside the `_update_check_extras`, but they
could be set during the initialization of the `LoggerAdapter`.