### PR TITLE
[bugfix] Filter out empty strings before writing preamble

### DIFF
--- a/reframe/core/schedulers/slurm.py
+++ b/reframe/core/schedulers/slurm.py
@@ -121,7 +121,7 @@ class SlurmJob(sched.Job):
             else:
                 preamble.append(opt)
 
-        # Filter out empty statements before returning"
+        # Filter out empty statements before returning
         return list(filter(None, preamble))
 
     def _run_command(self, cmd, timeout=None):

--- a/reframe/core/schedulers/slurm.py
+++ b/reframe/core/schedulers/slurm.py
@@ -121,7 +121,8 @@ class SlurmJob(sched.Job):
             else:
                 preamble.append(opt)
 
-        return preamble
+        # Filter out empty statements before returning"
+        return list(filter(None, preamble))
 
     def _run_command(self, cmd, timeout=None):
         """Run command cmd and re-raise any exception as a JobError."""

--- a/reframe/core/shell.py
+++ b/reframe/core/shell.py
@@ -4,7 +4,7 @@
 import abc
 
 
-_RFM_TRAP_ERROR = '''
+_RFM_TRAP_ERROR = r'''
 _onerror()
 {
     exitcode=$?
@@ -98,8 +98,10 @@ class ShellScriptGenerator:
         self.write(s, 'body')
 
     def finalize(self):
-        ret = '\n'.join([self.shebang, *self._prolog,
-                         *self._body, *self._epilog])
+        # Here empty strings are filtered out before joining
+        stripped_shell = filter(None, [self.shebang, *self._prolog,
+                                       *self._body, *self._epilog])
+        ret = '\n'.join(stripped_shell)
 
         # end with a new line
         if ret:

--- a/reframe/core/shell.py
+++ b/reframe/core/shell.py
@@ -98,10 +98,8 @@ class ShellScriptGenerator:
         self.write(s, 'body')
 
     def finalize(self):
-        # Here empty strings are filtered out before joining
-        stripped_shell = filter(None, [self.shebang, *self._prolog,
-                                       *self._body, *self._epilog])
-        ret = '\n'.join(stripped_shell)
+        ret = '\n'.join([self.shebang, *self._prolog,
+                         *self._body, *self._epilog])
 
         # end with a new line
         if ret:

--- a/unittests/test_schedulers.py
+++ b/unittests/test_schedulers.py
@@ -367,11 +367,6 @@ class TestSlurmJob(_TestJob, unittest.TestCase):
         with open(self.testjob.script_filename) as fp:
             self.assertIsNotNone(re.search(r'--hint=nomultithread', fp.read()))
 
-    def test_no_empty_lines_in_preamble(self):
-        self.setup_job()
-        for l in self.testjob.emit_preamble():
-            self.assertNotEqual(l, '')
-
     def test_submit(self):
         super().test_submit()
         self.assertEqual(0, self.testjob.exitcode)

--- a/unittests/test_schedulers.py
+++ b/unittests/test_schedulers.py
@@ -166,6 +166,11 @@ class _TestJob:
         self.testjob.prepare(self.commands, self.environs)
         self.assertRaises(JobNotStartedError, self.testjob.finished)
 
+    def test_no_empty_lines_in_preamble(self):
+        self.setup_job()
+        for l in self.testjob.emit_preamble():
+            self.assertNotEqual(l, '')
+
 
 class TestLocalJob(_TestJob, unittest.TestCase):
     def assertProcessDied(self, pid):
@@ -364,11 +369,6 @@ class TestSlurmJob(_TestJob, unittest.TestCase):
 
     def test_no_empty_lines_in_preamble(self):
         self.setup_job()
-        self.testjob._sched_nodelist = None
-        self.testjob._sched_exclude_nodelist = None
-        self.testjob._sched_partition = None
-        self.testjob._sched_reservation = None
-        self.testjob._sched_account = None
         for l in self.testjob.emit_preamble():
             self.assertNotEqual(l, '')
 

--- a/unittests/test_schedulers.py
+++ b/unittests/test_schedulers.py
@@ -167,7 +167,6 @@ class _TestJob:
         self.assertRaises(JobNotStartedError, self.testjob.finished)
 
     def test_no_empty_lines_in_preamble(self):
-        self.setup_job()
         for l in self.testjob.emit_preamble():
             self.assertNotEqual(l, '')
 

--- a/unittests/test_schedulers.py
+++ b/unittests/test_schedulers.py
@@ -362,6 +362,16 @@ class TestSlurmJob(_TestJob, unittest.TestCase):
         with open(self.testjob.script_filename) as fp:
             self.assertIsNotNone(re.search(r'--hint=nomultithread', fp.read()))
 
+    def test_no_empty_lines_in_preamble(self):
+        self.setup_job()
+        self.testjob._sched_nodelist = None
+        self.testjob._sched_exclude_nodelist = None
+        self.testjob._sched_partition = None
+        self.testjob._sched_reservation = None
+        self.testjob._sched_account = None
+        for l in self.testjob.emit_preamble():
+            self.assertNotEqual(l, '')
+
     def test_submit(self):
         super().test_submit()
         self.assertEqual(0, self.testjob.exitcode)


### PR DESCRIPTION
* Use `filter` to filter out empty strings before finalizing shell.

* User raw string to suppress invalid escape sequence warning.

Fixes #407 