### PR TITLE
[ci] Adapt Kesch settings

### DIFF
--- a/config/cscs.py
+++ b/config/cscs.py
@@ -114,7 +114,8 @@ class ReframeSettings:
                         'scheduler': 'nativeslurm',
                         'access': ['--partition=pn-regression'],
                         'environs': ['PrgEnv-cray', 'PrgEnv-cray-nompi',
-                                     'PrgEnv-pgi', 'PrgEnv-pgi-nompi'],
+                                     'PrgEnv-pgi', 'PrgEnv-pgi-nompi',
+                                     'PrgEnv-gnu', 'PrgEnv-gnu-nompi'],
                         'descr': 'Kesch post-processing nodes'
                     },
 
@@ -122,7 +123,8 @@ class ReframeSettings:
                         'scheduler': 'nativeslurm',
                         'access': ['--partition=cn-regression'],
                         'environs': ['PrgEnv-cray', 'PrgEnv-cray-nompi',
-                                     'PrgEnv-pgi', 'PrgEnv-pgi-nompi'],
+                                     'PrgEnv-pgi', 'PrgEnv-pgi-nompi',
+                                     'PrgEnv-gnu', 'PrgEnv-gnu-nompi'],
                         'descr': 'Kesch compute nodes',
                         'resources': {
                             '_rfm_gpu': ['--gres=gpu:{num_gpus_per_node}']
@@ -214,6 +216,20 @@ class ReframeSettings:
                 'PrgEnv-cray-nompi': {
                     'type': 'ProgEnvironment',
                     'modules': ['PrgEnv-cray'],
+                },
+                'PrgEnv-gnu': {
+                    'type': 'ProgEnvironment',
+                    'modules': ['gmvapich2/17.02_cuda_8.0_gdr'],
+                    'cc': 'mpicc',
+                    'cxx': 'mpic++',
+                    'ftn': 'mpif90',
+                },
+                'PrgEnv-gnu-nompi': {
+                    'type': 'ProgEnvironment',
+                    'modules': ['gmvapich2/17.02_cuda_8.0_gdr'],
+                    'cc': 'gcc',
+                    'cxx': 'g++',
+                    'ftn': 'gfortran',
                 },
             },
             'leone': {

--- a/config/cscs.py
+++ b/config/cscs.py
@@ -107,25 +107,22 @@ class ReframeSettings:
                 'partitions': {
                     'login': {
                         'scheduler': 'local',
-                        'environs': ['PrgEnv-gnu', 'PrgEnv-cray',
-                                     'PrgEnv-pgi', 'PrgEnv-gnu-gdr'],
+                        'environs': ['PrgEnv-cray-nompi', 'PrgEnv-pgi-nompi'],
                         'descr': 'Kesch login nodes',
                     },
                     'pn': {
                         'scheduler': 'nativeslurm',
                         'access': ['--partition=pn-regression'],
-                        'environs': ['PrgEnv-gnu', 'PrgEnv-cray',
-                                     'PrgEnv-pgi', 'PrgEnv-gnu-gdr'],
+                        'environs': ['PrgEnv-cray', 'PrgEnv-cray-nompi',
+                                     'PrgEnv-pgi', 'PrgEnv-pgi-nompi'],
                         'descr': 'Kesch post-processing nodes'
                     },
 
                     'cn': {
                         'scheduler': 'nativeslurm',
                         'access': ['--partition=cn-regression'],
-                        'environs': ['PrgEnv-gnu', 'PrgEnv-cray',
-                                     'PrgEnv-pgi', 'PrgEnv-gnu-gdr',
-                                     'PrgEnv-pgi_17.10_gdr', 'PrgEnv-pgi_18.4_gdr',
-                                     'PrgEnv-cray_gdr', 'PrgEnv-cray_gdr_2.3'],
+                        'environs': ['PrgEnv-cray', 'PrgEnv-cray-nompi',
+                                     'PrgEnv-pgi', 'PrgEnv-pgi-nompi'],
                         'descr': 'Kesch compute nodes',
                         'resources': {
                             '_rfm_gpu': ['--gres=gpu:{num_gpus_per_node}']
@@ -196,48 +193,27 @@ class ReframeSettings:
 
         'environments': {
             'kesch': {
-                'PrgEnv-gnu': {
-                    'type': 'ProgEnvironment',
-                    'modules': ['PrgEnv-gnu'],
-                    'cc': 'mpicc',
-                    'cxx': 'mpicxx',
-                    'ftn': 'mpif90',
-                },
-                'PrgEnv-pgi': {
+                'PrgEnv-pgi-nompi': {
                     'type': 'ProgEnvironment',
                     'modules': ['PrgEnv-pgi/17.10'],
-                    'cc': 'mpicc',
-                    'cxx': 'mpicxx',
-                    'ftn': 'mpif90',
+                    'cc': 'pgcc',
+                    'cxx': 'pgc++',
+                    'ftn': 'pgf90',
                 },
-                'PrgEnv-pgi_17.10_gdr': {
+                'PrgEnv-pgi': {
                     'type': 'ProgEnvironment',
                     'modules': ['PrgEnv-pgi/17.10_gdr'],
                     'cc': 'mpicc',
                     'cxx': 'mpicxx',
                     'ftn': 'mpif90',
                 },
-                'PrgEnv-pgi_18.4_gdr': {
-                    'type': 'ProgEnvironment',
-                    'modules': ['PrgEnv-pgi/18.4_gdr'],
-                    'cc': 'mpicc',
-                    'cxx': 'mpicxx',
-                    'ftn': 'mpif90',
-                },
-                'PrgEnv-cray_gdr': {
+                'PrgEnv-cray': {
                     'type': 'ProgEnvironment',
                     'modules': ['PrgEnv-cray/1.0.2_gdr'],
                 },
-                'PrgEnv-cray_gdr_2.3': {
+                'PrgEnv-cray-nompi': {
                     'type': 'ProgEnvironment',
-                    'modules': ['PrgEnv-cray/1.0.2_gdr_2.3'],
-                },
-                'PrgEnv-gnu-gdr': {
-                    'type': 'ProgEnvironment',
-                    'modules': ['gmvapich2/17.02_cuda_8.0_gdr'],
-                    'cc': 'mpicc',
-                    'cxx': 'mpic++',
-                    'ftn': 'mpif90',
+                    'modules': ['PrgEnv-cray'],
                 },
             },
             'leone': {

--- a/config/cscs.py
+++ b/config/cscs.py
@@ -107,7 +107,9 @@ class ReframeSettings:
                 'partitions': {
                     'login': {
                         'scheduler': 'local',
-                        'environs': ['PrgEnv-cray-nompi', 'PrgEnv-pgi-nompi'],
+                        'environs': ['PrgEnv-cray', 'PrgEnv-cray-nompi',
+                                     'PrgEnv-pgi', 'PrgEnv-pgi-nompi',
+                                     'PrgEnv-gnu', 'PrgEnv-gnu-nompi'],
                         'descr': 'Kesch login nodes',
                     },
                     'pn': {
@@ -226,7 +228,7 @@ class ReframeSettings:
                 },
                 'PrgEnv-gnu-nompi': {
                     'type': 'ProgEnvironment',
-                    'modules': ['gmvapich2/17.02_cuda_8.0_gdr'],
+                    'modules': ['PrgEnv-gnu'],
                     'cc': 'gcc',
                     'cxx': 'g++',
                     'ftn': 'gfortran',


### PR DESCRIPTION
This is a cleanup and reorganisation of the Kesch settings:

- Three programming environments (Cray, PGI, GNU)
- Two variants (MPI and non-MPI)

It is not final, since we are expecting the CS2M settings, but nonetheless I believe this one must be merged regardless. Only environments that are supposed to be stable must be put in the settings files. All other experiments should be done using the `-M` option or individually changing the settings file.