### PR TITLE
[bugfix] Comment out Graylog handler from CSCS config

### DIFF
--- a/config/cscs.py
+++ b/config/cscs.py
@@ -377,17 +377,17 @@ class ReframeSettings:
     perf_logging_config = {
         'level': 'DEBUG',
         'handlers': [
-            {
-                'type': 'graylog',
-                'host': 'your-server-here',
-                'port': 12345,
-                'level': 'INFO',
-                'format': '%(message)s',
-                'extras': {
-                    'facility': 'reframe',
-                    'data-version': '1.0',
-                }
-            },
+            #@ {
+            #@     'type': 'graylog',
+            #@     'host': 'your-server-here',
+            #@     'port': 12345,
+            #@     'level': 'INFO',
+            #@     'format': '%(message)s',
+            #@     'extras': {
+            #@         'facility': 'reframe',
+            #@         'data-version': '1.0',
+            #@     }
+            #@ },
             {
                 'type': 'filelog',
                 'prefix': '%(check_system)s/%(check_partition)s',


### PR DESCRIPTION
The current dummy server and port produce errors when trying to log the
performance. For this reason, the corresponding configuration lines are
commented out specially using the `#@` prefix and will be patched
on-the-fly for production runs.

This must be merged asap, cos it's blocking other PRs.

Fixes #349.