### PR TITLE
[test] Adapt QE test to PE18.08

### DIFF
--- a/cscs-checks/apps/espresso/espresso_check.py
+++ b/cscs-checks/apps/espresso/espresso_check.py
@@ -19,7 +19,7 @@ class EspressoBaseCheck(RunOnlyRegressionTest):
                                   self.stdout, 'energy', float)
         self.sanity_patterns = sn.all([
             sn.assert_found(r'convergence has been achieved', self.stdout),
-            sn.assert_reference(energy, -11427.08612278, -1e-10, 1e-10)])
+            sn.assert_reference(energy, -11427.09017162, -1e-10, 1e-10)])
         self.perf_patterns = {
             'sec': sn.extractsingle(r'electrons    :\s+(?P<sec>\S+)s CPU ',
                                     self.stdout, 'sec', float)


### PR DESCRIPTION
Update total energy value: see https://github.com/eth-cscs/reframe/issues/375#event-1886508006

For more information, see the release notes at https://gitlab.com/QEF/q-e/tags/qe-6.2.0
```
- Some constants in the definition of PBE functionals were truncated to
    6 significant digits. While not a bug, this could lead to tiny differences
    with respect to previous results and other XC implementations (r13592)
```

Fixes #375.