### PR TITLE
[feat] Add support for CMake

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -47,7 +47,7 @@ The important bit here is how we set up the build system for this test:
   :dedent: 4
 
 
-First, we set the build system to ``Make`` and then set the preprocessor flags for the compilation.
+First, we set the build system to :attr:`Make <reframe.core.buildsystems.Make>` and then set the preprocessor flags for the compilation.
 ReFrame will invoke ``make`` as follows:
 
 .. code::
@@ -76,7 +76,7 @@ If you want to limit build concurrency, you can do it as follows:
 
 
 Finally, you may also customize the name of the ``Makefile``.
-You can achieve that by setting the corresponding variable of the ``Make`` build system:
+You can achieve that by setting the corresponding variable of the :class:`Make <reframe.core.buildsystems.Make>` build system:
 
 .. code-block:: python
 
@@ -122,13 +122,15 @@ Add a configuration step before compiling the code
 ==================================================
 
 It is often the case that a configuration step is needed before compiling a code with ``make``.
-Currently, ReFrame does not provide specific abstractions for "configure-make"-style build systems.
-However, you can achieve the same effect using the :attr:`prebuild_cmd <reframe.core.pipeline.RegressionTest.prebuild_cmd>` for performing the configuration step.
-The following code snippet will configure a code with ``cmake`` before invoking ``make``:
+To address this kind of projects, ReFrame aims to offer specific abstractions for "configure-make"-style build systems.
+Currently, it supports only `CMake <https://cmake.org/>`__-based projects through its :class:`CMake <reframe.core.buildsystems.CMake>` build system.
+
+For other build systems, you can achieve the same effect using the :class:`Make <reframe.core.buildsystems.Make>` build system and the :attr:`prebuild_cmd <reframe.core.pipeline.RegressionTest.prebuild_cmd>` for performing the configuration step.
+The following code snippet will configure a code with ``./custom_configure`` before invoking ``make``:
 
 .. code-block:: python
 
-  self.prebuild_cmd = ['cmake -DUSE_LIBNUMA .']
+  self.prebuild_cmd = ['./custom_configure -with-mylib']
   self.build_system = 'Make'
   self.build_system.cppflags = ['-DHAVE_FOO']
   self.build_system.flags_from_environ = False
@@ -137,7 +139,7 @@ The generated build script then will have the following lines:
 
 .. code-block:: bash
 
-  cmake -DUSE_LIBNUMA .
+  ./custom_configure -with-mylib
   make -j CPPFLAGS='-DHAVE_FOO'
 
 

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -354,7 +354,7 @@ Assuming our test supported only GCC, we could simply add the following lines in
         self.build_system = 'SingleSource'
         self.build_system.cflags = ['-fopenmp']
 
-The ``SingleSource`` build system that we use here supports the compilation of a single file only.
+The :class:`SingleSource <reframe.core.buildsystems.SingleSource>` build system that we use here supports the compilation of a single file only.
 Each build system type defines a set of variables that the user can set.
 Based on the selected build system, ReFrame will generate a build script that will be used for building the code.
 The generated build script can be found in `the stage or the output directory of the test <running.html#configuring-reframe-directories>`__, along with the output of the compilation.

--- a/reframe/core/buildsystems.py
+++ b/reframe/core/buildsystems.py
@@ -444,8 +444,36 @@ class SingleSource(BuildSystem):
 
 
 class CMake(BuildSystem):
+    """A build system for compiling CMake-based projects.
+
+    This build system will emit the following commands:
+
+    1. Create a build directory if :attr:`builddir` is not :class:`None` and
+       change to it.
+    2. Invoke ``cmake`` to configure the project by setting the corresponding
+       CMake flags for compilers and compiler flags.
+    3. Issue ``make`` to compile the code.
+    """
+
+    #: The top-level directory of the code.
+    #:
+    #: This is set automatically by the framework based on the
+    #: :attr:`reframe.core.pipeline.RegressionTest.sourcepath` attribute.
+    #:
+    #: :type: :class:`str`
+    #: :default: :class:`None`
     srcdir = fields.StringField('srcdir', allow_none=True)
+
+    #: The CMake build directory, where all the generated files will be placed.
+    #:
+    #: :type: :class:`str`
+    #: :default: :class:`None`
     builddir = fields.StringField('builddir', allow_none=True)
+
+    #: Additional configuration options to be passed to the CMake invocation.
+    #:
+    #: :type: :class:`list[str]`
+    #: :default: ``[]``
     config_opts = fields.TypedListField('config_opts', str)
 
     def __init__(self):

--- a/reframe/core/pipeline.py
+++ b/reframe/core/pipeline.py
@@ -925,9 +925,15 @@ class RegressionTest:
         self.logger.debug('Staged sourcepath: %s' % staged_sourcepath)
         if os.path.isdir(staged_sourcepath):
             if not self.build_system:
-                self.build_system = 'Make'
+                # Try to guess the build system
+                if os.path.exists(os.path.join(staged_sourcepath,
+                                               'CMakeLists.txt')):
+                    self.build_system = 'CMake'
+                    self.build_system.builddir = 'rfm_build'
+                else:
+                    self.build_system = 'Make'
 
-            self.build_system.srcdir = self.sourcepath
+                self.build_system.srcdir = self.sourcepath
         else:
             if not self.build_system:
                 self.build_system = 'SingleSource'

--- a/reframe/core/pipeline.py
+++ b/reframe/core/pipeline.py
@@ -93,9 +93,13 @@ class RegressionTest:
     #: subfolder or a file contained in :attr:`sourcesdir`. This applies also
     #: in the case where :attr:`sourcesdir` is a Git repository.
     #:
-    #: If it refers to a regular file, this file will be compiled (its language
-    #: will be automatically recognized).
-    #: If it refers to a directory, ``make`` will be invoked in that directory.
+    #: If it refers to a regular file, this file will be compiled using the
+    #: :class:`SingleSource <reframe.core.buildsystems.SingleSource>` build
+    #: system.
+    #: If it refers to a directory, ReFrame will try to infer the build system
+    #: to use for the project and will fall back in using the :class:`Make
+    #: <reframe.core.buildsystems.Make>` build system, if it cannot find a more
+    #: specific one.
     #:
     #: :type: :class:`str`
     #: :default: ``''``

--- a/unittests/test_buildsystems.py
+++ b/unittests/test_buildsystems.py
@@ -33,7 +33,6 @@ class _BuildSystemTest:
         self.build_system.cxxflags = ['-Wall', '-std=c++11', '-O3']
         self.build_system.fflags = ['-Wall', '-O3']
         self.build_system.ldflags = ['-static']
-        self.build_system.flags_from_environ = False
 
 
 class TestMake(_BuildSystemTest, unittest.TestCase):
@@ -54,7 +53,7 @@ class TestMake(_BuildSystemTest, unittest.TestCase):
         self.assertEqual(expected,
                          self.build_system.emit_build_commands(self.environ))
 
-    def test_emit_no_env(self):
+    def test_emit_from_buildsystem(self):
         super().setup_base_buildsystem()
         self.build_system.makefile = 'Makefile_foo'
         self.build_system.srcdir = 'foodir'
@@ -72,6 +71,59 @@ class TestMake(_BuildSystemTest, unittest.TestCase):
     def test_emit_no_env_defaults(self):
         self.build_system.flags_from_environ = False
         self.assertEqual(['make -j'],
+                         self.build_system.emit_build_commands(self.environ))
+
+
+class TestCMake(_BuildSystemTest, unittest.TestCase):
+    def create_build_system(self):
+        return bs.CMake()
+
+    def test_emit_from_env(self):
+        self.build_system.srcdir = 'src'
+        self.build_system.builddir = 'build/foo'
+        self.build_system.config_opts = ['-DFOO=1']
+        self.build_system.max_concurrency = 32
+        expected = [
+            "cd src",
+            "mkdir -p build/foo",
+            "cd build/foo",
+            "cmake -DCMAKE_C_COMPILER='gcc' -DCMAKE_CXX_COMPILER='g++' "
+            "-DCMAKE_Fortran_COMPILER='gfortran' "
+            "-DCMAKE_CUDA_COMPILER='nvcc' "
+            "-DCMAKE_C_FLAGS='-DNDEBUG -Wall -std=c99' "
+            "-DCMAKE_CXX_FLAGS='-DNDEBUG -Wall -std=c++11' "
+            "-DCMAKE_Fortran_FLAGS='-DNDEBUG -Wall' "
+            "-DCMAKE_EXE_LINKER_FLAGS='-dynamic' -DFOO=1 ../..",
+            "make -j 32"
+
+        ]
+        self.assertEqual(expected,
+                         self.build_system.emit_build_commands(self.environ))
+
+    def test_emit_from_buildsystem(self):
+        super().setup_base_buildsystem()
+        self.build_system.builddir = 'build/foo'
+        self.build_system.config_opts = ['-DFOO=1']
+        self.build_system.max_concurrency = None
+        expected = [
+            "mkdir -p build/foo",
+            "cd build/foo",
+            "cmake -DCMAKE_C_COMPILER='cc' -DCMAKE_CXX_COMPILER='CC' "
+            "-DCMAKE_Fortran_COMPILER='ftn' -DCMAKE_CUDA_COMPILER='clang' "
+            "-DCMAKE_C_FLAGS='-DFOO -Wall -std=c99 -O3' "
+            "-DCMAKE_CXX_FLAGS='-DFOO -Wall -std=c++11 -O3' "
+            "-DCMAKE_Fortran_FLAGS='-DFOO -Wall -O3' "
+            "-DCMAKE_EXE_LINKER_FLAGS='-static' -DFOO=1 ../..",
+            "make -j"
+
+        ]
+        print(self.build_system.emit_build_commands(self.environ))
+        self.assertEqual(expected,
+                         self.build_system.emit_build_commands(self.environ))
+
+    def test_emit_no_env_defaults(self):
+        self.build_system.flags_from_environ = False
+        self.assertEqual(['cmake .', 'make -j'],
                          self.build_system.emit_build_commands(self.environ))
 
 


### PR DESCRIPTION
- Build system takes care of passing some of the basic CMake flags, such
  as the compiler and the compilation flags, by setting them from the
  current environment.
- CMake projects are also auto-detected is `sourcepath` contains a
  `CMakeLists.txt` file.

Closes #299.

Still todo:

- [x] Update documentation