### PR TITLE
[bugfix] Directly assign to `num_tasks` if `--flex-alloc-tasks` has an integer value

### DIFF
--- a/reframe/core/schedulers/__init__.py
+++ b/reframe/core/schedulers/__init__.py
@@ -236,15 +236,16 @@ class Job(abc.ABC):
         pass
 
     def guess_num_tasks(self):
-        available_nodes = self.get_partition_nodes()
-        getlogger().debug('flex_alloc_tasks: total available nodes in current '
-                          'virtual partition: %s' % len(available_nodes))
         if isinstance(self.sched_flex_alloc_tasks, int):
             if self.sched_flex_alloc_tasks <= 0:
                 raise JobError('invalid number of flex_alloc_tasks: %s' %
                                self.sched_flex_alloc_tasks)
 
             return self.sched_flex_alloc_tasks
+
+        available_nodes = self.get_partition_nodes()
+        getlogger().debug('flex_alloc_tasks: total available nodes in current '
+                          'virtual partition: %s' % len(available_nodes))
 
         # Try to guess the number of tasks now
         available_nodes = self.filter_nodes(available_nodes, self.options)


### PR DESCRIPTION
* If `--flex-alloc-tasks` is an int do not perform further actions,
  but directly assign `num_tasks`.

This allows to run on daint with specific number of `--flex-alloc-tasks` until #557 is fixed.