### PR TITLE
[test] Remove read-only files attribute from the CP2K check

### DIFF
--- a/cscs-checks/apps/cp2k/cp2k_check.py
+++ b/cscs-checks/apps/cp2k/cp2k_check.py
@@ -35,7 +35,6 @@ class Cp2kCheck(RunOnlyRegressionTest):
         self.tags = {'scs'}
         self.strict_check = False
         self.modules = ['CP2K']
-        self.readonly_files = ['GTH_BASIS_SETS', 'H2O-256.inp', 'POTENTIAL']
         self.extra_resources = {
             'switches': {
                 'num_switches': 1


### PR DESCRIPTION
Removing read-only files (no symbolic lik)