### PR TITLE
[test] Adapt trilinos regression test to PE18.08 and build systems

### DIFF
--- a/cscs-checks/libraries/math/trilinos_compile_run.py
+++ b/cscs-checks/libraries/math/trilinos_compile_run.py
@@ -1,28 +1,13 @@
 import os
+
+import reframe as rfm
 import reframe.utility.sanity as sn
 
-from reframe.core.pipeline import RegressionTest
 
-
-class TrilinosTest(RegressionTest):
-    def __init__(self, linkage, **kwargs):
-        super().__init__('trilinos_compile_run_%s' % linkage,
-                         os.path.dirname(__file__), **kwargs)
-
-        self.flags = ' -DHAVE_MPI -DEPETRA_MPI -lparmetis -%s ' % linkage
-        self.prgenv_flags = {
-            'PrgEnv-cray': ' -homp -hstd=c++11 -hmsglevel_4 ',
-            'PrgEnv-gnu': ' -fopenmp -std=c++11 -w -fpermissive ',
-            'PrgEnv-intel': ' -qopenmp -w -std=c++11 ',
-            'PrgEnv-pgi': ' -mp -w '
-        }
-        self.descr = 'Trilinos ' + linkage.capitalize()
-        self.sourcepath = 'example_AmesosFactory_HB.cpp'
-        #self.sourcepath = 'trilinos_compile_run.cpp'
-        self.input_file = os.path.join(self.current_system.resourcesdir,
-                                       'Trilinos', 'trilinos_compile_run.rua')
-
-        self.executable_opts = self.input_file.split()
+@rfm.parameterized_test(['static'], ['dynamic'])
+class TrilinosTest(rfm.RegressionTest):
+    def __init__(self, linkage):
+        super().__init__()
         self.valid_systems = ['daint:gpu', 'daint:mc',
                               'dom:gpu', 'dom:mc']
 
@@ -33,6 +18,21 @@ class TrilinosTest(RegressionTest):
             self.valid_prog_environs = ['PrgEnv-cray', 'PrgEnv-gnu',
                                         'PrgEnv-intel']
 
+        self.build_system = 'SingleSource'
+        self.build_system.ldflags = ['-%s' % linkage]
+        self.build_system.cppflags = ['-DHAVE_MPI', '-DEPETRA_MPI']
+        self.build_system.cxxflags = ['-lparmetis']
+        self.prgenv_flags = {
+            'PrgEnv-cray': ['-homp', '-hstd=c++11', '-hmsglevel_4'],
+            'PrgEnv-gnu': ['-fopenmp', '-std=c++11', '-w', '-fpermissive'],
+            'PrgEnv-intel': ['-qopenmp', '-w', '-std=c++11'],
+            'PrgEnv-pgi': ['-mp', '-w']
+        }
+        self.sourcepath = 'example_AmesosFactory_HB.cpp'
+        # self.sourcepath = 'trilinos_compile_run.cpp'
+        input_file = os.path.join(self.current_system.resourcesdir,
+                                  'Trilinos', 'trilinos_compile_run.rua')
+        self.executable_opts = input_file.split()
         self.modules = ['cray-mpich', 'cray-hdf5-parallel',
                         'cray-tpsl', 'cray-trilinos']
         self.num_tasks = 2
@@ -45,18 +45,10 @@ class TrilinosTest(RegressionTest):
         self.tags = {'production'}
 
     def setup(self, partition, environ, **job_opts):
+        prgenv_flags = self.prgenv_flags[environ.name]
+        self.build_system.cxxflags += prgenv_flags
         if environ.name == 'PrgEnv-intel':
             # CrayBug/836679
             self.modules += ['gcc/4.9.3']
 
         super().setup(partition, environ, **job_opts)
-
-    def compile(self):
-        prgenv_flags = self.prgenv_flags[self.current_environ.name]
-        self.current_environ.cxxflags = self.flags + prgenv_flags
-        super().compile()
-
-
-def _get_checks(**kwargs):
-    return [TrilinosTest('dynamic', **kwargs),
-            TrilinosTest('static',  **kwargs)]

--- a/cscs-checks/libraries/math/trilinos_compile_run.py
+++ b/cscs-checks/libraries/math/trilinos_compile_run.py
@@ -12,7 +12,6 @@ class TrilinosTest(rfm.RegressionTest):
                               'dom:gpu', 'dom:mc']
 
         # NOTE: PrgEnv-cray in dynamic does not work because of CrayBug/809265
-        # PrgEnv-cray seg faults for cray-trilinos/12.12.1.1
         if linkage == 'static':
             self.valid_prog_environs = ['PrgEnv-gnu', 'PrgEnv-intel']
         else:
@@ -20,9 +19,8 @@ class TrilinosTest(rfm.RegressionTest):
                                         'PrgEnv-intel']
 
         self.build_system = 'SingleSource'
-        self.build_system.ldflags = ['-%s' % linkage]
+        self.build_system.ldflags = ['-%s' % linkage, '-lparmetis']
         self.build_system.cppflags = ['-DHAVE_MPI', '-DEPETRA_MPI']
-        self.build_system.cxxflags = ['-lparmetis']
         self.prgenv_flags = {
             'PrgEnv-cray': ['-homp', '-hstd=c++11', '-hmsglevel_4'],
             'PrgEnv-gnu': ['-fopenmp', '-std=c++11', '-w', '-fpermissive'],
@@ -32,7 +30,7 @@ class TrilinosTest(rfm.RegressionTest):
         self.sourcepath = 'example_AmesosFactory_HB.cpp'
         input_file = os.path.join(self.current_system.resourcesdir,
                                   'Trilinos', 'trilinos_compile_run.rua')
-        self.executable_opts = input_file.split()
+        self.executable_opts = [input_file]
 
         # NOTE: default cray-trilinos module in PE/18.08 does not work
         self.modules = ['cray-mpich', 'cray-hdf5-parallel',
@@ -48,7 +46,7 @@ class TrilinosTest(rfm.RegressionTest):
 
     def setup(self, partition, environ, **job_opts):
         prgenv_flags = self.prgenv_flags[environ.name]
-        self.build_system.cxxflags += prgenv_flags
+        self.build_system.cxxflags = prgenv_flags
         if environ.name == 'PrgEnv-intel':
             # CrayBug/836679
             self.modules += ['gcc']

--- a/cscs-checks/libraries/math/trilinos_compile_run.py
+++ b/cscs-checks/libraries/math/trilinos_compile_run.py
@@ -11,10 +11,11 @@ class TrilinosTest(rfm.RegressionTest):
         self.valid_systems = ['daint:gpu', 'daint:mc',
                               'dom:gpu', 'dom:mc']
 
-        # Removed CRAY env in dynamic because of CrayBug/809265
-        if linkage == 'dynamic':
+        # NOTE: PrgEnv-cray in dynamic does not work because of CrayBug/809265
+        # PrgEnv-cray seg faults for cray-trilinos/12.12.1.1
+        if linkage == 'static':
             self.valid_prog_environs = ['PrgEnv-gnu', 'PrgEnv-intel']
-        elif linkage == 'static':
+        else:
             self.valid_prog_environs = ['PrgEnv-cray', 'PrgEnv-gnu',
                                         'PrgEnv-intel']
 
@@ -29,12 +30,13 @@ class TrilinosTest(rfm.RegressionTest):
             'PrgEnv-pgi': ['-mp', '-w']
         }
         self.sourcepath = 'example_AmesosFactory_HB.cpp'
-        # self.sourcepath = 'trilinos_compile_run.cpp'
         input_file = os.path.join(self.current_system.resourcesdir,
                                   'Trilinos', 'trilinos_compile_run.rua')
         self.executable_opts = input_file.split()
+
+        # NOTE: default cray-trilinos module in PE/18.08 does not work
         self.modules = ['cray-mpich', 'cray-hdf5-parallel',
-                        'cray-tpsl', 'cray-trilinos']
+                        'cray-tpsl', 'cray-trilinos/12.12.1.1']
         self.num_tasks = 2
         self.num_tasks_per_node = 2
         self.variables = {'OMP_NUM_THREADS': '1'}
@@ -49,6 +51,6 @@ class TrilinosTest(rfm.RegressionTest):
         self.build_system.cxxflags += prgenv_flags
         if environ.name == 'PrgEnv-intel':
             # CrayBug/836679
-            self.modules += ['gcc/4.9.3']
+            self.modules += ['gcc']
 
         super().setup(partition, environ, **job_opts)

--- a/cscs-checks/libraries/math/trilinos_compile_run.py
+++ b/cscs-checks/libraries/math/trilinos_compile_run.py
@@ -12,7 +12,7 @@ class TrilinosTest(rfm.RegressionTest):
                               'dom:gpu', 'dom:mc']
 
         # NOTE: PrgEnv-cray in dynamic does not work because of CrayBug/809265
-        if linkage == 'static':
+        if linkage == 'dynamic':
             self.valid_prog_environs = ['PrgEnv-gnu', 'PrgEnv-intel']
         else:
             self.valid_prog_environs = ['PrgEnv-cray', 'PrgEnv-gnu',


### PR DESCRIPTION
The test fails for `PrgEnv-cray` since the executable gibes a segmentation fault for cray-trilinos/12.12.1.1

Fixes #385 
Fixes #363 