### PR TITLE
[bugfix] Remove time limit from build jobs

### DIFF
--- a/reframe/core/pipeline.py
+++ b/reframe/core/pipeline.py
@@ -406,10 +406,19 @@ class RegressionTest:
     #:
     #: Time limit is specified as a three-tuple in the form ``(hh, mm, ss)``,
     #: with ``hh >= 0``, ``0 <= mm <= 59`` and ``0 <= ss <= 59``.
+    #: If set to :class:`None`, no time limit will be set.
+    #: The default time limit of the system partition's scheduler will be used.
+    #:
     #:
     #: :type: :class:`tuple[int]`
     #: :default: ``(0, 10, 0)``
-    time_limit = fields.TimerField('time_limit')
+    #:
+    #: .. note::
+    #:    .. versionchanged:: 2.15
+    #:
+    #:    This attribute may be set to :class:`None`.
+    #:
+    time_limit = fields.TimerField('time_limit', allow_none=True)
 
     #: Extra resources for this test.
     #:

--- a/reframe/core/schedulers/__init__.py
+++ b/reframe/core/schedulers/__init__.py
@@ -64,7 +64,7 @@ class Job(abc.ABC):
                  num_tasks_per_socket=None,
                  num_cpus_per_task=None,
                  use_smt=None,
-                 time_limit=(0, 10, 0),
+                 time_limit=None,
                  script_filename=None,
                  stdout=None,
                  stderr=None,

--- a/reframe/core/schedulers/local.py
+++ b/reframe/core/schedulers/local.py
@@ -133,8 +133,12 @@ class LocalJob(sched.Job):
             return
 
         # Convert job's time_limit to seconds
-        h, m, s = self.time_limit
-        timeout = h * 3600 + m * 60 + s
+        if self.time_limit is not None:
+            h, m, s = self.time_limit
+            timeout = h * 3600 + m * 60 + s
+        else:
+            timeout = 0
+
         try:
             self._wait_all(timeout)
             self._exitcode = self._proc.returncode

--- a/reframe/core/schedulers/pbs.py
+++ b/reframe/core/schedulers/pbs.py
@@ -70,10 +70,14 @@ class PbsJob(sched.Job):
     def emit_preamble(self):
         preamble = [
             self._format_option('-N "%s"' % self.name),
-            self._format_option('-l walltime=%d:%d:%d' % self.time_limit),
             self._format_option('-o %s' % self.stdout),
             self._format_option('-e %s' % self.stderr),
         ]
+
+        if self.time_limit is not None:
+            preamble.append(
+                self._format_option('-l walltime=%d:%d:%d' % self.time_limit))
+
         if self.sched_partition:
             preamble.append(
                 self._format_option('-q %s' % self.sched_partition))

--- a/reframe/core/schedulers/slurm.py
+++ b/reframe/core/schedulers/slurm.py
@@ -79,7 +79,6 @@ class SlurmJob(sched.Job):
     def emit_preamble(self):
         preamble = [
             self._format_option(self.name, '--job-name="{0}"'),
-            self._format_option('%d:%d:%d' % self.time_limit, '--time={0}'),
             self._format_option(self.num_tasks, '--ntasks={0}'),
             self._format_option(self.num_tasks_per_node,
                                 '--ntasks-per-node={0}'),
@@ -96,6 +95,10 @@ class SlurmJob(sched.Job):
             self._format_option(self.stdout, '--output={0}'),
             self._format_option(self.stderr, '--error={0}'),
         ]
+
+        if self.time_limit is not None:
+            preamble.append(self._format_option('%d:%d:%d' % self.time_limit,
+                                                '--time={0}'))
 
         if self.sched_exclusive_access:
             preamble.append(self._format_option(

--- a/unittests/test_launchers.py
+++ b/unittests/test_launchers.py
@@ -120,7 +120,6 @@ class TestSrunallocLauncher(_TestLauncher, unittest.TestCase):
     def expected_minimal_command(self):
         return ('srun '
                 '--job-name=fake_job '
-                '--time=0:10:0 '
                 '--output=./fake_job.out '
                 '--error=./fake_job.err '
                 '--ntasks=1 '


### PR DESCRIPTION
This PR changes basically the `Job` class by changing the default time limit.

- Time limit now defaults to `None`, meaning that the backends should
  not impose any time limit on the running job.
- Build jobs do not have any time limit.

Fixes #465.