### PR TITLE
[feat] Use different stage and output directories for different retries of the same test

### DIFF
--- a/reframe/core/runtime.py
+++ b/reframe/core/runtime.py
@@ -128,8 +128,9 @@ class HostResources:
             return os.path.join(self.prefix, 'output' + self._run_suffix(),
                                 self.timestamp)
         else:
-            return os.path.join(os.path.normpath(self.outputdir) +
-                                self._run_suffix(), self.timestamp)
+            return os.path.join(self.outputdir + self._run_suffix(),
+                                self.timestamp)
+
 
     @property
     def stage_prefix(self):
@@ -138,8 +139,8 @@ class HostResources:
             return os.path.join(self.prefix, 'stage' + self._run_suffix(),
                                 self.timestamp)
         else:
-            return os.path.join(os.path.normpath(self.stagedir) +
-                                self._run_suffix(), self.timestamp)
+            return os.path.join(self.stagedir + self._run_suffix(),
+                                self.timestamp)
 
     @property
     def perflog_prefix(self):
@@ -218,10 +219,7 @@ class RuntimeContext:
 
     @property
     def current_run(self):
-        """The current run.
-
-        :type: `integer`
-        """
+        # Not publicly documented
         return self._current_run
 
     @property

--- a/reframe/core/runtime.py
+++ b/reframe/core/runtime.py
@@ -219,7 +219,6 @@ class RuntimeContext:
 
     @property
     def current_run(self):
-        # Not publicly documented
         return self._current_run
 
     @property

--- a/reframe/core/runtime.py
+++ b/reframe/core/runtime.py
@@ -113,6 +113,10 @@ class HostResources:
         os.makedirs(ret, exist_ok=True)
         return ret
 
+    def _run_suffix(self):
+        current_run = runtime().current_run
+        return '_%s' % current_run if current_run > 0 else ''
+
     @property
     def timestamp(self):
         return self._timestamp.strftime(self.timefmt) if self.timefmt else ''
@@ -121,17 +125,21 @@ class HostResources:
     def output_prefix(self):
         """The output prefix directory of ReFrame."""
         if self.outputdir is None:
-            return os.path.join(self.prefix, 'output', self.timestamp)
+            return os.path.join(self.prefix, 'output' + self._run_suffix(),
+                                self.timestamp)
         else:
-            return os.path.join(self.outputdir, self.timestamp)
+            return os.path.join(os.path.normpath(self.outputdir) +
+                                self._run_suffix(), self.timestamp)
 
     @property
     def stage_prefix(self):
         """The stage prefix directory of ReFrame."""
         if self.stagedir is None:
-            return os.path.join(self.prefix, 'stage', self.timestamp)
+            return os.path.join(self.prefix, 'stage' + self._run_suffix(),
+                                self.timestamp)
         else:
-            return os.path.join(self.stagedir, self.timestamp)
+            return os.path.join(os.path.normpath(self.stagedir) +
+                                self._run_suffix(), self.timestamp)
 
     @property
     def perflog_prefix(self):
@@ -177,6 +185,7 @@ class RuntimeContext:
             self._system.outputdir, self._system.perflogdir)
         self._modules_system = ModulesSystem.create(
             self._system.modules_system)
+        self._current_run = 0
 
     def _autodetect_system(self):
         """Auto-detect system."""
@@ -203,6 +212,17 @@ class RuntimeContext:
             return self._site_config.modes[name]
         except KeyError:
             raise ConfigError('unknown execution mode: %s' % name) from None
+
+    def next_run(self):
+        self._current_run += 1
+
+    @property
+    def current_run(self):
+        """The current run.
+
+        :type: `integer`
+        """
+        return self._current_run
 
     @property
     def system(self):

--- a/reframe/frontend/executors/__init__.py
+++ b/reframe/frontend/executors/__init__.py
@@ -150,7 +150,6 @@ class Runner:
         self._policy = policy
         self._printer = printer or PrettyPrinter()
         self._max_retries = max_retries
-        self._current_run = 0
         self._stats = TestStats()
         self._policy.stats = self._stats
         self._policy.printer = self._printer
@@ -207,24 +206,19 @@ class Runner:
             return ret and check.supports_environ(environ.name)
 
     def _retry_failed(self, checks):
+        rt = runtime.runtime()
         while (self._stats.num_failures() and
-               self._current_run < self._max_retries):
+               rt.current_run < self._max_retries):
             failed_checks = [
                 c for c in checks if c.name in
                 set([t.check.name for t in self._stats.tasks_failed()])
             ]
-            self._current_run += 1
-            self._stats.next_run()
-            if self._stats.current_run != self._current_run:
-                raise AssertionError('current_run variable out of sync'
-                                     '(Runner: %d; TestStats: %d)' %
-                                     self._current_run,
-                                     self._stats.current_run)
+            rt.next_run()
 
             self._printer.separator(
                 'short double line',
                 'Retrying %d failed check(s) (retry %d/%d)' %
-                (len(failed_checks), self._current_run, self._max_retries)
+                (len(failed_checks), rt.current_run, self._max_retries)
             )
             self._runall(failed_checks)
 

--- a/reframe/frontend/statistics.py
+++ b/reframe/frontend/statistics.py
@@ -17,6 +17,7 @@ class TestStats:
         current_run = rt.runtime().current_run
         if current_run == len(self._tasks):
             self._tasks.append([])
+
         self._tasks[current_run].append(task)
 
     def get_tasks(self, run=-1):

--- a/unittests/test_policies.py
+++ b/unittests/test_policies.py
@@ -140,7 +140,7 @@ class TestSerialExecutionPolicy(unittest.TestCase):
 
         # Ensure that the test was retried #max_retries times and failed.
         self.assertEqual(1, self.runner.stats.num_cases())
-        self.assertEqual(max_retries, self.runner.stats.current_run)
+        self.assertEqual(max_retries, rt.runtime().current_run)
         self.assertEqual(1, self.runner.stats.num_failures())
 
     def test_retries_good_check(self):
@@ -151,7 +151,7 @@ class TestSerialExecutionPolicy(unittest.TestCase):
 
         # Ensure that the test passed without retries.
         self.assertEqual(1, self.runner.stats.num_cases())
-        self.assertEqual(0, self.runner.stats.current_run)
+        self.assertEqual(0, rt.runtime().current_run)
         self.assertEqual(0, self.runner.stats.num_failures())
 
     def test_pass_in_retries(self):
@@ -169,7 +169,7 @@ class TestSerialExecutionPolicy(unittest.TestCase):
         # Ensure that the test passed after retries in run #run_to_pass.
         self.assertEqual(1, self.runner.stats.num_cases())
         self.assertEqual(1, self.runner.stats.num_failures(run=0))
-        self.assertEqual(run_to_pass, self.runner.stats.current_run)
+        self.assertEqual(run_to_pass, rt.runtime().current_run)
         self.assertEqual(0, self.runner.stats.num_failures())
         os.remove(fp.name)
 

--- a/unittests/test_policies.py
+++ b/unittests/test_policies.py
@@ -27,6 +27,9 @@ class TestSerialExecutionPolicy(unittest.TestCase):
         # Set runtime prefix
         rt.runtime().resources.prefix = tempfile.mkdtemp(dir='unittests')
 
+        # Reset current_run
+        rt.runtime()._current_run = 0
+
     def tearDown(self):
         os_ext.rmtree(rt.runtime().resources.prefix)
 
@@ -133,9 +136,6 @@ class TestSerialExecutionPolicy(unittest.TestCase):
         stats = self.runner.stats
         self.assertEqual(1, stats.num_failures())
 
-    # Retries tests are executed in a different runtime as they modify
-    # the global rt.runtime().current_run what makes subsequent tests fail
-    @rt.switch_runtime(fixtures.TEST_SITE_CONFIG, 'generic')
     def test_retries_bad_check(self):
         max_retries = 2
         checks = [BadSetupCheck()]
@@ -147,7 +147,6 @@ class TestSerialExecutionPolicy(unittest.TestCase):
         self.assertEqual(max_retries, rt.runtime().current_run)
         self.assertEqual(1, self.runner.stats.num_failures())
 
-    @rt.switch_runtime(fixtures.TEST_SITE_CONFIG, 'generic')
     def test_retries_good_check(self):
         max_retries = 2
         checks = [HelloTest()]
@@ -159,7 +158,6 @@ class TestSerialExecutionPolicy(unittest.TestCase):
         self.assertEqual(0, rt.runtime().current_run)
         self.assertEqual(0, self.runner.stats.num_failures())
 
-    @rt.switch_runtime(fixtures.TEST_SITE_CONFIG, 'generic')
     def test_pass_in_retries(self):
         max_retries = 3
         run_to_pass = 2

--- a/unittests/test_policies.py
+++ b/unittests/test_policies.py
@@ -8,6 +8,7 @@ import reframe.frontend.executors.policies as policies
 import reframe.utility.os_ext as os_ext
 from reframe.core.exceptions import JobNotStartedError
 from reframe.frontend.loader import RegressionCheckLoader
+import unittests.fixtures as fixtures
 from unittests.resources.checks.hellocheck import HelloTest
 from unittests.resources.checks.frontend_checks import (
     KeyboardInterruptCheck, SleepCheck,
@@ -132,6 +133,9 @@ class TestSerialExecutionPolicy(unittest.TestCase):
         stats = self.runner.stats
         self.assertEqual(1, stats.num_failures())
 
+    # Retries tests are executed in a different runtime as they modify
+    # the global rt.runtime().current_run what makes subsequent tests fail
+    @rt.switch_runtime(fixtures.TEST_SITE_CONFIG, 'generic')
     def test_retries_bad_check(self):
         max_retries = 2
         checks = [BadSetupCheck()]
@@ -143,6 +147,7 @@ class TestSerialExecutionPolicy(unittest.TestCase):
         self.assertEqual(max_retries, rt.runtime().current_run)
         self.assertEqual(1, self.runner.stats.num_failures())
 
+    @rt.switch_runtime(fixtures.TEST_SITE_CONFIG, 'generic')
     def test_retries_good_check(self):
         max_retries = 2
         checks = [HelloTest()]
@@ -154,6 +159,7 @@ class TestSerialExecutionPolicy(unittest.TestCase):
         self.assertEqual(0, rt.runtime().current_run)
         self.assertEqual(0, self.runner.stats.num_failures())
 
+    @rt.switch_runtime(fixtures.TEST_SITE_CONFIG, 'generic')
     def test_pass_in_retries(self):
         max_retries = 3
         run_to_pass = 2


### PR DESCRIPTION
Includes the migration of the `current_run` variable to the class RuntimeContext and related changes.
Closes #403.