### PR TITLE
[ci] Temporarily disable running of checks on Daint

### DIFF
--- a/ci-scripts/ci-runner.bash
+++ b/ci-scripts/ci-runner.bash
@@ -194,6 +194,12 @@ else
     fi
 
 
+    # FIXME: Do not run modified checks on Daint during the PE upgrade
+    if [[ $(hostname) =~ daint ]]; then
+        exit $CI_EXITCODE
+    fi
+
+
     # Find modified or added user checks
     userchecks=( $(git diff origin/master...HEAD --name-only --oneline --no-merges | \
                    grep -e '^cscs-checks/.*\.py') )


### PR DESCRIPTION
For the duration of the PE upgrade.