### PR TITLE
[feat] Allow purging modules before running regression tests

### DIFF
--- a/reframe/frontend/cli.py
+++ b/reframe/frontend/cli.py
@@ -179,7 +179,7 @@ def main():
         help='Apply module mappings defined in FILE')
     misc_options.add_argument(
         '--purge-env', action='store_true', dest='purge_env', default=False,
-        help='Perform a `module purge\' before setup')
+        help="Perform a `module purge' before setup")
     misc_options.add_argument(
         '--nocolor', action='store_false', dest='colorize', default=True,
         help='Disable coloring of output')

--- a/reframe/frontend/cli.py
+++ b/reframe/frontend/cli.py
@@ -179,7 +179,7 @@ def main():
         help='Apply module mappings defined in FILE')
     misc_options.add_argument(
         '--purge-env', action='store_true', dest='purge_env', default=False,
-        help="Perform a `module purge' before setup")
+        help='Purge modules environment before running any tests')
     misc_options.add_argument(
         '--nocolor', action='store_false', dest='colorize', default=True,
         help='Disable coloring of output')

--- a/reframe/frontend/cli.py
+++ b/reframe/frontend/cli.py
@@ -178,6 +178,9 @@ def main():
         dest='module_map_file',
         help='Apply module mappings defined in FILE')
     misc_options.add_argument(
+        '--purge-env', action='store_true', dest='purge_env', default=False,
+        help='Perform a `module purge\' before setup')
+    misc_options.add_argument(
         '--nocolor', action='store_false', dest='colorize', default=True,
         help='Disable coloring of output')
     misc_options.add_argument(
@@ -412,6 +415,9 @@ def main():
         # Unload regression's module and load user-specified modules
         if settings.reframe_module:
             rt.modules_system.unload_module(settings.reframe_module)
+
+        if options.purge_env:
+            rt.modules_system.unload_all()
 
         for m in options.user_modules:
             try:


### PR DESCRIPTION
This option allows the user to specify whether or not they want to add a 'module purge' to the start of every job, before each module is loaded.

For example, given a sbatch job like so:
```bash
#!/bin/bash
#SBATCH -t 1:0
module load python
python test.py
```

The sbatch script will be output like this instead:

```bash
#!/bin/bash
#SBATCH -t 1:0
module purge
module load python
python test.py
```

The setting is per-system, so it fits next to the `module_system` option.
