### PR TITLE
[test] Adapt the TensorFlow module name for PE 18.08

### DIFF
--- a/cscs-checks/apps/tensorflow/tensorflow_check.py
+++ b/cscs-checks/apps/tensorflow/tensorflow_check.py
@@ -14,7 +14,7 @@ class TensorFlowBaseTest(rfm.RunOnlyRegressionTest):
         self.tags = {'production'}
         self.num_tasks = 1
         self.num_gpus_per_node = 1
-        self.modules = ['TensorFlow/1.7.0-CrayGNU-18.07-cuda-9.1-python3']
+        self.modules = ['TensorFlow/1.7.0-CrayGNU-18.08-cuda-9.1-python3']
 
         # Checkout to the branch corresponding to the module version of
         # TensorFlow


### PR DESCRIPTION
* Adapt the tensorflow module name to reflect the latest PE, 18.08.