### PR TITLE
[test] Adapt perftools to use build systems

### DIFF
--- a/cscs-checks/tools/profiling_and_debugging/perftools.py
+++ b/cscs-checks/tools/profiling_and_debugging/perftools.py
@@ -1,13 +1,13 @@
 import os
+
+import reframe as rfm
 import reframe.utility.sanity as sn
 
-from reframe.core.pipeline import RegressionTest
 
-
-class PerftoolsCheck(RegressionTest):
-    def __init__(self, lang, **kwargs):
-        super().__init__('perftools_check_' + lang.replace('+', 'p'),
-                         os.path.dirname(__file__), **kwargs)
+@rfm.parameterized_test(*([lang] for lang in ['C', 'Cpp', 'F90', 'Cuda']))
+class PerftoolsCheck(rfm.RegressionTest):
+    def __init__(self, lang):
+        super().__init__()
         if lang == 'Cuda':
             self.valid_systems = ['daint:gpu', 'dom:gpu']
         else:
@@ -22,27 +22,35 @@ class PerftoolsCheck(RegressionTest):
             # FIXME: PGI Fortran is hanging after completion
             self.valid_prog_environs = ['PrgEnv-cray', 'PrgEnv-gnu']
 
+        # NOTE: Reduce time limit because for PrgEnv-pgi even if the output
+        # is correct, the batch job uses all the time.
+        self.time_limit = (0, 1, 0)
+
         self.num_gpus_per_node = 1
         self.executable = 'perftools_check'
-
         self.prgenv_flags = {
-            'PrgEnv-cray':  ' -h nomessage=3140 -homp ',
-            'PrgEnv-gnu':   ' -fopenmp ',
-            'PrgEnv-intel': ' -openmp ',
-            'PrgEnv-pgi':   ' -mp ',
+            'PrgEnv-cray': ['-h nomessage=3140', '-homp'],
+            'PrgEnv-gnu': ['-fopenmp'],
+            'PrgEnv-intel': ['-openmp'],
+            'PrgEnv-pgi': ['-mp']
         }
-
         if self.current_system.name == 'kesch':
             # `-lcudart -lm` must be passed explicitly on kesch
-            self.prgenv_flags['PrgEnv-gnu'] = ' -fopenmp -lcudart -lm '
+            self.prgenv_flags['PrgEnv-gnu'] = ['-fopenmp', '-lcudart', '-lm']
 
         self.sanity_patterns = sn.assert_found('Table 1:  Profile by Function',
                                                self.stdout)
-        self.modules  = ['perftools-base', 'perftools-lite', 'cudatoolkit']
-        self.makefile = 'Makefile_perftools'
-        self.sourcesdir = os.path.join('src', lang)
-        self.maintainers = ['MK', 'JG']
-        self.tags = {'production'}
+        self.modules = ['perftools-lite', 'craype-accel-nvidia60']
+        self.build_system = 'Make'
+        self.build_system.makefile = 'Makefile_perftools'
+        if lang == 'Cpp':
+            self.sourcesdir = os.path.join('src', 'C++')
+        else:
+            self.sourcesdir = os.path.join('src', lang)
+
+        # NOTE: Restrict concurrency to allow creation of Fortran modules
+        if lang == 'F90':
+            self.build_system.max_concurrency = 1
 
         if lang != 'Cuda':
             self.num_tasks_per_node = 2
@@ -50,20 +58,15 @@ class PerftoolsCheck(RegressionTest):
         else:
             self.num_tasks_per_node = 1
 
-    def compile(self):
-        self.flags = ' -g -D_CSCS_ITMAX=1 -DUSE_MPI '
-        prgenv_flags = self.prgenv_flags[self.current_environ.name]
-        self.current_environ.cflags    = self.flags + prgenv_flags
-        self.current_environ.cxxflags  = self.flags + prgenv_flags
-        self.current_environ.fflags    = self.flags + prgenv_flags
-        self.current_environ.ldflags   = self.flags + prgenv_flags
-        super().compile(makefile=self.makefile,
-                        options='NVCCFLAGS="-arch=sm_60"')
+        self.maintainers = ['MK', 'JG']
+        self.tags = {'production'}
 
-
-def _get_checks(**kwargs):
-    ret = []
-    for lang in ['C', 'C++', 'F90', 'Cuda']:
-        ret.append(PerftoolsCheck(lang, **kwargs))
-
-    return ret
+    def setup(self, environ, partition, **job_opts):
+        super().setup(environ, partition, **job_opts)
+        flags = self.prgenv_flags[self.current_environ.name]
+        flags += ['-g', '-D_CSCS_ITMAX=1', '-DUSE_MPI']
+        self.build_system.cflags = flags
+        self.build_system.cxxflags = flags
+        self.build_system.fflags = flags
+        self.build_system.ldflags = flags
+        self.build_system.options = ['NVCCFLAGS="-arch=sm_60"']

--- a/cscs-checks/tools/profiling_and_debugging/perftools.py
+++ b/cscs-checks/tools/profiling_and_debugging/perftools.py
@@ -29,10 +29,10 @@ class PerftoolsCheck(rfm.RegressionTest):
         self.num_gpus_per_node = 1
         self.executable = 'perftools_check'
         self.prgenv_flags = {
-            'PrgEnv-cray': ['-h nomessage=3140', '-homp'],
-            'PrgEnv-gnu': ['-fopenmp'],
-            'PrgEnv-intel': ['-openmp'],
-            'PrgEnv-pgi': ['-mp']
+            'PrgEnv-cray': ['-g', '-h nomessage=3140', '-homp'],
+            'PrgEnv-gnu': ['-g', '-fopenmp'],
+            'PrgEnv-intel': ['-g', '-openmp'],
+            'PrgEnv-pgi': ['-g', '-mp']
         }
         if self.current_system.name == 'kesch':
             # `-lcudart -lm` must be passed explicitly on kesch
@@ -40,9 +40,13 @@ class PerftoolsCheck(rfm.RegressionTest):
 
         self.sanity_patterns = sn.assert_found('Table 1:  Profile by Function',
                                                self.stdout)
+
         self.modules = ['perftools-lite', 'craype-accel-nvidia60']
         self.build_system = 'Make'
         self.build_system.makefile = 'Makefile_perftools'
+        self.build_system.cppflags = ['-D_CSCS_ITMAX=1', '-DUSE_MPI']
+        self.build_system.options = ['NVCCFLAGS="-arch=sm_60"']
+
         if lang == 'Cpp':
             self.sourcesdir = os.path.join('src', 'C++')
         else:
@@ -64,9 +68,7 @@ class PerftoolsCheck(rfm.RegressionTest):
     def setup(self, environ, partition, **job_opts):
         super().setup(environ, partition, **job_opts)
         flags = self.prgenv_flags[self.current_environ.name]
-        flags += ['-g', '-D_CSCS_ITMAX=1', '-DUSE_MPI']
         self.build_system.cflags = flags
         self.build_system.cxxflags = flags
         self.build_system.fflags = flags
         self.build_system.ldflags = flags
-        self.build_system.options = ['NVCCFLAGS="-arch=sm_60"']

--- a/cscs-checks/tools/profiling_and_debugging/src/C++/Makefile_perftools
+++ b/cscs-checks/tools/profiling_and_debugging/src/C++/Makefile_perftools
@@ -7,7 +7,7 @@ LIB            =
 .SUFFIXES: .o .cc
 
 %.o: %.cc
-	$(CXX) $(CXXFLAGS) -c $< -o $(PE_ENV)$@
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $< -o $(PE_ENV)$@
 
 perftools_check: $(OBJ)
 	$(LD) $(LDFLAGS) $(OBJ2) $(LIB) -o $@

--- a/cscs-checks/tools/profiling_and_debugging/src/C/Makefile_perftools
+++ b/cscs-checks/tools/profiling_and_debugging/src/C/Makefile_perftools
@@ -7,7 +7,7 @@ LIB            =
 .SUFFIXES: .o .c
 
 %.o: %.c
-	$(CC) $(CFLAGS) -c $< -o $(PE_ENV)$@
+	$(CC) $(CPPFLAGS) $(CFLAGS) -c $< -o $(PE_ENV)$@
 
 perftools_check: $(OBJ)
 	$(LD) $(LDFLAGS) $(OBJ2) $(LIB) -o $@

--- a/cscs-checks/tools/profiling_and_debugging/src/Cuda/Makefile_perftools
+++ b/cscs-checks/tools/profiling_and_debugging/src/Cuda/Makefile_perftools
@@ -12,7 +12,7 @@ LIB            =
 .SUFFIXES: .o .c
 
 %.o: %.c
-	$(CC) $(CFLAGS) $(DDTFLAGS) -c $< -o $(PE_ENV)$@
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(DDTFLAGS) -c $< -o $(PE_ENV)$@
 
 perftools_check: $(OBJ)
 	$(LD) $(LDFLAGS) $(OBJ2) $(LIB) -o $@

--- a/cscs-checks/tools/profiling_and_debugging/src/F90/Makefile_perftools
+++ b/cscs-checks/tools/profiling_and_debugging/src/F90/Makefile_perftools
@@ -7,7 +7,7 @@ LIB            =
 .SUFFIXES: .o .F90
 
 %.o: %.F90
-	$(FC) $(FFLAGS) -c $< -o $(PE_ENV)$@
+	$(FC) $(CPPFLAGS) $(FFLAGS) -c $< -o $(PE_ENV)$@
 
 perftools_check: $(OBJ)
 	$(LD) $(LDFLAGS) $(OBJ2) $(LIB) -o $@


### PR DESCRIPTION
* Adapt the perftools test to use build systems.

* Use new regression test syntax.

Solves the test failure due to the following error:
`attempt to set an aggregate field of different type. Required typespec: list[str]`

This is the last regression test that addresses issue #397.

Closes #397 