### PR TITLE
[refactor] Better support for dynamic type checking and field validation

### DIFF
--- a/reframe/core/buildsystems.py
+++ b/reframe/core/buildsystems.py
@@ -19,7 +19,7 @@ class BuildSystem:
     #:
     #: :type: :class:`str`
     #: :default: :class:`None`
-    cc  = fields.TypedField('cc', str, None)
+    cc  = fields.TypedField('cc', str, type(None))
 
     #: The C++ compiler to be used.
     #: If set to :class:`None` and :attr:`flags_from_environ` is :class:`True`,
@@ -27,7 +27,7 @@ class BuildSystem:
     #:
     #: :type: :class:`str`
     #: :default: :class:`None`
-    cxx = fields.TypedField('cxx', str, None)
+    cxx = fields.TypedField('cxx', str, type(None))
 
     #: The Fortran compiler to be used.
     #: If set to :class:`None` and :attr:`flags_from_environ` is :class:`True`,
@@ -35,7 +35,7 @@ class BuildSystem:
     #:
     #: :type: :class:`str`
     #: :default: :class:`None`
-    ftn = fields.TypedField('ftn', str, None)
+    ftn = fields.TypedField('ftn', str, type(None))
 
     #: The CUDA compiler to be used.
     #: If set to :class:`None` and :attr:`flags_from_environ` is :class:`True`,
@@ -43,7 +43,7 @@ class BuildSystem:
     #:
     #: :type: :class:`str`
     #: :default: :class:`None`
-    nvcc = fields.TypedField('nvcc', str, None)
+    nvcc = fields.TypedField('nvcc', str, type(None))
 
     #: The C compiler flags to be used.
     #: If set to :class:`None` and :attr:`flags_from_environ` is :class:`True`,
@@ -52,7 +52,7 @@ class BuildSystem:
     #:
     #: :type: :class:`List[str]`
     #: :default: :class:`None`
-    cflags = fields.TypedField('cflags', typ.List[str], None)
+    cflags = fields.TypedField('cflags', typ.List[str], type(None))
 
     #: The preprocessor flags to be used.
     #: If set to :class:`None` and :attr:`flags_from_environ` is :class:`True`,
@@ -61,7 +61,7 @@ class BuildSystem:
     #:
     #: :type: :class:`List[str]`
     #: :default: :class:`None`
-    cppflags = fields.TypedField('cppflags', typ.List[str], None)
+    cppflags = fields.TypedField('cppflags', typ.List[str], type(None))
 
     #: The C++ compiler flags to be used.
     #: If set to :class:`None` and :attr:`flags_from_environ` is :class:`True`,
@@ -70,7 +70,7 @@ class BuildSystem:
     #:
     #: :type: :class:`List[str]`
     #: :default: :class:`None`
-    cxxflags = fields.TypedField('cxxflags', typ.List[str], None)
+    cxxflags = fields.TypedField('cxxflags', typ.List[str], type(None))
 
     #: The Fortran compiler flags to be used.
     #: If set to :class:`None` and :attr:`flags_from_environ` is :class:`True`,
@@ -79,7 +79,7 @@ class BuildSystem:
     #:
     #: :type: :class:`List[str]`
     #: :default: :class:`None`
-    fflags  = fields.TypedField('fflags', typ.List[str], None)
+    fflags  = fields.TypedField('fflags', typ.List[str], type(None))
 
     #: The linker flags to be used.
     #: If set to :class:`None` and :attr:`flags_from_environ` is :class:`True`,
@@ -88,7 +88,7 @@ class BuildSystem:
     #:
     #: :type: :class:`List[str]`
     #: :default: :class:`None`
-    ldflags = fields.TypedField('ldflags', typ.List[str], None)
+    ldflags = fields.TypedField('ldflags', typ.List[str], type(None))
 
     #: Set compiler and compiler flags from the current programming environment
     #: if not specified otherwise.
@@ -127,7 +127,7 @@ class BuildSystem:
             This method is relevant only to developers of new build systems.
         """
 
-    def _resolve_flags(self, flags, environ, allow_none=True):
+    def _resolve_flags(self, flags, environ):
         _flags = getattr(self, flags)
         if _flags is not None:
             return _flags
@@ -148,16 +148,16 @@ class BuildSystem:
             return flags
 
     def _cc(self, environ):
-        return self._resolve_flags('cc', environ, False)
+        return self._resolve_flags('cc', environ)
 
     def _cxx(self, environ):
-        return self._resolve_flags('cxx', environ, False)
+        return self._resolve_flags('cxx', environ)
 
     def _ftn(self, environ):
-        return self._resolve_flags('ftn', environ, False)
+        return self._resolve_flags('ftn', environ)
 
     def _nvcc(self, environ):
-        return self._resolve_flags('nvcc', environ, False)
+        return self._resolve_flags('nvcc', environ)
 
     def _cppflags(self, environ):
         return self._fix_flags(self._resolve_flags('cppflags', environ))
@@ -206,7 +206,7 @@ class Make(BuildSystem):
     #:
     #: :type: :class:`str`
     #: :default: :class:`None`
-    makefile = fields.TypedField('makefile', str, None)
+    makefile = fields.TypedField('makefile', str, type(None))
 
     #: The top-level directory of the code.
     #:
@@ -215,7 +215,7 @@ class Make(BuildSystem):
     #:
     #: :type: :class:`str`
     #: :default: :class:`None`
-    srcdir = fields.TypedField('srcdir', str, None)
+    srcdir = fields.TypedField('srcdir', str, type(None))
 
     #: Limit concurrency for ``make`` jobs.
     #: This attribute controls the ``-j`` option passed to ``make``.
@@ -225,7 +225,7 @@ class Make(BuildSystem):
     #:
     #: :type: integer
     #: :default: :class:`None`
-    max_concurrency = fields.TypedField('max_concurrency', int, None)
+    max_concurrency = fields.TypedField('max_concurrency', int, type(None))
 
     def __init__(self):
         super().__init__()
@@ -322,7 +322,7 @@ class SingleSource(BuildSystem):
     #: :attr:`reframe.core.pipeline.RegressionTest.sourcepath` attribute.
     #:
     #: :type: :class:`str` or :class:`None`
-    srcfile = fields.TypedField('srcfile', str, None)
+    srcfile = fields.TypedField('srcfile', str, type(None))
 
     #: The executable file to be generated.
     #:
@@ -330,7 +330,7 @@ class SingleSource(BuildSystem):
     #: :attr:`reframe.core.pipeline.RegressionTest.executable` attribute.
     #:
     #: :type: :class:`str` or :class:`None`
-    executable = fields.TypedField('executable', str, None)
+    executable = fields.TypedField('executable', str, type(None))
 
     #: The include path to be used for this compilation.
     #:
@@ -354,7 +354,7 @@ class SingleSource(BuildSystem):
     #:   - CUDA: `.cu`.
     #:
     #: :type: :class:`str` or :class:`None`
-    lang = fields.TypedField('lang', str, None)
+    lang = fields.TypedField('lang', str, type(None))
 
     def __init__(self):
         super().__init__()
@@ -454,13 +454,13 @@ class ConfigureBasedBuildSystem(BuildSystem):
     #:
     #: :type: :class:`str`
     #: :default: :class:`None`
-    srcdir = fields.TypedField('srcdir', str, None)
+    srcdir = fields.TypedField('srcdir', str, type(None))
 
     #: The CMake build directory, where all the generated files will be placed.
     #:
     #: :type: :class:`str`
     #: :default: :class:`None`
-    builddir = fields.TypedField('builddir', str, None)
+    builddir = fields.TypedField('builddir', str, type(None))
 
     #: Additional configuration options to be passed to the CMake invocation.
     #:
@@ -478,7 +478,7 @@ class ConfigureBasedBuildSystem(BuildSystem):
     #:
     #: :type: integer
     #: :default: :class:`None`
-    max_concurrency = fields.TypedField('max_concurrency', int, None)
+    max_concurrency = fields.TypedField('max_concurrency', int, type(None))
 
     def __init__(self):
         super().__init__()
@@ -652,11 +652,8 @@ class BuildSystemField(fields.TypedField):
     representing the name of the concrete class of a build system.
     """
 
-    def __init__(self, fieldname, allow_none=False):
-        if allow_none:
-            super().__init__(fieldname, BuildSystem, None)
-        else:
-            super().__init__(fieldname, BuildSystem)
+    def __init__(self, fieldname, *other_types):
+        super().__init__(fieldname, BuildSystem, *other_types)
 
     def __set__(self, obj, value):
         if isinstance(value, str):

--- a/reframe/core/buildsystems.py
+++ b/reframe/core/buildsystems.py
@@ -644,7 +644,7 @@ class Autotools(ConfigureBasedBuildSystem):
         return prepare_cmd + [' '.join(configure_cmd), ' '.join(make_cmd)]
 
 
-class BuildSystemField(fields.TypedField):
+class BuildSystemField(fields.TypedFieldAdapter):
     """A field representing a build system.
 
     You may either assign an instance of :class:`BuildSystem` or a string

--- a/reframe/core/buildsystems.py
+++ b/reframe/core/buildsystems.py
@@ -2,6 +2,7 @@ import abc
 import os
 
 import reframe.core.fields as fields
+import reframe.utility.typecheck as typ
 from reframe.core.exceptions import BuildSystemError
 
 
@@ -18,7 +19,7 @@ class BuildSystem:
     #:
     #: :type: :class:`str`
     #: :default: :class:`None`
-    cc  = fields.StringField('cc', allow_none=True)
+    cc  = fields.TypedField('cc', str, None)
 
     #: The C++ compiler to be used.
     #: If set to :class:`None` and :attr:`flags_from_environ` is :class:`True`,
@@ -26,7 +27,7 @@ class BuildSystem:
     #:
     #: :type: :class:`str`
     #: :default: :class:`None`
-    cxx = fields.StringField('cxx', allow_none=True)
+    cxx = fields.TypedField('cxx', str, None)
 
     #: The Fortran compiler to be used.
     #: If set to :class:`None` and :attr:`flags_from_environ` is :class:`True`,
@@ -34,7 +35,7 @@ class BuildSystem:
     #:
     #: :type: :class:`str`
     #: :default: :class:`None`
-    ftn = fields.StringField('ftn', allow_none=True)
+    ftn = fields.TypedField('ftn', str, None)
 
     #: The CUDA compiler to be used.
     #: If set to :class:`None` and :attr:`flags_from_environ` is :class:`True`,
@@ -42,59 +43,59 @@ class BuildSystem:
     #:
     #: :type: :class:`str`
     #: :default: :class:`None`
-    nvcc = fields.StringField('nvcc', allow_none=True)
+    nvcc = fields.TypedField('nvcc', str, None)
 
     #: The C compiler flags to be used.
     #: If set to :class:`None` and :attr:`flags_from_environ` is :class:`True`,
     #: the corresponding flags defined in the current programming environment
     #: will be used.
     #:
-    #: :type: :class:`str`
+    #: :type: :class:`List[str]`
     #: :default: :class:`None`
-    cflags = fields.TypedListField('cflags', str, allow_none=True)
+    cflags = fields.TypedField('cflags', typ.List[str], None)
 
     #: The preprocessor flags to be used.
     #: If set to :class:`None` and :attr:`flags_from_environ` is :class:`True`,
     #: the corresponding flags defined in the current programming environment
     #: will be used.
     #:
-    #: :type: :class:`str`
+    #: :type: :class:`List[str]`
     #: :default: :class:`None`
-    cppflags = fields.TypedListField('cppflags', str, allow_none=True)
+    cppflags = fields.TypedField('cppflags', typ.List[str], None)
 
     #: The C++ compiler flags to be used.
     #: If set to :class:`None` and :attr:`flags_from_environ` is :class:`True`,
     #: the corresponding flags defined in the current programming environment
     #: will be used.
     #:
-    #: :type: :class:`str`
+    #: :type: :class:`List[str]`
     #: :default: :class:`None`
-    cxxflags = fields.TypedListField('cxxflags', str, allow_none=True)
+    cxxflags = fields.TypedField('cxxflags', typ.List[str], None)
 
     #: The Fortran compiler flags to be used.
     #: If set to :class:`None` and :attr:`flags_from_environ` is :class:`True`,
     #: the corresponding flags defined in the current programming environment
     #: will be used.
     #:
-    #: :type: :class:`str`
+    #: :type: :class:`List[str]`
     #: :default: :class:`None`
-    fflags  = fields.TypedListField('fflags', str, allow_none=True)
+    fflags  = fields.TypedField('fflags', typ.List[str], None)
 
     #: The linker flags to be used.
     #: If set to :class:`None` and :attr:`flags_from_environ` is :class:`True`,
     #: the corresponding flags defined in the current programming environment
     #: will be used.
     #:
-    #: :type: :class:`str`
+    #: :type: :class:`List[str]`
     #: :default: :class:`None`
-    ldflags = fields.TypedListField('ldflags', str, allow_none=True)
+    ldflags = fields.TypedField('ldflags', typ.List[str], None)
 
     #: Set compiler and compiler flags from the current programming environment
     #: if not specified otherwise.
     #:
     #: :type: :class:`bool`
     #: :default: :class:`True`
-    flags_from_environ = fields.BooleanField('flags_from_environ')
+    flags_from_environ = fields.TypedField('flags_from_environ', bool)
 
     def __init__(self):
         self.cc  = None
@@ -196,16 +197,16 @@ class Make(BuildSystem):
     #: Append these options to the ``make`` invocation.
     #: This variable is also useful for passing variables or targets to ``make``.
     #:
-    #: :type: :class:`list[str]`
+    #: :type: :class:`List[str]`
     #: :default: ``[]``
-    options = fields.TypedListField('options', str)
+    options = fields.TypedField('options', typ.List[str])
 
     #: Instruct build system to use this Makefile.
     #: This option is useful when having non-standard Makefile names.
     #:
     #: :type: :class:`str`
     #: :default: :class:`None`
-    makefile = fields.StringField('makefile', allow_none=True)
+    makefile = fields.TypedField('makefile', str, None)
 
     #: The top-level directory of the code.
     #:
@@ -214,7 +215,7 @@ class Make(BuildSystem):
     #:
     #: :type: :class:`str`
     #: :default: :class:`None`
-    srcdir = fields.StringField('srcdir', allow_none=True)
+    srcdir = fields.TypedField('srcdir', str, None)
 
     #: Limit concurrency for ``make`` jobs.
     #: This attribute controls the ``-j`` option passed to ``make``.
@@ -224,7 +225,7 @@ class Make(BuildSystem):
     #:
     #: :type: integer
     #: :default: :class:`None`
-    max_concurrency = fields.IntegerField('max_concurrency', allow_none=True)
+    max_concurrency = fields.TypedField('max_concurrency', int, None)
 
     def __init__(self):
         super().__init__()
@@ -321,7 +322,7 @@ class SingleSource(BuildSystem):
     #: :attr:`reframe.core.pipeline.RegressionTest.sourcepath` attribute.
     #:
     #: :type: :class:`str` or :class:`None`
-    srcfile = fields.StringField('srcfile', allow_none=True)
+    srcfile = fields.TypedField('srcfile', str, None)
 
     #: The executable file to be generated.
     #:
@@ -329,7 +330,7 @@ class SingleSource(BuildSystem):
     #: :attr:`reframe.core.pipeline.RegressionTest.executable` attribute.
     #:
     #: :type: :class:`str` or :class:`None`
-    executable = fields.StringField('executable', allow_none=True)
+    executable = fields.TypedField('executable', str, None)
 
     #: The include path to be used for this compilation.
     #:
@@ -337,9 +338,9 @@ class SingleSource(BuildSystem):
     #: :attr:`BuildSystem.cppflags`, by prepending to each of them the ``-I``
     #: option.
     #:
-    #: :type: :class:`list[str]`
+    #: :type: :class:`List[str]`
     #: :default: ``[]``
-    include_path = fields.TypedListField('include_path', str)
+    include_path = fields.TypedField('include_path', typ.List[str])
 
     #: The programming language of the file that needs to be compiled.
     #: If not specified, the build system will try to figure it out
@@ -353,7 +354,7 @@ class SingleSource(BuildSystem):
     #:   - CUDA: `.cu`.
     #:
     #: :type: :class:`str` or :class:`None`
-    lang = fields.StringField('lang', allow_none=True)
+    lang = fields.TypedField('lang', str, None)
 
     def __init__(self):
         super().__init__()
@@ -453,31 +454,31 @@ class ConfigureBasedBuildSystem(BuildSystem):
     #:
     #: :type: :class:`str`
     #: :default: :class:`None`
-    srcdir = fields.StringField('srcdir', allow_none=True)
+    srcdir = fields.TypedField('srcdir', str, None)
 
     #: The CMake build directory, where all the generated files will be placed.
     #:
     #: :type: :class:`str`
     #: :default: :class:`None`
-    builddir = fields.StringField('builddir', allow_none=True)
+    builddir = fields.TypedField('builddir', str, None)
 
     #: Additional configuration options to be passed to the CMake invocation.
     #:
-    #: :type: :class:`list[str]`
+    #: :type: :class:`List[str]`
     #: :default: ``[]``
-    config_opts = fields.TypedListField('config_opts', str)
+    config_opts = fields.TypedField('config_opts', typ.List[str])
 
     #: Options to be passed to the subsequent ``make`` invocation.
     #:
-    #: :type: :class:`list[str]`
+    #: :type: :class:`List[str]`
     #: :default: ``[]``
-    make_opts = fields.TypedListField('make_opts', str)
+    make_opts = fields.TypedField('make_opts', typ.List[str])
 
     #: Same as for the :attr:`Make` build system.
     #:
     #: :type: integer
     #: :default: :class:`None`
-    max_concurrency = fields.IntegerField('max_concurrency', allow_none=True)
+    max_concurrency = fields.TypedField('max_concurrency', int, None)
 
     def __init__(self):
         super().__init__()
@@ -644,7 +645,7 @@ class Autotools(ConfigureBasedBuildSystem):
         return prepare_cmd + [' '.join(configure_cmd), ' '.join(make_cmd)]
 
 
-class BuildSystemField(fields.TypedFieldAdapter):
+class BuildSystemField(fields.TypedField):
     """A field representing a build system.
 
     You may either assign an instance of :class:`BuildSystem` or a string
@@ -652,7 +653,10 @@ class BuildSystemField(fields.TypedFieldAdapter):
     """
 
     def __init__(self, fieldname, allow_none=False):
-        super().__init__(fieldname, BuildSystem, allow_none)
+        if allow_none:
+            super().__init__(fieldname, BuildSystem, None)
+        else:
+            super().__init__(fieldname, BuildSystem)
 
     def __set__(self, obj, value):
         if isinstance(value, str):

--- a/reframe/core/config.py
+++ b/reframe/core/config.py
@@ -4,6 +4,7 @@ import collections.abc
 import reframe.core.debug as debug
 import reframe.core.fields as fields
 import reframe.utility as util
+import reframe.utility.typecheck as types
 from reframe.core.exceptions import (ConfigError,
                                      ReframeError,
                                      ReframeFatalError,
@@ -32,7 +33,7 @@ def settings():
 
 class SiteConfiguration:
     """Holds the configuration of systems and environments"""
-    _modes = fields.ScopedDictField('_modes', (list, str))
+    _modes = fields.ScopedDictField('_modes', types.List[str])
 
     def __init__(self, dict_config=None):
         self._systems = {}

--- a/reframe/core/environments.py
+++ b/reframe/core/environments.py
@@ -232,65 +232,70 @@ class ProgEnvironment(Environment):
     #: The C++ compiler of this programming environment.
     #:
     #: :type: :class:`str` or :class:`None`
-    cxx = fields.DeprecatedField(fields.TypedField('cxx', str, None),
+    cxx = fields.DeprecatedField(fields.TypedField('cxx', str, type(None)),
                                  'setting this field is deprecated; '
                                  'please set it through a build system',
                                  fields.DeprecatedField.OP_SET)
-    _cxx = fields.TypedField('cxx', str, None)
+    _cxx = fields.TypedField('cxx', str, type(None))
 
     #: The Fortran compiler of this programming environment.
     #:
     #: :type: :class:`str` or :class:`None`
-    ftn = fields.DeprecatedField(fields.TypedField('ftn', str, None),
+    ftn = fields.DeprecatedField(fields.TypedField('ftn', str, type(None)),
                                  'setting this field is deprecated; '
                                  'please set it through a build system',
                                  fields.DeprecatedField.OP_SET)
-    _ftn = fields.TypedField('ftn', str, None)
+    _ftn = fields.TypedField('ftn', str, type(None))
 
     #: The preprocessor flags of this programming environment.
     #:
     #: :type: :class:`str` or :class:`None`
-    cppflags = fields.DeprecatedField(fields.TypedField('cppflags', str, None),
-                                      'setting this field is deprecated; '
-                                      'please set it through a build system',
-                                      fields.DeprecatedField.OP_SET)
-    _cppflags = fields.TypedField('cppflags', str, None)
+    cppflags = fields.DeprecatedField(
+        fields.TypedField('cppflags', str, type(None)),
+        'setting this field is deprecated; '
+        'please set it through a build system',
+        fields.DeprecatedField.OP_SET)
+    _cppflags = fields.TypedField('cppflags', str, type(None))
 
     #: The C compiler flags of this programming environment.
     #:
     #: :type: :class:`str` or :class:`None`
-    cflags = fields.DeprecatedField(fields.TypedField('cflags', str, None),
-                                    'setting this field is deprecated; '
-                                    'please set it through a build system',
-                                    fields.DeprecatedField.OP_SET)
-    _cflags = fields.TypedField('cflags', str, None)
+    cflags = fields.DeprecatedField(
+        fields.TypedField('cflags', str, type(None)),
+        'setting this field is deprecated; '
+        'please set it through a build system',
+        fields.DeprecatedField.OP_SET)
+    _cflags = fields.TypedField('cflags', str, type(None))
 
     #: The C++ compiler flags of this programming environment.
     #:
     #: :type: :class:`str` or :class:`None`
-    cxxflags = fields.DeprecatedField(fields.TypedField('cxxflags', str, None),
-                                      'setting this field is deprecated; '
-                                      'please set it through a build system',
-                                      fields.DeprecatedField.OP_SET)
-    _cxxflags = fields.TypedField('cxxflags', str, None)
+    cxxflags = fields.DeprecatedField(
+        fields.TypedField('cxxflags', str, type(None)),
+        'setting this field is deprecated; '
+        'please set it through a build system',
+        fields.DeprecatedField.OP_SET)
+    _cxxflags = fields.TypedField('cxxflags', str, type(None))
 
     #: The Fortran compiler flags of this programming environment.
     #:
     #: :type: :class:`str` or :class:`None`
-    fflags = fields.DeprecatedField(fields.TypedField('fflags', str, None),
-                                    'setting this field is deprecated; '
-                                    'please set it through a build system',
-                                    fields.DeprecatedField.OP_SET)
-    _fflags = fields.TypedField('fflags', str, None)
+    fflags = fields.DeprecatedField(
+        fields.TypedField('fflags', str, type(None)),
+        'setting this field is deprecated; '
+        'please set it through a build system',
+        fields.DeprecatedField.OP_SET)
+    _fflags = fields.TypedField('fflags', str, type(None))
 
     #: The linker flags of this programming environment.
     #:
     #: :type: :class:`str` or :class:`None`
-    ldflags = fields.DeprecatedField(fields.TypedField('ldflags', str, None),
-                                     'setting this field is deprecated; '
-                                     'please set it through a build system',
-                                     fields.DeprecatedField.OP_SET)
-    _ldflags = fields.TypedField('ldflags', str, None)
+    ldflags = fields.DeprecatedField(
+        fields.TypedField('ldflags', str, type(None)),
+        'setting this field is deprecated; '
+        'please set it through a build system',
+        fields.DeprecatedField.OP_SET)
+    _ldflags = fields.TypedField('ldflags', str, type(None))
 
     #: The include search path of this programming environment.
     #:

--- a/reframe/core/environments.py
+++ b/reframe/core/environments.py
@@ -5,6 +5,7 @@ import os
 
 import reframe.core.fields as fields
 import reframe.utility.os_ext as os_ext
+import reframe.utility.typecheck as typ
 from reframe.core.exceptions import EnvironError, SpawnedProcessError
 from reframe.core.runtime import runtime
 
@@ -16,9 +17,9 @@ class Environment:
     to be set when this environment is loaded by the framework.
     Users may not create or modify directly environments.
     """
-    name = fields.StringPatternField('name', r'(\w|-)+')
-    modules = fields.TypedListField('modules', str)
-    variables = fields.TypedDictField('variables', str, str)
+    name = fields.TypedField('name', typ.Str[r'(\w|-)+'])
+    modules = fields.TypedField('modules', typ.List[str])
+    variables = fields.TypedField('variables', typ.Dict[str, str])
 
     def __init__(self, name, modules=[], variables={}, **kwargs):
         self._name = name
@@ -222,100 +223,96 @@ class ProgEnvironment(Environment):
     #: The C compiler of this programming environment.
     #:
     #: :type: :class:`str`
-    cc = fields.DeprecatedField(fields.StringField('cc'),
+    cc = fields.DeprecatedField(fields.TypedField('cc', str),
                                 'setting this field is deprecated; '
                                 'please set it through a build system',
                                 fields.DeprecatedField.OP_SET)
-    _cc = fields.StringField('cc')
+    _cc = fields.TypedField('cc', str)
 
     #: The C++ compiler of this programming environment.
     #:
     #: :type: :class:`str` or :class:`None`
-    cxx = fields.DeprecatedField(fields.StringField('cxx', allow_none=True),
+    cxx = fields.DeprecatedField(fields.TypedField('cxx', str, None),
                                  'setting this field is deprecated; '
                                  'please set it through a build system',
                                  fields.DeprecatedField.OP_SET)
-    _cxx = fields.StringField('cxx', allow_none=True)
+    _cxx = fields.TypedField('cxx', str, None)
 
     #: The Fortran compiler of this programming environment.
     #:
     #: :type: :class:`str` or :class:`None`
-    ftn = fields.DeprecatedField(fields.StringField('ftn', allow_none=True),
+    ftn = fields.DeprecatedField(fields.TypedField('ftn', str, None),
                                  'setting this field is deprecated; '
                                  'please set it through a build system',
                                  fields.DeprecatedField.OP_SET)
-    _ftn = fields.StringField('ftn', allow_none=True)
+    _ftn = fields.TypedField('ftn', str, None)
 
     #: The preprocessor flags of this programming environment.
     #:
     #: :type: :class:`str` or :class:`None`
-    cppflags = fields.DeprecatedField(
-        fields.StringField('cppflags', allow_none=True),
-        'setting this field is deprecated; '
-        'please set it through a build system',
-        fields.DeprecatedField.OP_SET)
-    _cppflags = fields.StringField('cppflags', allow_none=True)
+    cppflags = fields.DeprecatedField(fields.TypedField('cppflags', str, None),
+                                      'setting this field is deprecated; '
+                                      'please set it through a build system',
+                                      fields.DeprecatedField.OP_SET)
+    _cppflags = fields.TypedField('cppflags', str, None)
 
     #: The C compiler flags of this programming environment.
     #:
     #: :type: :class:`str` or :class:`None`
-    cflags = fields.DeprecatedField(
-        fields.StringField('cflags', allow_none=True),
-        'setting this field is deprecated; '
-        'please set it through a build system',
-        fields.DeprecatedField.OP_SET)
-    _cflags = fields.StringField('cflags', allow_none=True)
+    cflags = fields.DeprecatedField(fields.TypedField('cflags', str, None),
+                                    'setting this field is deprecated; '
+                                    'please set it through a build system',
+                                    fields.DeprecatedField.OP_SET)
+    _cflags = fields.TypedField('cflags', str, None)
 
     #: The C++ compiler flags of this programming environment.
     #:
     #: :type: :class:`str` or :class:`None`
-    cxxflags = fields.DeprecatedField(
-        fields.StringField('cxxflags', allow_none=True),
-        'setting this field is deprecated; '
-        'please set it through a build system',
-        fields.DeprecatedField.OP_SET)
-    _cxxflags = fields.StringField('cxxflags', allow_none=True)
+    cxxflags = fields.DeprecatedField(fields.TypedField('cxxflags', str, None),
+                                      'setting this field is deprecated; '
+                                      'please set it through a build system',
+                                      fields.DeprecatedField.OP_SET)
+    _cxxflags = fields.TypedField('cxxflags', str, None)
 
     #: The Fortran compiler flags of this programming environment.
     #:
     #: :type: :class:`str` or :class:`None`
-    fflags = fields.DeprecatedField(
-        fields.StringField('fflags', allow_none=True),
-        'setting this field is deprecated; '
-        'please set it through a build system',
-        fields.DeprecatedField.OP_SET)
-    _fflags = fields.StringField('fflags', allow_none=True)
+    fflags = fields.DeprecatedField(fields.TypedField('fflags', str, None),
+                                    'setting this field is deprecated; '
+                                    'please set it through a build system',
+                                    fields.DeprecatedField.OP_SET)
+    _fflags = fields.TypedField('fflags', str, None)
 
     #: The linker flags of this programming environment.
     #:
     #: :type: :class:`str` or :class:`None`
-    ldflags = fields.DeprecatedField(
-        fields.StringField('ldflags', allow_none=True),
-        'setting this field is deprecated; '
-        'please set it through a build system',
-        fields.DeprecatedField.OP_SET)
-    _ldflags = fields.StringField('ldflags', allow_none=True)
+    ldflags = fields.DeprecatedField(fields.TypedField('ldflags', str, None),
+                                     'setting this field is deprecated; '
+                                     'please set it through a build system',
+                                     fields.DeprecatedField.OP_SET)
+    _ldflags = fields.TypedField('ldflags', str, None)
 
     #: The include search path of this programming environment.
     #:
     #: :type: :class:`list` of :class:`str`
     #: :default: ``[]``
     include_search_path = fields.DeprecatedField(
-        fields.TypedListField('include_search_path', str),
+        fields.TypedField('include_search_path', typ.List[str]),
         'setting this field is deprecated; '
         'please set it through a build system',
         fields.DeprecatedField.OP_SET)
-    _include_search_path = fields.TypedListField('include_search_path', str)
+    _include_search_path = fields.TypedField('include_search_path',
+                                             typ.List[str])
 
     #: Propagate the compilation flags to the ``make`` invocation.
     #:
     #: :type: :class:`bool`
     #: :default: :class:`True`
-    propagate = fields.DeprecatedField(fields.BooleanField('propagate'),
+    propagate = fields.DeprecatedField(fields.TypedField('propagate', bool),
                                        'setting this field is deprecated; '
                                        'please set it through a build system',
                                        fields.DeprecatedField.OP_SET)
-    _propagate = fields.BooleanField('propagate')
+    _propagate = fields.TypedField('propagate', bool)
 
     def __init__(self,
                  name,

--- a/reframe/core/fields.py
+++ b/reframe/core/fields.py
@@ -2,12 +2,11 @@
 # Useful descriptors for advanced operations on fields
 #
 
-import collections
 import copy
-import numbers
+import itertools
 import os
-import re
 
+import reframe.utility.typecheck as types
 from reframe.core.exceptions import user_deprecation_warning
 from reframe.utility import ScopedDict
 
@@ -51,268 +50,83 @@ class ForwardField:
         self._target.__dict__[self._attr] = value
 
 
-class AnyField(Field):
-    """Store a value that may be validated by distinct fields."""
-
-    def __init__(self, fieldname, fields, allow_none=False):
-        super().__init__(fieldname)
-        self._fields = [fieldtype(self._name, *args, allow_none=allow_none)
-                        for fieldtype, *args in fields]
-
-    def __set__(self, obj, value):
-        # Try the field descriptors in turn until one validates the input
-        for f in self._fields:
-            try:
-                f.__set__(obj, value)
-                break
-            except (TypeError, ValueError):
-                pass
-        else:
-            # All field set attemps have failed
-            # FIXME: This is not a very informative message.
-            raise TypeError('attempt to set a field of different type.')
-
-
 class TypedField(Field):
     """Stores a field of predefined type"""
 
-    def __init__(self, fieldname, fieldtype, allow_none=False):
+    def __init__(self, fieldname, main_type, *other_types):
         super().__init__(fieldname)
-        self._fieldtype = fieldtype
-        self._allow_none = allow_none
+        self._types = tuple(map(lambda t: type(t) if t is None else t,
+                                itertools.chain((main_type,), other_types)))
 
     def _check_type(self, value):
-        return ((self._allow_none and value is None) or
-                isinstance(value, self._fieldtype))
+        if not any(isinstance(value, t) for t in self._types):
+            typedescr = '|'.join(t.__name__ for t in self._types)
+            raise TypeError(
+                "failed to set field '%s': type mismatch: "
+                "required type is '%s'" % (self._name, typedescr))
 
     def __set__(self, obj, value):
-        if not self._check_type(value):
-            raise TypeError('attempt to set a field of different type. '
-                            'Required: %s, Found: %s' %
-                            (self._fieldtype.__name__, type(value).__name__))
-
+        self._check_type(value)
         super().__set__(obj, value)
 
 
-class AggregateTypeField(Field):
-    """Store a typed container with elements of certain type(s)
+class TypedFieldAdapter(TypedField):
+    """Adapter class for enabling the old interface."""
 
-    The typespec has the following syntax:
-    typespec := type |
-                (typespec, None) |
-                (aggr_type, typespec) |
-                (seq_type, ((typespec, typespec, ...),)) |
-                (map_type, (typespec, typespec))
-    aggr_type := list | tuple | set | frozenset | dict
-    seq_type  := list | tuple
-    map_type  := dict
-    type      := <any-python-type> | callable"""
-
-    def __init__(self, fieldname, typespec, allow_none=False):
-        super().__init__(fieldname)
-        self._typespec = typespec
-        self._allow_none = allow_none
-
-    def __set__(self, obj, value):
-        if not self._check_type_ext(value):
-            raise TypeError('attempt to set an aggregate field '
-                            'of different type. Required typespec: %s' %
-                            self._format_typespec(self._typespec))
-
-        super().__set__(obj, value)
-
-    def _check_type_ext(self, value):
-        # Checks also value against None if that's allowed
-        if value is None and self._allow_none:
-            return True
-
-        return self._check_type(value, self._typespec)
-
-    def _extract_typeinfo(self, typespec):
-        """Check if a typespec is of the form (type, None)
-
-        If yes, returns (type, True) else (typespec, False)
-        """
-        if not isinstance(typespec, tuple):
-            return (typespec, False)
-
-        if len(typespec) != 2:
-            raise ValueError('invalid typespec: %s' % str(typespec))
-
-        if typespec[1] is not None:
-            return (typespec, False)
+    def __init__(self, fieldname, fieldtype, allow_none=False):
+        if allow_none:
+            super().__init__(fieldname, fieldtype, None)
         else:
-            return (typespec[0], True)
-
-    def _format_typespec(self, typespec):
-        # Extract the type information and check if None is allowed
-        typespec, allow_none = self._extract_typeinfo(typespec)
-        if not isinstance(typespec, tuple):
-            return typespec.__name__
-
-        if len(typespec) != 2:
-            raise ValueError('invalid typespec: %s' % str(typespec))
-
-        container_type, element_type = typespec
-        if issubclass(container_type, collections.abc.Sequence):
-            if isinstance(element_type, tuple) and len(element_type) == 1:
-                # non-uniformly typed container
-                elem_types = element_type[0]
-                ret = '%s[' % container_type.__name__
-                ret += ','.join(self._format_typespec(t) for t in elem_types)
-                return ret + ']'
-            else:
-                # uniformly typed container
-                return '%s[%s]' % (
-                    container_type.__name__,
-                    self._format_typespec(element_type))
-        elif issubclass(container_type, collections.abc.Set):
-            return '%s[%s]' % (container_type.__name__,
-                               self._format_typespec(element_type))
-
-        elif issubclass(container_type, collections.abc.Mapping):
-            if len(element_type) != 2:
-                raise ValueError('invalid mapping typespec: %s' %
-                                 str(element_type))
-
-            key_type, value_type = element_type
-            return '%s[%s,%s]' % (
-                container_type.__name__,
-                self._format_typespec(key_type),
-                self._format_typespec(value_type))
-        else:
-            return ''
-
-        return ''
-
-    def _check_type(self, value, typespec):
-        # Extract the type information and check if None is allowed
-        typespec, allow_none = self._extract_typeinfo(typespec)
-        if value is None and allow_none:
-            return True
-
-        if not isinstance(typespec, tuple):
-            # we need to make a special check if typespec == callable
-            return (callable(value)
-                    if typespec == callable else isinstance(value, typespec))
-
-        if len(typespec) != 2:
-            raise ValueError('invalid typespec: %s' % str(typespec))
-
-        container_type, element_type = typespec
-        if not isinstance(value, container_type):
-            return False
-
-        if issubclass(container_type, collections.abc.Sequence):
-            if isinstance(element_type, tuple) and len(element_type) == 1:
-                # non-uniformly typed container
-                elem_types = element_type[0]
-                if len(value) != len(elem_types):
-                    return False
-
-                for v, t in zip(value, elem_types):
-                    if not self._check_type(v, t):
-                        return False
-            else:
-                # uniformly typed container
-                for v in value:
-                    if not self._check_type(v, element_type):
-                        return False
-
-        elif issubclass(container_type, collections.abc.Set):
-            for v in value:
-                if not self._check_type(v, element_type):
-                    return False
-
-        elif issubclass(container_type, collections.abc.Mapping):
-            if len(element_type) != 2:
-                raise ValueError('invalid mapping typespec: %s' %
-                                 str(element_type))
-
-            key_type, value_type = element_type
-            for k, v in value.items():
-                if not self._check_type(k, key_type):
-                    return False
-                if not self._check_type(v, value_type):
-                    return False
-        else:
-            return False
-
-        return True
+            super().__init__(fieldname, fieldtype)
 
 
-class StringField(TypedField):
-    """Stores a standard string object"""
+class StringField(TypedFieldAdapter):
+    """Stores a standard string object."""
 
     def __init__(self, fieldname, allow_none=False):
         super().__init__(fieldname, str, allow_none)
 
 
-class StringPatternField(StringField):
-    """Stores a string that must follow a specific pattern"""
+class StringPatternField(TypedFieldAdapter):
+    """Stores a string that must follow a specific pattern."""
 
     def __init__(self, fieldname, pattern, allow_none=False):
-        super().__init__(fieldname, allow_none)
-        self._pattern = pattern
-
-    def __set__(self, obj, value):
-        if not self._check_type(value):
-            raise TypeError('a string type is required')
-
-        if (value is not None and
-            not re.fullmatch(self._pattern, value, re.ASCII)):
-            raise ValueError(
-                'cannot validate string "%s" against pattern: "%s"' %
-                (value, self._pattern))
-
-        super().__set__(obj, value)
+        super().__init__(fieldname, types.Str[pattern], allow_none)
 
 
-class IntegerField(TypedField):
-    """Stores an integer object"""
+class IntegerField(TypedFieldAdapter):
+    """Stores an integer object."""
 
     def __init__(self, fieldname, allow_none=False):
-        super().__init__(fieldname, numbers.Integral, allow_none)
+        super().__init__(fieldname, int, allow_none)
 
 
-class BooleanField(TypedField):
-    """Stores a boolean object"""
+class BooleanField(TypedFieldAdapter):
+    """Stores a boolean object."""
 
     def __init__(self, fieldname, allow_none=False):
         super().__init__(fieldname, bool, allow_none)
 
 
-class TypedListField(AggregateTypeField):
-    """Stores a list of objects of the same type"""
+class TypedListField(TypedFieldAdapter):
+    """Stores a list of objects of the same type."""
 
     def __init__(self, fieldname, elemtype, allow_none=False):
-        super().__init__(
-            fieldname, (list, elemtype), allow_none)
+        super().__init__(fieldname, types.List[elemtype], allow_none)
 
 
-class TypedSequenceField(AggregateTypeField):
-    """Stores a list of objects of the same type"""
-
-    def __init__(self, fieldname, elemtype, allow_none=False):
-        super().__init__(
-            fieldname, (collections.abc.Sequence, elemtype), allow_none)
-
-
-class TypedSetField(AggregateTypeField):
-    """Stores a list of objects of the same type"""
+class TypedSetField(TypedFieldAdapter):
+    """Stores a list of objects of the same type."""
 
     def __init__(self, fieldname, elemtype, allow_none=False):
-        super().__init__(
-            fieldname, (collections.abc.Set, elemtype), allow_none)
+        super().__init__(fieldname, types.Set[elemtype], allow_none)
 
 
-class TypedDictField(AggregateTypeField):
-    """Stores a list of objects of the same type"""
+class TypedDictField(TypedFieldAdapter):
+    """Stores a dictionary with keys and values of specific types."""
 
     def __init__(self, fieldname, keytype, valuetype, allow_none=False):
-        super().__init__(fieldname,
-                         (collections.abc.Mapping, (keytype, valuetype)),
-                         allow_none)
+        super().__init__(fieldname, types.Dict[keytype, valuetype], allow_none)
 
 
 class CopyOnWriteField(Field):
@@ -343,17 +157,14 @@ class ConstantField(Field):
         raise ValueError('attempt to set a read-only variable')
 
 
-class TimerField(AggregateTypeField):
+class TimerField(TypedFieldAdapter):
     """Stores a timer in the form of a tuple '(hh, mm, ss)'"""
 
     def __init__(self, fieldname, allow_none=False):
-        super().__init__(fieldname, (tuple, ((int, int, int),)), allow_none)
+        super().__init__(fieldname, types.Tuple[int, int, int], allow_none)
 
     def __set__(self, obj, value):
-        if not self._check_type_ext(value):
-            raise TypeError('attempt to set a timer field '
-                            'with a wrong type')
-
+        self._check_type(value)
         if value is not None:
             # Check also the values for minutes and seconds
             h, m, s = value
@@ -376,10 +187,7 @@ class AbsolutePathField(StringField):
     """
 
     def __set__(self, obj, value):
-        if not self._check_type(value):
-            raise TypeError('attempt to set a path field with a '
-                            'non string value: %s' % value)
-
+        self._check_type(value)
         if value is not None:
             value = os.path.abspath(value)
 
@@ -387,32 +195,27 @@ class AbsolutePathField(StringField):
         Field.__set__(self, obj, value)
 
 
-class ScopedDictField(AggregateTypeField):
-    """Stores a ScopedDict with a specific type
+class ScopedDictField(TypedField):
+    """Stores a ScopedDict with a specific type.
 
     It also handles implicit conversions from ordinary dicts."""
 
     def __init__(self, fieldname, valuetype, allow_none=False):
-        super().__init__(
-            fieldname, (dict, (str, (dict, (str, valuetype)))), allow_none
-        )
-        self._valuetype = valuetype
+        if allow_none:
+            super().__init__(fieldname,
+                             types.Dict[str, types.Dict[str, valuetype]],
+                             ScopedDict, None)
+        else:
+            super().__init__(fieldname,
+                             types.Dict[str, types.Dict[str, valuetype]],
+                             ScopedDict)
 
     def __set__(self, obj, value):
-        if isinstance(value, ScopedDict):
-            # value is already a ScopedDict
-            Field.__set__(self, obj, value)
-        else:
-            # Try to convert value to a ScopedDict
-            if not self._check_type_ext(value):
-                raise TypeError(
-                    'attempt to set a ScopedDict with values '
-                    'of different type. Required typespec: %s' %
-                    self._format_typespec(self._valuetype))
+        self._check_type(value)
+        if not isinstance(value, ScopedDict):
+            value = ScopedDict(value) if value is not None else value
 
-            # Call Field's __set__() method, validation is already performed
-            Field.__set__(self, obj,
-                          ScopedDict(value) if value is not None else value)
+        Field.__set__(self, obj, value)
 
 
 class DeprecatedField(Field):

--- a/reframe/core/fields.py
+++ b/reframe/core/fields.py
@@ -70,65 +70,6 @@ class TypedField(Field):
         super().__set__(obj, value)
 
 
-class TypedFieldAdapter(TypedField):
-    """Adapter class for enabling the old interface."""
-
-    def __init__(self, fieldname, fieldtype, allow_none=False):
-        if allow_none:
-            super().__init__(fieldname, fieldtype, None)
-        else:
-            super().__init__(fieldname, fieldtype)
-
-
-class StringField(TypedFieldAdapter):
-    """Stores a standard string object."""
-
-    def __init__(self, fieldname, allow_none=False):
-        super().__init__(fieldname, str, allow_none)
-
-
-class StringPatternField(TypedFieldAdapter):
-    """Stores a string that must follow a specific pattern."""
-
-    def __init__(self, fieldname, pattern, allow_none=False):
-        super().__init__(fieldname, types.Str[pattern], allow_none)
-
-
-class IntegerField(TypedFieldAdapter):
-    """Stores an integer object."""
-
-    def __init__(self, fieldname, allow_none=False):
-        super().__init__(fieldname, int, allow_none)
-
-
-class BooleanField(TypedFieldAdapter):
-    """Stores a boolean object."""
-
-    def __init__(self, fieldname, allow_none=False):
-        super().__init__(fieldname, bool, allow_none)
-
-
-class TypedListField(TypedFieldAdapter):
-    """Stores a list of objects of the same type."""
-
-    def __init__(self, fieldname, elemtype, allow_none=False):
-        super().__init__(fieldname, types.List[elemtype], allow_none)
-
-
-class TypedSetField(TypedFieldAdapter):
-    """Stores a list of objects of the same type."""
-
-    def __init__(self, fieldname, elemtype, allow_none=False):
-        super().__init__(fieldname, types.Set[elemtype], allow_none)
-
-
-class TypedDictField(TypedFieldAdapter):
-    """Stores a dictionary with keys and values of specific types."""
-
-    def __init__(self, fieldname, keytype, valuetype, allow_none=False):
-        super().__init__(fieldname, types.Dict[keytype, valuetype], allow_none)
-
-
 class CopyOnWriteField(Field):
     """Holds a copy of the variable that is assigned to it the first time"""
 
@@ -157,11 +98,14 @@ class ConstantField(Field):
         raise ValueError('attempt to set a read-only variable')
 
 
-class TimerField(TypedFieldAdapter):
+class TimerField(TypedField):
     """Stores a timer in the form of a tuple '(hh, mm, ss)'"""
 
     def __init__(self, fieldname, allow_none=False):
-        super().__init__(fieldname, types.Tuple[int, int, int], allow_none)
+        if allow_none:
+            super().__init__(fieldname, types.Tuple[int, int, int], None)
+        else:
+            super().__init__(fieldname, types.Tuple[int, int, int])
 
     def __set__(self, obj, value):
         self._check_type(value)
@@ -180,11 +124,17 @@ class TimerField(TypedFieldAdapter):
         Field.__set__(self, obj, value)
 
 
-class AbsolutePathField(StringField):
+class AbsolutePathField(TypedField):
     """A string field that stores an absolute path.
 
     Any string assigned to such a field, will be converted to an absolute path.
     """
+
+    def __init__(self, fieldname, allow_none=False):
+        if allow_none:
+            super().__init__(fieldname, str, None)
+        else:
+            super().__init__(fieldname, str)
 
     def __set__(self, obj, value):
         self._check_type(value)

--- a/reframe/core/launchers/__init__.py
+++ b/reframe/core/launchers/__init__.py
@@ -1,6 +1,7 @@
 import abc
 
-from reframe.core.fields import TypedListField
+import reframe.core.fields as fields
+import reframe.utility.typecheck as typ
 
 
 class JobLauncher(abc.ABC):
@@ -23,7 +24,7 @@ class JobLauncher(abc.ABC):
     #:
     #: :type: :class:`list` of :class:`str`
     #: :default: ``[]``
-    options = TypedListField('options', str)
+    options = fields.TypedField('options', typ.List[str])
 
     def __init__(self, options=[]):
         self.options = list(options)

--- a/reframe/core/modules.py
+++ b/reframe/core/modules.py
@@ -9,6 +9,7 @@ from collections import OrderedDict
 
 import reframe.core.fields as fields
 import reframe.utility.os_ext as os_ext
+import reframe.utility.typecheck as types
 from reframe.core.exceptions import (ConfigError, EnvironError,
                                      SpawnedProcessError)
 
@@ -77,8 +78,8 @@ class ModulesSystem:
     modules systems implementation.
     """
 
-    module_map = fields.AggregateTypeField('module_map',
-                                           (dict, (str, (list, str))))
+    module_map = fields.TypedField('module_map',
+                                   types.Dict[str, types.List[str]])
 
     @classmethod
     def create(cls, modules_kind=None):

--- a/reframe/core/pipeline.py
+++ b/reframe/core/pipeline.py
@@ -419,7 +419,7 @@ class RegressionTest:
     #:
     #:    This attribute may be set to :class:`None`.
     #:
-    time_limit = fields.TimerField('time_limit', allow_none=True)
+    time_limit = fields.TimerField('time_limit', type(None))
 
     #: Extra resources for this test.
     #:

--- a/reframe/core/pipeline.py
+++ b/reframe/core/pipeline.py
@@ -19,7 +19,7 @@ import reframe.core.runtime as rt
 import reframe.core.shell as shell
 import reframe.utility as util
 import reframe.utility.os_ext as os_ext
-import reframe.utility.typecheck as types
+import reframe.utility.typecheck as typ
 from reframe.core.buildsystems import BuildSystem, BuildSystemField
 from reframe.core.deferrable import deferrable, _DeferredExpression, evaluate
 from reframe.core.environments import Environment, EnvironmentSnapshot
@@ -63,30 +63,31 @@ class RegressionTest:
     #: The name of the test.
     #:
     #: :type: string that can contain any character except ``/``
-    name = fields.StringPatternField('name', '[^\/]+')
+    name = fields.TypedField('name', typ.Str[r'[^\/]+'])
 
     #: List of programming environments supported by this test.
     #:
-    #: :type: :class:`list[str]`
+    #: :type: :class:`List[str]`
     #: :default: ``[]``
     #:
     #: .. note::
     #:     .. versionchanged:: 2.12
     #:        Programming environments can now be specified using wildcards.
-    valid_prog_environs = fields.TypedListField('valid_prog_environs', str)
+    valid_prog_environs = fields.TypedField('valid_prog_environs',
+                                            typ.List[str])
 
     #: List of systems supported by this test.
     #: The general syntax for systems is ``<sysname>[:<partname]``.
     #:
-    #: :type: :class:`list[str]`
+    #: :type: :class:`List[str]`
     #: :default: ``[]``
-    valid_systems = fields.TypedListField('valid_systems', str)
+    valid_systems = fields.TypedField('valid_systems', typ.List[str])
 
     #: A detailed description of the test.
     #:
     #: :type: :class:`str`
     #: :default: ``self.name``
-    descr = fields.StringField('descr')
+    descr = fields.TypedField('descr', str)
 
     #: The path to the source file or source directory of the test.
     #:
@@ -104,7 +105,7 @@ class RegressionTest:
     #:
     #: :type: :class:`str`
     #: :default: ``''``
-    sourcepath = fields.StringField('sourcepath')
+    sourcepath = fields.TypedField('sourcepath', str)
 
     #: The directory containing the test's resources.
     #:
@@ -128,7 +129,7 @@ class RegressionTest:
     #:
     #:     .. versionchanged:: 2.10
     #:        Support for Git repositories was added.
-    sourcesdir = fields.StringField('sourcesdir', allow_none=True)
+    sourcesdir = fields.TypedField('sourcesdir', str, None)
 
     #: The build system to be used for this test.
     #: If not specified, the framework will try to figure it out automatically
@@ -151,30 +152,30 @@ class RegressionTest:
     #: These commands are executed during the compilation phase and from
     #: inside the stage directory. **Each entry in the list spawns a new shell.**
     #:
-    #: :type: :class:`list[str]`
+    #: :type: :class:`List[str]`
     #: :default: ``[]``
-    prebuild_cmd = fields.TypedListField('prebuild_cmd', str)
+    prebuild_cmd = fields.TypedField('prebuild_cmd', typ.List[str])
 
     #: List of shell commands to be executed after a successful compilation.
     #:
     #: These commands are executed during the compilation phase and from inside
     #: the stage directory. **Each entry in the list spawns a new shell.**
     #:
-    #: :type: :class:`list[str]`
+    #: :type: :class:`List[str]`
     #: :default: ``[]``
-    postbuild_cmd = fields.TypedListField('postbuild_cmd', str)
+    postbuild_cmd = fields.TypedField('postbuild_cmd', typ.List[str])
 
     #: The name of the executable to be launched during the run phase.
     #:
     #: :type: :class:`str`
     #: :default: ``os.path.join('.', self.name)``
-    executable = fields.StringField('executable')
+    executable = fields.TypedField('executable', str)
 
     #: List of options to be passed to the :attr:`executable`.
     #:
-    #: :type: :class:`list[str]`
+    #: :type: :class:`List[str]`
     #: :default: ``[]``
-    executable_opts = fields.TypedListField('executable_opts', str)
+    executable_opts = fields.TypedField('executable_opts', typ.List[str])
 
     #: List of shell commands to execute before launching this job.
     #:
@@ -182,23 +183,23 @@ class RegressionTest:
     #: Instead, they are emitted in the generated job script just before the
     #: actual job launch command.
     #:
-    #: :type: :class:`list` of :class:`str`
+    #: :type: :class:`List[str]`
     #: :default: ``[]``
     #:
     #: .. note::
     #:    .. versionadded:: 2.10
-    pre_run = fields.TypedListField('pre_run', str)
+    pre_run = fields.TypedField('pre_run', typ.List[str])
 
     #: List of shell commands to execute after launching this job.
     #:
     #: See :attr:`pre_run` for a more detailed description of the semantics.
     #:
-    #: :type: :class:`list` of :class:`str`
+    #: :type: :class:`List[str]`
     #: :default: ``[]``
     #:
     #: .. note::
     #:    .. versionadded:: 2.10
-    post_run = fields.TypedListField('post_run', str)
+    post_run = fields.TypedField('post_run', typ.List[str])
 
     #: List of files to be kept after the test finishes.
     #:
@@ -212,9 +213,9 @@ class RegressionTest:
     #:
     #: Relative path names are resolved against the stage directory.
     #:
-    #: :type: :class:`list[str]`
+    #: :type: :class:`List[str]`
     #: :default: ``[]``
-    keep_files = fields.TypedListField('keep_files', str)
+    keep_files = fields.TypedField('keep_files', typ.List[str])
 
     #: List of files or directories (relative to the :attr:`sourcesdir`) that
     #: will be symlinked in the stage directory and not copied.
@@ -222,25 +223,25 @@ class RegressionTest:
     #: You can use this variable to avoid copying very large files to the stage
     #: directory.
     #:
-    #: :type: :class:`list[str]`
+    #: :type: :class:`List[str]`
     #: :default: ``[]``
-    readonly_files = fields.TypedListField('readonly_files', str)
+    readonly_files = fields.TypedField('readonly_files', typ.List[str])
 
     #: Set of tags associated with this test.
     #:
     #: This test can be selected from the frontend using any of these tags.
     #:
-    #: :type: :class:`set[str]`
+    #: :type: :class:`Set[str]`
     #: :default: an empty set
-    tags = fields.TypedSetField('tags', str)
+    tags = fields.TypedField('tags', typ.Set[str])
 
     #: List of people responsible for this test.
     #:
     #: When the test fails, this contact list will be printed out.
     #:
-    #: :type: :class:`list[str]`
+    #: :type: :class:`List[str]`
     #: :default: ``[]``
-    maintainers = fields.TypedListField('maintainers', str)
+    maintainers = fields.TypedField('maintainers', typ.List[str])
 
     #: Mark this test as a strict performance test.
     #:
@@ -250,7 +251,7 @@ class RegressionTest:
     #:
     #: :type: boolean
     #: :default: :class:`True`
-    strict_check = fields.BooleanField('strict_check')
+    strict_check = fields.TypedField('strict_check', bool)
 
     #: Number of tasks required by this test.
     #:
@@ -270,7 +271,7 @@ class RegressionTest:
     #:     .. versionchanged:: 2.9
     #:        Added support for running the test using all the nodes of the
     #:        specified reservation if the number of tasks is set to ``0``.
-    num_tasks = fields.IntegerField('num_tasks')
+    num_tasks = fields.TypedField('num_tasks', int)
 
     #: Number of tasks per node required by this test.
     #:
@@ -278,14 +279,13 @@ class RegressionTest:
     #:
     #: :type: integral or :class:`None`
     #: :default: :class:`None`
-    num_tasks_per_node = fields.IntegerField('num_tasks_per_node',
-                                             allow_none=True)
+    num_tasks_per_node = fields.TypedField('num_tasks_per_node', int, None)
 
     #: Number of GPUs per node required by this test.
     #:
     #: :type: integral
     #: :default: ``0``
-    num_gpus_per_node = fields.IntegerField('num_gpus_per_node')
+    num_gpus_per_node = fields.TypedField('num_gpus_per_node', int)
 
     #: Number of CPUs per task required by this test.
     #:
@@ -293,8 +293,7 @@ class RegressionTest:
     #:
     #: :type: integral or :class:`None`
     #: :default: :class:`None`
-    num_cpus_per_task = fields.IntegerField('num_cpus_per_task',
-                                            allow_none=True)
+    num_cpus_per_task = fields.TypedField('num_cpus_per_task', int, None)
 
     #: Number of tasks per core required by this test.
     #:
@@ -302,8 +301,7 @@ class RegressionTest:
     #:
     #: :type: integral or :class:`None`
     #: :default: :class:`None`
-    num_tasks_per_core  = fields.IntegerField('num_tasks_per_core',
-                                              allow_none=True)
+    num_tasks_per_core  = fields.TypedField('num_tasks_per_core', int, None)
 
     #: Number of tasks per socket required by this test.
     #:
@@ -311,8 +309,7 @@ class RegressionTest:
     #:
     #: :type: integral or :class:`None`
     #: :default: :class:`None`
-    num_tasks_per_socket = fields.IntegerField('num_tasks_per_socket',
-                                               allow_none=True)
+    num_tasks_per_socket = fields.TypedField('num_tasks_per_socket', int, None)
 
     #: Specify whether this tests needs simultaneous multithreading enabled.
     #:
@@ -320,20 +317,19 @@ class RegressionTest:
     #:
     #: :type: boolean or :class:`None`
     #: :default: :class:`None`
-    use_multithreading = fields.BooleanField('use_multithreading',
-                                             allow_none=True)
+    use_multithreading = fields.TypedField('use_multithreading', bool, None)
 
     #: Specify whether this test needs exclusive access to nodes.
     #:
     #: :type: boolean
     #: :default: :class:`False`
-    exclusive_access = fields.BooleanField('exclusive_access')
+    exclusive_access = fields.TypedField('exclusive_access', bool)
 
     #: Always execute this test locally.
     #:
     #: :type: boolean
     #: :default: :class:`False`
-    local = fields.BooleanField('local')
+    local = fields.TypedField('local', bool)
 
     #: The set of reference values for this test.
     #:
@@ -342,7 +338,7 @@ class RegressionTest:
     #:
     #: :type: A scoped dictionary with system names as scopes or :class:`None`
     #: :default: ``{}``
-    reference = fields.ScopedDictField('reference', types.Tuple[object])
+    reference = fields.ScopedDictField('reference', typ.Tuple[object])
     # FIXME: There is not way currently to express tuples of `float`s or
     # `None`s, so we just use the very generic `object`
 
@@ -384,24 +380,24 @@ class RegressionTest:
     #:     </sanity_functions_reference>`) as values.
     #:     :class:`None` is also allowed.
     #: :default: :class:`None`
-    perf_patterns = fields.TypedDictField(
-        'perf_patterns', str, _DeferredExpression, allow_none=True)
+    perf_patterns = fields.TypedField('perf_patterns',
+                                      typ.Dict[str, _DeferredExpression], None)
 
     #: List of modules to be loaded before running this test.
     #:
     #: These modules will be loaded during the :func:`setup` phase.
     #:
-    #: :type: :class:`list[str]`
+    #: :type: :class:`List[str]`
     #: :default: ``[]``
-    modules = fields.TypedListField('modules', str)
+    modules = fields.TypedField('modules', typ.List[str])
 
     #: Environment variables to be set before running this test.
     #:
     #: These variables will be set during the :func:`setup` phase.
     #:
-    #: :type: :class:`dict[str, str]`
+    #: :type: :class:`Dict[str, str]`
     #: :default: ``{}``
-    variables = fields.TypedDictField('variables', str, str)
+    variables = fields.TypedField('variables', typ.Dict[str, str])
 
     #: Time limit for this test.
     #:
@@ -477,7 +473,7 @@ class RegressionTest:
     #:
     #:     self.extra_resources = {'_rfm_gpu': {'num_gpus_per_node': 2}}
     #:
-    #: :type: :class:`dict[str, dict[str, object]]`
+    #: :type: :class:`Dict[str, Dict[str, object]]`
     #: :default: ``{}``
     #:
     #: .. note::
@@ -487,14 +483,14 @@ class RegressionTest:
     #:    A new more powerful syntax was introduced
     #:    that allows also custom job script directive prefixes.
     #:
-    extra_resources = fields.TypedField(
-        'extra_resources', types.Dict[str, types.Dict[str, object]])
+    extra_resources = fields.TypedField('extra_resources',
+                                        typ.Dict[str, typ.Dict[str, object]])
 
     # Private properties
-    _prefix = fields.StringField('_prefix')
-    _stagedir = fields.StringField('_stagedir', allow_none=True)
-    _stdout = fields.StringField('_stdout', allow_none=True)
-    _stderr = fields.StringField('_stderr', allow_none=True)
+    _prefix = fields.TypedField('_prefix', str)
+    _stagedir = fields.TypedField('_stagedir', str, None)
+    _stdout = fields.TypedField('_stdout', str, None)
+    _stderr = fields.TypedField('_stderr', str, None)
     _current_partition = fields.TypedField('_current_partition',
                                            SystemPartition, None)
     _current_environ = fields.TypedField('_current_environ', Environment, None)

--- a/reframe/core/pipeline.py
+++ b/reframe/core/pipeline.py
@@ -129,7 +129,7 @@ class RegressionTest:
     #:
     #:     .. versionchanged:: 2.10
     #:        Support for Git repositories was added.
-    sourcesdir = fields.TypedField('sourcesdir', str, None)
+    sourcesdir = fields.TypedField('sourcesdir', str, type(None))
 
     #: The build system to be used for this test.
     #: If not specified, the framework will try to figure it out automatically
@@ -145,7 +145,7 @@ class RegressionTest:
     #: :default: :class:`None`.
     #:
     #: .. versionadded:: 2.14
-    build_system = BuildSystemField('build_system', allow_none=True)
+    build_system = BuildSystemField('build_system', type(None))
 
     #: List of shell commands to be executed before compiling.
     #:
@@ -279,7 +279,8 @@ class RegressionTest:
     #:
     #: :type: integral or :class:`None`
     #: :default: :class:`None`
-    num_tasks_per_node = fields.TypedField('num_tasks_per_node', int, None)
+    num_tasks_per_node = fields.TypedField('num_tasks_per_node',
+                                           int, type(None))
 
     #: Number of GPUs per node required by this test.
     #:
@@ -293,7 +294,7 @@ class RegressionTest:
     #:
     #: :type: integral or :class:`None`
     #: :default: :class:`None`
-    num_cpus_per_task = fields.TypedField('num_cpus_per_task', int, None)
+    num_cpus_per_task = fields.TypedField('num_cpus_per_task', int, type(None))
 
     #: Number of tasks per core required by this test.
     #:
@@ -301,7 +302,8 @@ class RegressionTest:
     #:
     #: :type: integral or :class:`None`
     #: :default: :class:`None`
-    num_tasks_per_core  = fields.TypedField('num_tasks_per_core', int, None)
+    num_tasks_per_core  = fields.TypedField('num_tasks_per_core',
+                                            int, type(None))
 
     #: Number of tasks per socket required by this test.
     #:
@@ -309,7 +311,8 @@ class RegressionTest:
     #:
     #: :type: integral or :class:`None`
     #: :default: :class:`None`
-    num_tasks_per_socket = fields.TypedField('num_tasks_per_socket', int, None)
+    num_tasks_per_socket = fields.TypedField('num_tasks_per_socket',
+                                             int, type(None))
 
     #: Specify whether this tests needs simultaneous multithreading enabled.
     #:
@@ -317,7 +320,8 @@ class RegressionTest:
     #:
     #: :type: boolean or :class:`None`
     #: :default: :class:`None`
-    use_multithreading = fields.TypedField('use_multithreading', bool, None)
+    use_multithreading = fields.TypedField('use_multithreading',
+                                           bool, type(None))
 
     #: Specify whether this test needs exclusive access to nodes.
     #:
@@ -366,7 +370,7 @@ class RegressionTest:
     #:           self.sanity_patterns = sn.assert_found(r'.*', self.stdout)
     #:
     sanity_patterns = fields.TypedField('sanity_patterns',
-                                        _DeferredExpression, None)
+                                        _DeferredExpression, type(None))
 
     #: Patterns for verifying the performance of this test.
     #:
@@ -380,8 +384,8 @@ class RegressionTest:
     #:     </sanity_functions_reference>`) as values.
     #:     :class:`None` is also allowed.
     #: :default: :class:`None`
-    perf_patterns = fields.TypedField('perf_patterns',
-                                      typ.Dict[str, _DeferredExpression], None)
+    perf_patterns = fields.TypedField(
+        'perf_patterns', typ.Dict[str, _DeferredExpression], type(None))
 
     #: List of modules to be loaded before running this test.
     #:
@@ -488,14 +492,15 @@ class RegressionTest:
 
     # Private properties
     _prefix = fields.TypedField('_prefix', str)
-    _stagedir = fields.TypedField('_stagedir', str, None)
-    _stdout = fields.TypedField('_stdout', str, None)
-    _stderr = fields.TypedField('_stderr', str, None)
+    _stagedir = fields.TypedField('_stagedir', str, type(None))
+    _stdout = fields.TypedField('_stdout', str, type(None))
+    _stderr = fields.TypedField('_stderr', str, type(None))
     _current_partition = fields.TypedField('_current_partition',
-                                           SystemPartition, None)
-    _current_environ = fields.TypedField('_current_environ', Environment, None)
-    _job = fields.TypedField('_job', Job, None)
-    _build_job = fields.TypedField('_build_job', Job, None)
+                                           SystemPartition, type(None))
+    _current_environ = fields.TypedField('_current_environ',
+                                         Environment, type(None))
+    _job = fields.TypedField('_job', Job, type(None))
+    _build_job = fields.TypedField('_build_job', Job, type(None))
 
     def __new__(cls, *args, **kwargs):
         obj = super().__new__(cls)

--- a/reframe/core/pipeline.py
+++ b/reframe/core/pipeline.py
@@ -19,6 +19,7 @@ import reframe.core.runtime as rt
 import reframe.core.shell as shell
 import reframe.utility as util
 import reframe.utility.os_ext as os_ext
+import reframe.utility.typecheck as types
 from reframe.core.buildsystems import BuildSystem, BuildSystemField
 from reframe.core.deferrable import deferrable, _DeferredExpression, evaluate
 from reframe.core.environments import Environment, EnvironmentSnapshot
@@ -341,7 +342,7 @@ class RegressionTest:
     #:
     #: :type: A scoped dictionary with system names as scopes or :class:`None`
     #: :default: ``{}``
-    reference = fields.ScopedDictField('reference', (tuple, object))
+    reference = fields.ScopedDictField('reference', types.Tuple[object])
     # FIXME: There is not way currently to express tuples of `float`s or
     # `None`s, so we just use the very generic `object`
 
@@ -368,8 +369,8 @@ class RegressionTest:
     #:
     #:           self.sanity_patterns = sn.assert_found(r'.*', self.stdout)
     #:
-    sanity_patterns = fields.TypedField(
-        'sanity_patterns', _DeferredExpression, allow_none=True)
+    sanity_patterns = fields.TypedField('sanity_patterns',
+                                        _DeferredExpression, None)
 
     #: Patterns for verifying the performance of this test.
     #:
@@ -486,8 +487,8 @@ class RegressionTest:
     #:    A new more powerful syntax was introduced
     #:    that allows also custom job script directive prefixes.
     #:
-    extra_resources = fields.AggregateTypeField(
-        'extra_resources', (dict, (str, (dict, (str, object)))))
+    extra_resources = fields.TypedField(
+        'extra_resources', types.Dict[str, types.Dict[str, object]])
 
     # Private properties
     _prefix = fields.StringField('_prefix')
@@ -495,11 +496,10 @@ class RegressionTest:
     _stdout = fields.StringField('_stdout', allow_none=True)
     _stderr = fields.StringField('_stderr', allow_none=True)
     _current_partition = fields.TypedField('_current_partition',
-                                           SystemPartition, allow_none=True)
-    _current_environ = fields.TypedField('_current_environ', Environment,
-                                         allow_none=True)
-    _job = fields.TypedField('_job', Job, allow_none=True)
-    _build_job = fields.TypedField('_build_job', Job, allow_none=True)
+                                           SystemPartition, None)
+    _current_environ = fields.TypedField('_current_environ', Environment, None)
+    _job = fields.TypedField('_job', Job, None)
+    _build_job = fields.TypedField('_build_job', Job, None)
 
     def __new__(cls, *args, **kwargs):
         obj = super().__new__(cls)

--- a/reframe/core/runtime.py
+++ b/reframe/core/runtime.py
@@ -92,9 +92,9 @@ class HostResources:
     #:    Users may not set this field.
     #:
     prefix = fields.AbsolutePathField('prefix')
-    outputdir = fields.AbsolutePathField('outputdir', allow_none=True)
-    stagedir  = fields.AbsolutePathField('stagedir', allow_none=True)
-    perflogdir = fields.AbsolutePathField('perflogdir', allow_none=True)
+    outputdir = fields.AbsolutePathField('outputdir', type(None))
+    stagedir  = fields.AbsolutePathField('stagedir', type(None))
+    perflogdir = fields.AbsolutePathField('perflogdir', type(None))
 
     def __init__(self, prefix=None, stagedir=None,
                  outputdir=None, perflogdir=None, timefmt=None):
@@ -130,7 +130,6 @@ class HostResources:
         else:
             return os.path.join(self.outputdir + self._run_suffix(),
                                 self.timestamp)
-
 
     @property
     def stage_prefix(self):

--- a/reframe/core/schedulers/__init__.py
+++ b/reframe/core/schedulers/__init__.py
@@ -50,9 +50,9 @@ class Job(abc.ABC):
     #: :type: :class:`reframe.core.launchers.JobLauncher`
     launcher = fields.TypedField('launcher', JobLauncher)
 
-    _jobid = fields.TypedField('_jobid', int, None)
-    _exitcode = fields.TypedField('_exitcode', int, None)
-    _state = fields.TypedField('_state', JobState, None)
+    _jobid = fields.TypedField('_jobid', int, type(None))
+    _exitcode = fields.TypedField('_exitcode', int, type(None))
+    _state = fields.TypedField('_state', JobState, type(None))
 
     # The sched_* arguments are exposed also to the frontend
     def __init__(self,

--- a/reframe/core/schedulers/__init__.py
+++ b/reframe/core/schedulers/__init__.py
@@ -8,6 +8,7 @@ import os
 import reframe.core.debug as debug
 import reframe.core.fields as fields
 import reframe.core.shell as shell
+import reframe.utility.typecheck as typ
 from reframe.core.exceptions import JobNotStartedError
 from reframe.core.launchers import JobLauncher
 
@@ -39,9 +40,9 @@ class Job(abc.ABC):
 
     #: Options to be passed to the backend job scheduler.
     #:
-    #: :type: :class:`list` of :class:`str`
+    #: :type: :class:`List[str]`
     #: :default: ``[]``
-    options = fields.TypedListField('options', str)
+    options = fields.TypedField('options', typ.List[str])
 
     #: The parallel program launcher that will be used to launch the parallel
     #: executable of this job.
@@ -49,8 +50,8 @@ class Job(abc.ABC):
     #: :type: :class:`reframe.core.launchers.JobLauncher`
     launcher = fields.TypedField('launcher', JobLauncher)
 
-    _jobid = fields.IntegerField('_jobid', allow_none=True)
-    _exitcode = fields.IntegerField('_exitcode', allow_none=True)
+    _jobid = fields.TypedField('_jobid', int, None)
+    _exitcode = fields.TypedField('_exitcode', int, None)
     _state = fields.TypedField('_state', JobState, None)
 
     # The sched_* arguments are exposed also to the frontend

--- a/reframe/core/schedulers/__init__.py
+++ b/reframe/core/schedulers/__init__.py
@@ -51,7 +51,7 @@ class Job(abc.ABC):
 
     _jobid = fields.IntegerField('_jobid', allow_none=True)
     _exitcode = fields.IntegerField('_exitcode', allow_none=True)
-    _state = fields.TypedField('_state', JobState, allow_none=True)
+    _state = fields.TypedField('_state', JobState, None)
 
     # The sched_* arguments are exposed also to the frontend
     def __init__(self,

--- a/reframe/core/systems.py
+++ b/reframe/core/systems.py
@@ -12,7 +12,7 @@ class SystemPartition:
     _access    = fields.TypedField('_access', typ.List[str])
     _environs  = fields.TypedField('_environs', typ.List[Environment])
     _resources = fields.TypedField('_resources', typ.Dict[str, typ.List[str]])
-    _local_env = fields.TypedField('_local_env', Environment, None)
+    _local_env = fields.TypedField('_local_env', Environment, type(None))
 
     # maximum concurrent jobs
     _max_jobs  = fields.TypedField('_max_jobs', int)
@@ -149,12 +149,12 @@ class System:
     _hostnames  = fields.TypedField('_hostnames', typ.List[str])
     _partitions = fields.TypedField('_partitions', typ.List[SystemPartition])
     _modules_system = fields.TypedField('_modules_system',
-                                        typ.Str[r'(\w|-)+'], None)
+                                        typ.Str[r'(\w|-)+'], type(None))
 
     _prefix = fields.TypedField('_prefix', str)
-    _stagedir  = fields.TypedField('_stagedir', str, None)
-    _outputdir = fields.TypedField('_outputdir', str, None)
-    _perflogdir = fields.TypedField('_perflogdir', str, None)
+    _stagedir  = fields.TypedField('_stagedir', str, type(None))
+    _outputdir = fields.TypedField('_outputdir', str, type(None))
+    _perflogdir = fields.TypedField('_perflogdir', str, type(None))
     _resourcesdir = fields.TypedField('_resourcesdir', str)
 
     def __init__(self, name, descr=None, hostnames=[], partitions=[],

--- a/reframe/core/systems.py
+++ b/reframe/core/systems.py
@@ -1,21 +1,21 @@
 import reframe.core.debug as debug
 import reframe.core.fields as fields
-import reframe.utility.typecheck as types
+import reframe.utility.typecheck as typ
 from reframe.core.environments import Environment
 
 
 class SystemPartition:
     """A representation of a system partition inside ReFrame."""
 
-    _name      = fields.StringPatternField('_name', '(\w|-)+')
-    _descr     = fields.StringField('_descr')
-    _access    = fields.TypedListField('_access', str)
-    _environs  = fields.TypedListField('_environs', Environment)
-    _resources = fields.TypedDictField('_resources', str, types.List[str])
+    _name      = fields.TypedField('_name', typ.Str['(\w|-)+'])
+    _descr     = fields.TypedField('_descr', str)
+    _access    = fields.TypedField('_access', typ.List[str])
+    _environs  = fields.TypedField('_environs', typ.List[Environment])
+    _resources = fields.TypedField('_resources', typ.Dict[str, typ.List[str]])
     _local_env = fields.TypedField('_local_env', Environment, None)
 
     # maximum concurrent jobs
-    _max_jobs  = fields.IntegerField('_max_jobs')
+    _max_jobs  = fields.TypedField('_max_jobs', int)
 
     def __init__(self, name, descr=None, scheduler=None, launcher=None,
                  access=[], environs=[], resources={}, local_env=None,
@@ -144,18 +144,18 @@ class SystemPartition:
 
 class System:
     """A representation of a system inside ReFrame."""
-    _name  = fields.StringPatternField('_name', '(\w|-)+')
-    _descr = fields.StringField('_descr')
-    _hostnames  = fields.TypedListField('_hostnames', str)
-    _partitions = fields.TypedListField('_partitions', SystemPartition)
-    _modules_system = fields.StringPatternField('_modules_system',
-                                                '(\w|-)+', allow_none=True)
+    _name  = fields.TypedField('_name', typ.Str[r'(\w|-)+'])
+    _descr = fields.TypedField('_descr', str)
+    _hostnames  = fields.TypedField('_hostnames', typ.List[str])
+    _partitions = fields.TypedField('_partitions', typ.List[SystemPartition])
+    _modules_system = fields.TypedField('_modules_system',
+                                        typ.Str[r'(\w|-)+'], None)
 
-    _prefix = fields.StringField('_prefix')
-    _stagedir  = fields.StringField('_stagedir', allow_none=True)
-    _outputdir = fields.StringField('_outputdir', allow_none=True)
-    _perflogdir = fields.StringField('_perflogdir', allow_none=True)
-    _resourcesdir = fields.StringField('_resourcesdir')
+    _prefix = fields.TypedField('_prefix', str)
+    _stagedir  = fields.TypedField('_stagedir', str, None)
+    _outputdir = fields.TypedField('_outputdir', str, None)
+    _perflogdir = fields.TypedField('_perflogdir', str, None)
+    _resourcesdir = fields.TypedField('_resourcesdir', str)
 
     def __init__(self, name, descr=None, hostnames=[], partitions=[],
                  prefix='.', stagedir=None, outputdir=None, perflogdir=None,

--- a/reframe/core/systems.py
+++ b/reframe/core/systems.py
@@ -1,6 +1,6 @@
 import reframe.core.debug as debug
 import reframe.core.fields as fields
-
+import reframe.utility.typecheck as types
 from reframe.core.environments import Environment
 
 
@@ -11,8 +11,8 @@ class SystemPartition:
     _descr     = fields.StringField('_descr')
     _access    = fields.TypedListField('_access', str)
     _environs  = fields.TypedListField('_environs', Environment)
-    _resources = fields.TypedDictField('_resources', str, (list, str))
-    _local_env = fields.TypedField('_local_env', Environment, allow_none=True)
+    _resources = fields.TypedDictField('_resources', str, types.List[str])
+    _local_env = fields.TypedField('_local_env', Environment, None)
 
     # maximum concurrent jobs
     _max_jobs  = fields.IntegerField('_max_jobs')

--- a/reframe/utility/typecheck.py
+++ b/reframe/utility/typecheck.py
@@ -9,7 +9,7 @@ checks should hold:
 ::
     l = [1, 2, 3]
     assert isinstance(l, List[int]) == True
-    assert isinstance(l, List[false]) == False
+    assert isinstance(l, List[float]) == False
 
 
 Aggregate types can be combined in an arbitrary depth, so that can type check
@@ -197,9 +197,6 @@ class _MappingType(_TypeFactory):
 
 class StrType(_ContainerType):
     """A metaclass for type checking string types."""
-
-    def __instancecheck__(cls, inst):
-        return False
 
     def __instancecheck__(cls, inst):
         if not issubclass(type(inst), cls):

--- a/reframe/utility/typecheck.py
+++ b/reframe/utility/typecheck.py
@@ -1,0 +1,171 @@
+import abc
+import collections
+import re
+
+
+class _TypeFactory(abc.ABCMeta):
+    def register_subtypes(cls):
+        for t in cls._subtypes:
+            cls.register(t)
+
+
+class ContainerType(_TypeFactory):
+    def __init__(cls, name, bases, namespace):
+        super().__init__(name, bases, namespace)
+        cls._elem_type = None
+        cls._bases = bases
+        cls._namespace = namespace
+        cls.register_subtypes()
+
+    def __instancecheck__(cls, inst):
+        if not issubclass(type(inst), cls):
+            return False
+
+        if cls._elem_type is None:
+            return True
+
+        return all(isinstance(c, cls._elem_type) for c in inst)
+
+    def __getitem__(cls, elem_type):
+        if not isinstance(elem_type, type):
+            raise TypeError('{0} is not a valid type'.format(elem_type))
+
+        if isinstance(elem_type, tuple):
+            raise TypeError('invalid type specification for container type: '
+                            'expected ContainerType[elem_type]')
+
+        ret = ContainerType('%s[%s]' % (cls.__name__, elem_type.__name__),
+                            cls._bases, cls._namespace)
+        ret._elem_type = elem_type
+        ret.register_subtypes()
+        cls.register(ret)
+        return ret
+
+
+class TupleType(ContainerType):
+    def __instancecheck__(cls, inst):
+        if not issubclass(type(inst), cls):
+            return False
+
+        if cls._elem_type is None:
+            return True
+
+        if len(cls._elem_type) == 1:
+            # tuple with elements of the same type
+            return all(isinstance(c, cls._elem_type[0]) for c in inst)
+
+        # Non-uniformly typed tuple
+        if len(inst) != len(cls._elem_type):
+            return False
+
+        return all(isinstance(elem, req_type)
+                   for req_type, elem in zip(cls._elem_type, inst))
+
+    def __getitem__(cls, elem_types):
+        if not isinstance(elem_types, tuple):
+            elem_types = (elem_types,)
+
+        for t in elem_types:
+            if not isinstance(t, type):
+                raise TypeError('{0} is not a valid type'.format(t))
+
+        cls_name = '%s[%s]' % (
+            cls.__name__, ','.join(c.__name__ for c in elem_types)
+        )
+        ret = TupleType(cls_name, cls._bases, cls._namespace)
+        ret._elem_type = elem_types
+        ret.register_subtypes()
+        cls.register(ret)
+        return ret
+
+
+class MappingType(_TypeFactory):
+    def __init__(cls, name, bases, namespace):
+        super().__init__(name, bases, namespace)
+        cls._key_type = None
+        cls._value_type = None
+        cls._bases = bases
+        cls._namespace = namespace
+        cls.register_subtypes()
+
+    def __instancecheck__(cls, inst):
+        if not issubclass(type(inst), cls):
+            return False
+
+        if cls._key_type is None and cls._key_type is None:
+            return True
+
+        assert cls._key_type is not None and cls._value_type is not None
+        has_valid_keys = all(isinstance(k, cls._key_type)
+                             for k in inst.keys())
+        has_valid_values = all(isinstance(v, cls._value_type)
+                               for v in inst.values())
+        return has_valid_keys and has_valid_values
+
+    def __getitem__(cls, typespec):
+        try:
+            key_type, value_type = typespec
+        except ValueError:
+            raise TypeError(
+                'invalid type specification for mapping type: '
+                'expected MappingType[key_type, value_type]') from None
+
+        for t in typespec:
+            if not isinstance(t, type):
+                raise TypeError('{0} is not a valid type'.format(t))
+
+        cls_name = '%s[%s,%s]' % (cls.__name__, key_type.__name__,
+                                  value_type.__name__)
+        ret = MappingType(cls_name, cls._bases, cls._namespace)
+        ret._key_type = key_type
+        ret._value_type = value_type
+        ret.register_subtypes()
+        cls.register(ret)
+        return ret
+
+
+class StrType(ContainerType):
+    def __instancecheck__(cls, inst):
+        return False
+
+    def __instancecheck__(cls, inst):
+        if not issubclass(type(inst), cls):
+            return False
+
+        if cls._elem_type is None:
+            return True
+
+        # _elem_type is a regex
+        return re.fullmatch(cls._elem_type, inst) is not None
+
+    def __getitem__(cls, patt):
+        if not isinstance(patt, str):
+            raise TypeError('invalid type specification for string type: '
+                            'expected StrType[regex]')
+
+        ret = StrType("%s[r'%s']" % (cls.__name__, patt),
+                      cls._bases, cls._namespace)
+        ret._elem_type = patt
+        ret.register_subtypes()
+        cls.register(ret)
+        return ret
+
+
+class Dict(metaclass=MappingType):
+    _subtypes = (dict,)
+
+
+class List(metaclass=ContainerType):
+    _subtypes = (list,)
+
+
+class Set(metaclass=ContainerType):
+    _subtypes = (set,)
+
+
+class Str(metaclass=StrType):
+    _subtypes = (str,)
+
+
+class Tuple(metaclass=TupleType):
+    _subtypes = (tuple,)

--- a/unittests/test_fields.py
+++ b/unittests/test_fields.py
@@ -74,111 +74,6 @@ class TestFields(unittest.TestCase):
         with self.assertRaises(TypeError):
             tester.field_any = 3
 
-    def test_string_field(self):
-        class FieldTester:
-            field = fields.StringField('field')
-
-            def __init__(self, value):
-                self.field = value
-
-        tester = FieldTester('foo')
-        self.assertIsInstance(FieldTester.field, fields.StringField)
-        self.assertEqual('foo', tester.field)
-        self.assertRaises(TypeError, exec, 'tester.field = 13',
-                          globals(), locals())
-
-    def test_string_pattern_field(self):
-        class FieldTester:
-            field = fields.StringPatternField('field', '\S+')
-
-            def __init__(self, value):
-                self.field = value
-
-        tester = FieldTester('foo123')
-        self.assertIsInstance(FieldTester.field, fields.StringPatternField)
-        self.assertEqual('foo123', tester.field)
-        with self.assertRaises(TypeError):
-            tester.field = 13
-
-        with self.assertRaises(TypeError):
-            tester.field = 'foo 123'
-
-    def test_integer_field(self):
-        class FieldTester:
-            field  = fields.IntegerField('field')
-
-            def __init__(self, value):
-                self.field = value
-
-        tester = FieldTester(5)
-        self.assertIsInstance(FieldTester.field, fields.IntegerField)
-        self.assertEqual(5, tester.field)
-        self.assertRaises(TypeError, FieldTester, 'foo')
-        self.assertRaises(TypeError, exec, "tester.field = 'foo'",
-                          globals(), locals())
-
-    def test_boolean_field(self):
-        class FieldTester:
-            field  = fields.BooleanField('field')
-
-            def __init__(self, value):
-                self.field = value
-
-        tester = FieldTester(True)
-        self.assertIsInstance(FieldTester.field, fields.BooleanField)
-        self.assertEqual(True, tester.field)
-        self.assertRaises(TypeError, FieldTester, 'foo')
-        self.assertRaises(TypeError, exec, 'tester.field = 3',
-                          globals(), locals())
-
-    def test_typed_list_field(self):
-        class FieldTester:
-            field  = fields.TypedListField('field', str)
-
-            def __init__(self, value):
-                self.field = value
-
-        tester = FieldTester(['a', 'b', 'c'])
-        self.assertEqual(['a', 'b', 'c'], tester.field)
-        self.assertRaises(TypeError, FieldTester, [1, 'foo'])
-        with self.assertRaises(TypeError):
-            tester.field = 'foo'
-
-    def test_typed_set_field(self):
-        class FieldTester:
-            field  = fields.TypedSetField('field', int)
-
-            def __init__(self, value):
-                self.field = value
-
-        tester = FieldTester({1, 2, 3})
-        self.assertIsInstance(FieldTester.field, fields.TypedSetField)
-        self.assertEqual({1, 2, 3}, tester.field)
-        self.assertRaises(TypeError, FieldTester, {1, 'foo'})
-        self.assertRaises(TypeError, exec, 'tester.field = [1, 2]',
-                          globals(), locals())
-
-    def test_typed_dict_field(self):
-        class FieldTester:
-            field  = fields.TypedDictField('field', str, int)
-
-            def __init__(self, value):
-                self.field = value
-
-        user_dict = {
-            'foo': 1,
-            'bar': 2,
-            'foobar': 3
-        }
-
-        tester = FieldTester(user_dict)
-        self.assertIsInstance(FieldTester.field, fields.TypedDictField)
-        self.assertEqual(user_dict, tester.field)
-        self.assertRaises(TypeError, FieldTester, {1: 'foo'})
-        self.assertRaises(TypeError, FieldTester, {'foo': 1.3})
-        self.assertRaises(TypeError, exec, 'tester.field = [1, 2]',
-                          globals(), locals())
-
     def test_timer_field(self):
         class FieldTester:
             field = fields.TimerField('field')
@@ -253,14 +148,14 @@ class TestFields(unittest.TestCase):
         from reframe.core.exceptions import ReframeDeprecationWarning
 
         class FieldTester:
-            value = fields.DeprecatedField(fields.IntegerField('value'),
+            value = fields.DeprecatedField(fields.TypedField('value', int),
                                            'value field is deprecated')
-            _value = fields.IntegerField('value')
-            ro = fields.DeprecatedField(fields.IntegerField('ro'),
+            _value = fields.TypedField('value', int)
+            ro = fields.DeprecatedField(fields.TypedField('ro', int),
                                         'value field is deprecated',
                                         fields.DeprecatedField.OP_SET)
-            _ro = fields.IntegerField('ro')
-            wo = fields.DeprecatedField(fields.IntegerField('wo'),
+            _ro = fields.TypedField('ro', int)
+            wo = fields.DeprecatedField(fields.TypedField('wo', int),
                                         'value field is deprecated',
                                         fields.DeprecatedField.OP_GET)
 

--- a/unittests/test_fields.py
+++ b/unittests/test_fields.py
@@ -54,7 +54,7 @@ class TestFields(unittest.TestCase):
 
         class FieldTester:
             field = fields.TypedField('field', ClassA)
-            field_any = fields.TypedField('field_any', ClassA, str, None)
+            field_any = fields.TypedField('field_any', ClassA, str, type(None))
 
             def __init__(self, value):
                 self.field = value
@@ -66,8 +66,9 @@ class TestFields(unittest.TestCase):
 
         tester.field = ClassB()
         self.assertEqual(10, tester.field.value)
-        self.assertRaises(TypeError, exec, 'tester.field = None',
-                          globals(), locals())
+        with self.assertRaises(TypeError):
+            tester.field = None
+
         tester.field_any = None
         tester.field_any = 'foo'
         tester.field_any = ClassA(5)
@@ -77,8 +78,8 @@ class TestFields(unittest.TestCase):
     def test_timer_field(self):
         class FieldTester:
             field = fields.TimerField('field')
-            field_maybe_none = fields.TimerField('field_maybe_none',
-                                                 allow_none=True)
+            field_maybe_none = fields.TimerField(
+                'field_maybe_none', type(None))
 
         tester = FieldTester()
         tester.field = (65, 22, 47)
@@ -192,7 +193,7 @@ class TestFields(unittest.TestCase):
 
     def test_absolute_path_field(self):
         class FieldTester:
-            value = fields.AbsolutePathField('value', allow_none=True)
+            value = fields.AbsolutePathField('value', type(None))
 
             def __init__(self, value):
                 self.value = value
@@ -212,8 +213,8 @@ class TestFields(unittest.TestCase):
     def test_scoped_dict_field(self):
         class FieldTester:
             field = fields.ScopedDictField('field', int)
-            field_maybe_none = fields.ScopedDictField('field_maybe_none',
-                                                      int, allow_none=True)
+            field_maybe_none = fields.ScopedDictField(
+                'field_maybe_none', int, type(None))
 
         tester = FieldTester()
 

--- a/unittests/test_fields.py
+++ b/unittests/test_fields.py
@@ -54,8 +54,7 @@ class TestFields(unittest.TestCase):
 
         class FieldTester:
             field = fields.TypedField('field', ClassA)
-            field_maybe_none = fields.TypedField('field_maybe_none', ClassA,
-                                                 allow_none=True)
+            field_any = fields.TypedField('field_any', ClassA, str, None)
 
             def __init__(self, value):
                 self.field = value
@@ -69,150 +68,11 @@ class TestFields(unittest.TestCase):
         self.assertEqual(10, tester.field.value)
         self.assertRaises(TypeError, exec, 'tester.field = None',
                           globals(), locals())
-        tester.field_maybe_none = None
-
-    def test_aggregate_typed_field(self):
-        class FieldTester:
-            simple_int  = fields.AggregateTypeField('simple_int', int)
-            int_list    = fields.AggregateTypeField('int_list', (list, int))
-            tuple_list  = fields.AggregateTypeField('tuple_list',
-                                                    (list, (tuple, int)))
-            mixed_tuple = fields.AggregateTypeField(
-                'mixed_tuple', (tuple, ((int, float, int),)))
-            float_tuple = fields.AggregateTypeField('float_tuple',
-                                                    (tuple, float))
-            dict_list   = fields.AggregateTypeField('dict_list',
-                                                    (list, (dict, (str, int))))
-            multilevel_dict = fields.AggregateTypeField(
-                'multilevel_dict', (dict, (str, (dict, (str, int))))
-            )
-            complex_dict = fields.AggregateTypeField(
-                'complex_dict',
-                (dict, (str, (dict, (str, (list, (
-                    tuple, ((str, (callable, None), (callable, None)),))
-                )))))
-            )
-
-            # Fields allowing None's
-            int_list_none = fields.AggregateTypeField('int_list_none',
-                                                      (list, (int, None)))
-
-            dict_list_none = fields.AggregateTypeField(
-                'dict_list_none',
-                (list, ((dict, (str, int)), None))
-            )
-            multilevel_dict_none = fields.AggregateTypeField(
-                'multilevel_dict_none',
-                (dict, (str, ((dict, (str, (int, None))), None)))
-            )
-            mixed_tuple_none = fields.AggregateTypeField(
-                'mixed_tuple',
-                (tuple, ((int, (float, None), (int, None)),))
-            )
-
-        int_list = [1, 2, 3]
-        int_list_none = [1, None, 3]
-        tuple_list = [(1, 2, 3), (4, 5, 6)]
-        dict_list = [
-            {'a': 1, 'b': 2},
-            {'a': 3, 'b': 4}
-        ]
-        typed_tuple = (1, 2.2, 'foo')
-        float_tuple = (2.3, 1.2, 5.6, 9.8)
-        mixed_tuple = (1, 2.3, 3)
-        multilevel_dict = {
-            'foo': {
-                'a': 1,
-                'b': 2,
-            },
-            'bar': {
-                'c': 3,
-                'd': 4,
-            }
-        }
-        complex_dict = {
-            '-': {
-                'pattern': [
-                    ('foo', int, int),
-                    ('bar', None, float),
-                ],
-                'patt': [
-                    ('foobar', int, None),
-                ]
-            }
-        }
-        dict_list_none = [
-            {'a': 1, 'b': 2},
-            None
-        ]
-
-        # Test valid assignments
-        tester = FieldTester()
-        tester.simple_int = 1
-        tester.int_list = int_list
-        tester.int_list_none = int_list_none
-        tester.tuple_list = tuple_list
-        tester.dict_list = dict_list
-        tester.multilevel_dict = multilevel_dict
-        tester.float_tuple = float_tuple
-        tester.complex_dict = complex_dict
-        tester.mixed_tuple = mixed_tuple
-        tester.mixed_tuple_none = (1, None, 3)
-        tester.mixed_tuple_none = (1, 2.3, None)
-        tester.dict_list_none = dict_list_none
-
-        self.assertIsInstance(FieldTester.simple_int,
-                              fields.AggregateTypeField)
-        self.assertEqual(1, tester.simple_int)
-        self.assertEqual(int_list, tester.int_list)
-        self.assertEqual(tuple_list, tester.tuple_list)
-        self.assertEqual(dict_list, tester.dict_list)
-        self.assertEqual(multilevel_dict, tester.multilevel_dict)
-        self.assertEqual(float_tuple, tester.float_tuple)
-        self.assertEqual(complex_dict, tester.complex_dict)
-        self.assertEqual(dict_list_none, tester.dict_list_none)
-        self.assertEqual(int_list_none, tester.int_list_none)
-
-        # Test empty containers
-        tester.int_list = []
-        tester.tuple_list = []
-        tester.dict_list = [{'a': 1, 'b': 2}, {}]
-        tester.multilevel_dict = {
-            'foo': {},
-            'bar': {
-                'c': 3,
-                'd': 4,
-            }
-        }
-
-        # Test invalid assignments
-        self.assertRaises(TypeError, exec,
-                          "tester.int_list = ['a', 'b']",
-                          globals(), locals())
-        self.assertRaises(TypeError, exec,
-                          "tester.int_list = int_list_none",
-                          globals(), locals())
-        self.assertRaises(TypeError, exec,
-                          "tester.int_list = tuple_list",
-                          globals(), locals())
-        self.assertRaises(TypeError, exec,
-                          "tester.dict_list = multilevel_dict",
-                          globals(), locals())
-        self.assertRaises(TypeError, exec,
-                          "tester.dict_list = dict_list_none",
-                          globals(), locals())
-        self.assertRaises(TypeError, exec,
-                          "tester.dict_list = 4",
-                          globals(), locals())
-        self.assertRaises(TypeError, exec,
-                          "tester.float_tuple = mixed_tuple",
-                          globals(), locals())
-        self.assertRaises(TypeError, exec,
-                          "tester.mixed_tuple = float_tuple",
-                          globals(), locals())
-        self.assertRaises(TypeError, exec,
-                          "tester.complex_dict = multilevel_dict",
-                          globals(), locals())
+        tester.field_any = None
+        tester.field_any = 'foo'
+        tester.field_any = ClassA(5)
+        with self.assertRaises(TypeError):
+            tester.field_any = 3
 
     def test_string_field(self):
         class FieldTester:
@@ -237,10 +97,11 @@ class TestFields(unittest.TestCase):
         tester = FieldTester('foo123')
         self.assertIsInstance(FieldTester.field, fields.StringPatternField)
         self.assertEqual('foo123', tester.field)
-        self.assertRaises(TypeError, exec, 'tester.field = 13',
-                          globals(), locals())
-        self.assertRaises(ValueError, exec, 'tester.field = "foo 123"',
-                          globals(), locals())
+        with self.assertRaises(TypeError):
+            tester.field = 13
+
+        with self.assertRaises(TypeError):
+            tester.field = 'foo 123'
 
     def test_integer_field(self):
         class FieldTester:
@@ -282,21 +143,6 @@ class TestFields(unittest.TestCase):
         self.assertRaises(TypeError, FieldTester, [1, 'foo'])
         with self.assertRaises(TypeError):
             tester.field = 'foo'
-
-    def test_typed_sequence_field(self):
-        class FieldTester:
-            field  = fields.TypedSequenceField('field', str)
-
-            def __init__(self, value):
-                self.field = value
-
-        tester = FieldTester(['a', 'b', 'c'])
-        self.assertEqual(['a', 'b', 'c'], tester.field)
-
-        # strings are valid sequences
-        tester.field = 'foo'
-        self.assertEqual('foo', tester.field)
-        self.assertRaises(TypeError, FieldTester, [1, 'foo'])
 
     def test_typed_set_field(self):
         class FieldTester:
@@ -403,26 +249,6 @@ class TestFields(unittest.TestCase):
         self.assertEqual(3, t.a)
         self.assertEqual(4, t.b)
 
-    def test_any_field(self):
-        class FieldTester:
-            value = fields.AnyField('field',
-                                    [(fields.IntegerField,),
-                                     (fields.TypedListField, int)],
-                                    allow_none=True)
-
-            def __init__(self, value):
-                self.value = value
-
-        tester = FieldTester(1)
-        tester.value = 2
-        tester.value = [1, 2]
-        tester.value = None
-        self.assertIsInstance(FieldTester.value, fields.AnyField)
-        self.assertRaises(TypeError, exec, 'tester.value = 1.2',
-                          globals(), locals())
-        self.assertRaises(TypeError, exec, 'tester.value = {1, 2}',
-                          globals(), locals())
-
     def test_deprecated_field(self):
         from reframe.core.exceptions import ReframeDeprecationWarning
 
@@ -485,8 +311,8 @@ class TestFields(unittest.TestCase):
 
         # This should not raise
         tester.value = None
-        self.assertRaises(TypeError, exec, 'tester.value = 1',
-                          globals(), locals())
+        with self.assertRaises(TypeError):
+            tester.value = 1
 
     def test_scoped_dict_field(self):
         class FieldTester:

--- a/unittests/test_fields.py
+++ b/unittests/test_fields.py
@@ -199,11 +199,11 @@ class TestFields(unittest.TestCase):
                 self.value = value
 
         tester = FieldTester('foo')
-        self.assertEquals(os.path.abspath('foo'), tester.value)
+        self.assertEqual(os.path.abspath('foo'), tester.value)
 
         # Test set with an absolute path already
         tester.value = os.path.abspath('foo')
-        self.assertEquals(os.path.abspath('foo'), tester.value)
+        self.assertEqual(os.path.abspath('foo'), tester.value)
 
         # This should not raise
         tester.value = None

--- a/unittests/test_typecheck.py
+++ b/unittests/test_typecheck.py
@@ -1,0 +1,138 @@
+import unittest
+import reframe.utility.typecheck as types
+
+
+class TestTypes(unittest.TestCase):
+    def _test_type_hierarchy(self, builtin_type, ctype):
+        self.assertTrue(issubclass(builtin_type, ctype))
+        self.assertTrue(issubclass(ctype[int], ctype))
+        self.assertTrue(issubclass(ctype[ctype[int]], ctype))
+        self.assertFalse(issubclass(ctype[int], ctype[float]))
+        self.assertFalse(issubclass(ctype[ctype[int]], ctype[int]))
+        self.assertFalse(issubclass(ctype[int], ctype[ctype[int]]))
+
+    def test_list_type(self):
+        l = [1, 2]
+        ll = [[1, 2], [3, 4]]
+        self.assertIsInstance(l, types.List)
+        self.assertIsInstance(l, types.List[int])
+        self.assertFalse(isinstance(l, types.List[float]))
+
+        self.assertIsInstance(ll, types.List)
+        self.assertIsInstance(ll, types.List[types.List[int]])
+        self._test_type_hierarchy(list, types.List)
+
+        # Test invalid arguments
+        with self.assertRaises(TypeError):
+            types.List[3]
+
+        with self.assertRaises(TypeError):
+            types.List[int, float]
+
+    def test_set_type(self):
+        s = {1, 2}
+        ls = [{1, 2}, {3, 4}]
+        self.assertIsInstance(s, types.Set)
+        self.assertIsInstance(s, types.Set[int])
+        self.assertFalse(isinstance(s, types.Set[float]))
+
+        self.assertIsInstance(ls, types.List)
+        self.assertIsInstance(ls, types.List[types.Set[int]])
+        self._test_type_hierarchy(set, types.Set)
+
+        # Test invalid arguments
+        with self.assertRaises(TypeError):
+            types.Set[3]
+
+        with self.assertRaises(TypeError):
+            types.Set[int, float]
+
+    def test_uniform_tuple_type(self):
+        t = (1, 2)
+        tl = ([1, 2], [3, 4])
+        lt = [(1, 2), (3, 4)]
+        self.assertIsInstance(t, types.Tuple)
+        self.assertIsInstance(t, types.Tuple[int])
+        self.assertFalse(isinstance(t, types.Tuple[float]))
+
+        self.assertIsInstance(tl, types.Tuple)
+        self.assertIsInstance(tl, types.Tuple[types.List[int]])
+
+        self.assertIsInstance(lt, types.List)
+        self.assertIsInstance(lt, types.List[types.Tuple[int]])
+        self._test_type_hierarchy(tuple, types.Tuple)
+
+        # Test invalid arguments
+        with self.assertRaises(TypeError):
+            types.Set[3]
+
+    def test_non_uniform_tuple_type(self):
+        t = (1, 2.3, '4', ['a', 'b'])
+        self.assertIsInstance(t, types.Tuple)
+        self.assertIsInstance(t, types.Tuple[int, float, str, types.List[str]])
+        self.assertFalse(isinstance(t, types.Tuple[float, int, str]))
+        self.assertFalse(isinstance(t, types.Tuple[float, int, str, int]))
+
+        # Test invalid arguments
+        with self.assertRaises(TypeError):
+            types.Set[int, 3]
+
+    def test_mapping_type(self):
+        d = {'one': 1, 'two': 2}
+        dl = {'one': [1, 2], 'two': [3, 4]}
+        ld = [{'one': 1, 'two': 2}, {'three': 3}]
+        self.assertIsInstance(d, types.Dict)
+        self.assertIsInstance(d, types.Dict[str, int])
+        self.assertFalse(isinstance(d, types.Dict[int, int]))
+
+        self.assertIsInstance(dl, types.Dict)
+        self.assertIsInstance(dl, types.Dict[str, types.List[int]])
+        self.assertIsInstance(ld, types.List[types.Dict[str, int]])
+
+        # Test invalid arguments
+        with self.assertRaises(TypeError):
+            types.Dict[int]
+
+        with self.assertRaises(TypeError):
+            types.Dict[int, 3]
+
+    def test_str_type(self):
+        s = '123'
+        ls = ['1', '23', '456']
+        self.assertIsInstance(s, types.Str)
+        self.assertIsInstance(s, types.Str[r'\d+'])
+        self.assertIsInstance(ls, types.List[types.Str[r'\d+']])
+        self.assertFalse(isinstance(s, types.Str[r'a.*']))
+        self.assertFalse(isinstance(ls, types.List[types.Str[r'a.*']]))
+        self.assertFalse(isinstance('hello, world', types.Str[r'\S+']))
+
+        # Test invalid arguments
+        with self.assertRaises(TypeError):
+            types.Str[int]
+
+    def test_type_names(self):
+        self.assertEqual('List', types.List.__name__)
+        self.assertEqual('List[int]', types.List[int].__name__)
+        self.assertEqual('Dict[str,List[int]]',
+                         types.Dict[str, types.List[int]].__name__)
+        self.assertEqual('Tuple[int,Set[float],str]',
+                         types.Tuple[int, types.Set[float], str].__name__)
+        self.assertEqual("List[Str[r'\d+']]",
+                         types.List[types.Str[r'\d+']].__name__)
+
+    def test_custom_types(self):
+        class C:
+            def __init__(self, v):
+                self.__v = v
+
+            def __hash__(self):
+                return hash(self.__v)
+
+        l = [C(0), C(1), C(2)]
+        d = {0: C(0), 1: C(1)}
+        cd = {C(0): 0, C(1): 1}
+        t = (0, C(0), '1')
+        self.assertIsInstance(l, types.List[C])
+        self.assertIsInstance(d, types.Dict[int, C])
+        self.assertIsInstance(cd, types.Dict[C, int])
+        self.assertIsInstance(t, types.Tuple[int, C, str])


### PR DESCRIPTION
This PR offers a type checking facility for aggregate types based on [PEP484](https://www.python.org/dev/peps/pep-0484/) type hints. It also adjusts and simplifies the data validation descriptors (`reframe.core.fields`) by using the new facility.

More specifically, the `reframe.utility.typecheck` module defines types for aggregate data structures, such as lists, dictionaries etc. that you can use with the [`isinstance()`](https://docs.python.org/3.6/library/functions.html#isinstance) builtin function to recursively check the type of all the elements of an aggregate data structure. Suppose you have a list of integers, such as `[1, 2, 3]`, the following checks should hold:

```python
from reframe.utility.typecheck import List

l = [1, 2, 3]
assert isinstance(l, List[int]) == True
assert isinstance(l, List[float]) == False
```

Aggregate types can be combined in an arbitrary depth, so that can type check any complex data structure:

```python
from reframe.utility.typecheck import Dict, List

d = {'a': [1, 2], 'b': [3, 4]}
assert isisntance(d, Dict) == True
assert isisntance(d, Dict[str, List[int]]) == True
```

This module offers the following aggregate types:
- `List[T]`: This corresponds to a list with elements of type `T`.
- `Set[T]`: This corresponds to a set with elements of type `T`.
- `Dict[K,V]`: This corresponds to a dictionary with keys of type `K` and values of type ``V``.
- `Tuple[T]`: This corresponds to a tuple with elements of type `T`.
- `Tuple[T1,T2,...,Tn]`: This corresponds to a tuple with `n` elements, whose types are exactly `T1`, `T2`, ..., `Tn` and in that order.
- `Str[patt]`: This corresponds to a string type, whose members are all the strings matching the regular expression `patt`.

This modules internally leverages metaclasses and the [`__isinstancecheck__()`](https://docs.python.org/3.6/reference/datamodel.html#class.__instancecheck__) method to customize the behaviour of the `isinstance()` builtin.
By implementing also the [`__getitem__`](https://docs.python.org/3.6/reference/datamodel.html#object.__getitem__) accessor method, it follows the look-and-feel of the type hints proposed in PEP484.
This method returns a new type that is a subtype of the base container type.
Using the facilities of [`abc.ABCMeta`](https://docs.python.org/3.6/library/abc.html#abc.ABCMeta), builtin types, such as `list`, `str` etc. are registered as subtypes of the base container types offered by this module.
The type hierarchy of the types defined in this module is the following (example shown for `List`, but it is analogous for the rest of the types):

```
          List
        /   |
       /    |
      /     |
    list  List[T]
```

In the above example `T` may refer to any type, so that `List[List[int]]` is an instance of `List`, but not an instance of `List[int]`.

Fixes #47.
