### PR TITLE
[test] Adapt scorep test to PE 18.07

### DIFF
--- a/cscs-checks/tools/profiling_and_debugging/scorep_mpi_omp.py
+++ b/cscs-checks/tools/profiling_and_debugging/scorep_mpi_omp.py
@@ -28,6 +28,10 @@ class ScorepHybrid(rfm.RegressionTest):
         self.executable = 'jacobi'
         self.build_system = 'Make'
         self.build_system.makefile = 'Makefile_scorep_mpi_omp'
+        # NOTE: Restrict concurrency to allow creation of Fortran modules
+        if lang == 'F90':
+            self.build_system.max_concurrency = 1
+
         self.sourcesdir = 'src/%s' % lang
         self.build_system.srcdir = self.sourcesdir
         self.num_tasks = 3

--- a/cscs-checks/tools/profiling_and_debugging/scorep_mpi_omp.py
+++ b/cscs-checks/tools/profiling_and_debugging/scorep_mpi_omp.py
@@ -1,35 +1,35 @@
-import os
+import reframe as rfm
 import reframe.utility.sanity as sn
 
-from reframe.core.pipeline import RegressionTest
 
-
-class ScorepHybrid(RegressionTest):
-    def __init__(self, lang, **kwargs):
-        super().__init__('scorep_mpi_omp_%s' % lang.replace('+', 'p'),
-                         os.path.dirname(__file__), **kwargs)
-
+@rfm.parameterized_test(['C'], ['C++'], ['F90'])
+class ScorepHybrid(rfm.RegressionTest):
+    def __init__(self, lang):
+        super().__init__()
+        self.name = 'scorep_mpi_omp_%s' % lang.replace('+', 'p')
         self.descr = 'SCORE-P %s check' % lang
         self.valid_systems = ['daint:gpu', 'daint:mc', 'dom:gpu', 'dom:mc']
 
         self.valid_prog_environs = ['PrgEnv-gnu', 'PrgEnv-intel', 'PrgEnv-pgi']
 
         self.scorep_modules = {
-            'PrgEnv-gnu': ['Score-P/3.1-CrayGNU-17.08'],
-            'PrgEnv-intel': ['Score-P/3.1-CrayIntel-17.08'],
-            'PrgEnv-pgi': ['Score-P/3.1-CrayPGI-17.08']
+            'PrgEnv-gnu': ['Score-P/4.0-CrayGNU-18.07'],
+            'PrgEnv-intel': ['Score-P/4.0-CrayIntel-18.07'],
+            'PrgEnv-pgi': ['Score-P/4.0-CrayPGI-18.07']
         }
 
         self.prgenv_flags = {
-            'PrgEnv-cray': '-g -homp',
-            'PrgEnv-gnu': '-g -fopenmp',
-            'PrgEnv-intel': '-g -openmp',
-            'PrgEnv-pgi': '-g -mp'
+            'PrgEnv-cray': ['-g', '-homp'],
+            'PrgEnv-gnu': ['-g', '-fopenmp'],
+            'PrgEnv-intel': ['-g', '-openmp'],
+            'PrgEnv-pgi': ['-g', '-mp']
         }
 
         self.executable = 'jacobi'
-        self.makefile = 'Makefile_scorep_mpi_omp'
-        self.sourcesdir = os.path.join('src', lang)
+        self.build_system = 'Make'
+        self.build_system.makefile = 'Makefile_scorep_mpi_omp'
+        self.sourcesdir = 'src/%s' % lang
+        self.build_system.srcdir = self.sourcesdir
         self.num_tasks = 3
         self.num_tasks_per_node = 3
         self.num_cpus_per_task = 4
@@ -63,29 +63,19 @@ class ScorepHybrid(RegressionTest):
             'otf2-print scorep-*/traces.otf2 > %s' % self.otf2_file
         ]
 
-    def compile(self):
-        prgenv_flags = self.prgenv_flags[self.current_environ.name]
-        self.current_environ.cflags   = prgenv_flags
-        self.current_environ.cxxflags = prgenv_flags
-        self.current_environ.fflags   = prgenv_flags
-        self.current_environ.ldflags  = '-lm'
-        super().compile(makefile=self.makefile,
-                        options="PREP='scorep --nopreprocess "
-                                " --mpp=mpi --thread=omp'")
-
     def setup(self, partition, environ, **job_opts):
         if partition.fullname in ['daint:gpu', 'dom:gpu']:
             self.scorep_modules['PrgEnv-gnu'] = [
-                'Score-P/3.1-CrayGNU-17.08-cuda-8.0'
+                'Score-P/4.0-CrayGNU-18.07-cuda-9.1'
             ]
 
         self.modules = self.scorep_modules[environ.name]
         super().setup(partition, environ, **job_opts)
-
-
-def _get_checks(**kwargs):
-    ret = []
-    for lang in ['C', 'C++', 'F90']:
-        ret.append(ScorepHybrid(lang, **kwargs))
-
-    return ret
+        prgenv_flags = self.prgenv_flags[self.current_environ.name]
+        self.build_system.cflags = prgenv_flags
+        self.build_system.cxxflags = prgenv_flags
+        self.build_system.fflags = prgenv_flags
+        self.build_system.ldflags = ['-lm']
+        self.build_system.options = [
+            "PREP='scorep --nopreprocess --mpp=mpi --thread=omp'"
+        ]

--- a/cscs-checks/tools/profiling_and_debugging/src/F90/Makefile_scorep_mpi_omp
+++ b/cscs-checks/tools/profiling_and_debugging/src/F90/Makefile_scorep_mpi_omp
@@ -5,17 +5,7 @@ all: jacobi
 
 OBJS :=  _variableDef.o _jacobi.o _main.o
 
-_variableDef.o:
-	@echo 'Compiling: $@'
-	@echo '$(PREP) $(FC) $(FFLAGS) -c -o $(@) $(@:.o=.F90)'
-	$(PREP) $(FC) $(FFLAGS) -c -o $(@) $(@:.o=.F90)
-
-_jacobi.o: _variableDef.o
-	@echo 'Compiling: $@'
-	@echo '$(PREP) $(FC) $(FFLAGS) -c -o $(@) $(@:.o=.F90)'
-	$(PREP) $(FC) $(FFLAGS) -c -o $(@) $(@:.o=.F90)
-
-_main.o: _variableDef.o _jacobi.o
+$(OBJS):
 	@echo 'Compiling: $@'
 	@echo '$(PREP) $(FC) $(FFLAGS) -c -o $(@) $(@:.o=.F90)'
 	$(PREP) $(FC) $(FFLAGS) -c -o $(@) $(@:.o=.F90)

--- a/cscs-checks/tools/profiling_and_debugging/src/F90/Makefile_scorep_mpi_omp
+++ b/cscs-checks/tools/profiling_and_debugging/src/F90/Makefile_scorep_mpi_omp
@@ -5,7 +5,17 @@ all: jacobi
 
 OBJS :=  _variableDef.o _jacobi.o _main.o
 
-$(OBJS):
+_variableDef.o:
+	@echo 'Compiling: $@'
+	@echo '$(PREP) $(FC) $(FFLAGS) -c -o $(@) $(@:.o=.F90)'
+	$(PREP) $(FC) $(FFLAGS) -c -o $(@) $(@:.o=.F90)
+
+_jacobi.o: _variableDef.o
+	@echo 'Compiling: $@'
+	@echo '$(PREP) $(FC) $(FFLAGS) -c -o $(@) $(@:.o=.F90)'
+	$(PREP) $(FC) $(FFLAGS) -c -o $(@) $(@:.o=.F90)
+
+_main.o: _variableDef.o _jacobi.o
 	@echo 'Compiling: $@'
 	@echo '$(PREP) $(FC) $(FFLAGS) -c -o $(@) $(@:.o=.F90)'
 	$(PREP) $(FC) $(FFLAGS) -c -o $(@) $(@:.o=.F90)


### PR DESCRIPTION
* Adapt to build systems.

* Adapt to new syntax.

* Add dependencies in Makefile for F90 to ensure that
  Fortran modules are build before used.

Closes #367 
Addresses #397 