### PR TITLE
[test] Adapt hdf5 tests to build systems

### DIFF
--- a/cscs-checks/libraries/io/hdf5_compile_run.py
+++ b/cscs-checks/libraries/io/hdf5_compile_run.py
@@ -1,21 +1,17 @@
-import os
+import reframe as rfm
 import reframe.utility.sanity as sn
 
-from reframe.core.pipeline import RegressionTest
 
-
-class HDF5Test(RegressionTest):
-    def __init__(self, lang, linkage, **kwargs):
-        super().__init__('hdf5_read_write_%s_%s' % (linkage, lang),
-                         os.path.dirname(__file__), **kwargs)
-
-        self.flags = ' -%s ' % linkage
-        self.lang_names = {
+@rfm.parameterized_test(*[[lang, linkage] for lang in ['c', 'f90']
+                          for linkage in ['static', 'dynamic']])
+class HDF5Test(rfm.RegressionTest):
+    def __init__(self, lang, linkage):
+        super().__init__()
+        lang_names = {
             'c': 'C',
             'f90': 'Fortran 90'
         }
-
-        self.descr = self.lang_names[lang] + ' HDF5 ' + linkage.capitalize()
+        self.descr = lang_names[lang] + ' HDF5 ' + linkage.capitalize()
         self.sourcepath = 'h5ex_d_chunk.' + lang
         self.valid_systems = ['daint:gpu', 'daint:mc',
                               'dom:gpu', 'dom:mc']
@@ -71,23 +67,12 @@ class HDF5Test(RegressionTest):
 
         self.num_tasks = 1
         self.num_tasks_per_node = 1
+        self.build_system = 'SingleSource'
+        flags = ['-%s' % linkage]
+        self.build_system.cflags = flags
+        self.build_system.cxxflags = flags
+        self.build_system.fflags = flags
+        self.post_run = ['h5dump h5ex_d_chunk.h5 > h5dump_out.txt']
 
         self.maintainers = ['SO']
         self.tags = {'production'}
-
-        self.post_run = ['h5dump h5ex_d_chunk.h5 > h5dump_out.txt']
-
-    def compile(self):
-        self.current_environ.cflags = self.flags
-        self.current_environ.cxxflags = self.flags
-        self.current_environ.fflags = self.flags
-        super().compile()
-
-
-def _get_checks(**kwargs):
-    ret = []
-    for lang in ['c', 'f90']:
-        for linkage in ['dynamic', 'static']:
-            ret.append(HDF5Test(lang, linkage, **kwargs))
-
-    return ret

--- a/cscs-checks/libraries/io/hdf5_compile_run.py
+++ b/cscs-checks/libraries/io/hdf5_compile_run.py
@@ -2,8 +2,8 @@ import reframe as rfm
 import reframe.utility.sanity as sn
 
 
-@rfm.parameterized_test(*[[lang, linkage] for lang in ['c', 'f90']
-                          for linkage in ['static', 'dynamic']])
+@rfm.parameterized_test(*([lang, linkage] for lang in ['c', 'f90']
+                          for linkage in ['static', 'dynamic']))
 class HDF5Test(rfm.RegressionTest):
     def __init__(self, lang, linkage):
         super().__init__()
@@ -68,10 +68,7 @@ class HDF5Test(rfm.RegressionTest):
         self.num_tasks = 1
         self.num_tasks_per_node = 1
         self.build_system = 'SingleSource'
-        flags = ['-%s' % linkage]
-        self.build_system.cflags = flags
-        self.build_system.cxxflags = flags
-        self.build_system.fflags = flags
+        self.build_system.ldflags = ['-%s' % linkage]
         self.post_run = ['h5dump h5ex_d_chunk.h5 > h5dump_out.txt']
 
         self.maintainers = ['SO']


### PR DESCRIPTION
* Adapt hdf5 regression tests to build systems.

* Change to new regression test syntax.

Closes #386  