### PR TITLE
[feat] Add support for units in performance references

### DIFF
--- a/config/cscs.py
+++ b/config/cscs.py
@@ -414,7 +414,8 @@ class ReframeSettings:
                     '%(check_perf_var)s=%(check_perf_value)s|'
                     'ref=%(check_perf_ref)s '
                     '(l=%(check_perf_lower_thres)s, '
-                    'u=%(check_perf_upper_thres)s)'
+                    'u=%(check_perf_upper_thres)s)|'
+                    '%(check_perf_unit)s'
                 ),
                 'append': True
             }

--- a/docs/running.rst
+++ b/docs/running.rst
@@ -716,7 +716,7 @@ ReFrame supports an additional logging facility for recording performance values
 This is configured by the ``perf_logging_config`` variables, whose syntax is the same as for the ``logging_config``:
 
 .. literalinclude:: ../reframe/settings.py
-  :lines: 80-98
+  :lines: 80-99
   :dedent: 4
 
 Performance logging introduces two new log record handlers, specifically designed for this purpose.
@@ -773,6 +773,7 @@ The attributes of this handler are the following:
   - ``check_perf_ref``: The reference performance value of a certain performance variable.
   - ``check_perf_value``: The performance value obtained by this test for a certain performance variable.
   - ``check_perf_var``: The name of the `performance variable <tutorial.html#writing-a-performance-test>`__, whose value is logged.
+  - ``check_perf_unit``: The unit of measurement for the measured performance variable, if specified in the corresponding tuple of the :attr:`reframe.core.pipeline.RegressionTest.reference` attribute.
 
 Using the default performance log format, the resulting log entries look like the following:
 

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -594,9 +594,12 @@ The ``perf`` subkey will then be searched in the following scopes in this order:
 The first occurrence will be used as the reference value of the ``perf`` performance variable.
 In our example, the ``perf`` key will be resolved in the ``daint:gpu`` scope giving us the reference value.
 
-Reference values in ReFrame are specified as a three-tuple comprising the reference value and lower and upper thresholds.
+Reference values in ReFrame are specified as a three-tuple or four-tuple comprising the reference value, the lower and upper thresholds and, optionally, the measurement unit.
 Thresholds are specified as decimal fractions of the reference value. For nonnegative reference values, the lower threshold must lie in the [-1,0], whereas the upper threshold may be any positive real number or zero.
 In our example, the reference value for this test on ``daint:gpu`` is 50 Gflop/s ±10%. Setting a threshold value to :class:`None` disables the threshold.
+If you specify a measurement unit as well, you will be able to log it the performance logs of the test; this is handy when you are inspecting or plotting the performance values.
+
+
 
 Combining It All Together
 -------------------------

--- a/reframe/core/logging.py
+++ b/reframe/core/logging.py
@@ -344,6 +344,7 @@ class LoggerAdapter(logging.LoggerAdapter):
                 'check_perf_ref': None,
                 'check_perf_lower_thres': None,
                 'check_perf_upper_thres': None,
+                'check_perf_unit': None,
                 'osuser':  os_ext.osuser()  or '<unknown>',
                 'osgroup': os_ext.osgroup() or '<unknown>',
                 'check_tags': None,
@@ -382,7 +383,7 @@ class LoggerAdapter(logging.LoggerAdapter):
             self.extra['check_jobid'] = self.check.job.jobid
 
     def log_performance(self, level, tag, value, ref,
-                        low_thres, upper_thres, msg=None):
+                        low_thres, upper_thres, unit=None, *, msg=None):
 
         # Update the performance-relevant extras and log the message
         self.extra['check_perf_var'] = tag
@@ -390,6 +391,7 @@ class LoggerAdapter(logging.LoggerAdapter):
         self.extra['check_perf_ref'] = ref
         self.extra['check_perf_lower_thres'] = low_thres
         self.extra['check_perf_upper_thres'] = upper_thres
+        self.extra['check_perf_unit'] = unit
         if msg is None:
             msg = 'sent by ' + self.extra['osuser']
 

--- a/reframe/core/pipeline.py
+++ b/reframe/core/pipeline.py
@@ -337,8 +337,26 @@ class RegressionTest:
 
     #: The set of reference values for this test.
     #:
-    #: Refer to the :doc:`ReFrame Tutorial </tutorial>` for concrete usage
-    #: examples.
+    #: The reference values are specified as a scoped dictionary keyed on the
+    #: performance variables defined in :attr:`perf_patterns` and scoped under
+    #: the system/partition combinations.
+    #: The reference itself is a three- or four-tuple that contains the
+    #: reference value, the lower and upper thresholds and, optionally, the
+    #: measurement unit.
+    #: An example follows:
+    #:
+    #: .. code:: python
+    #:
+    #:    self.reference = {
+    #:        'sys0:part0': {
+    #:            'perfvar0': (50, -0.1, 0.1, 'Gflop/s'),
+    #:            'perfvar1': (20, -0.1, 0.1, 'GB/s')
+    #:        },
+    #:        'sys0:part1': {
+    #:            'perfvar0': (100, -0.1, 0.1, 'Gflop/s'),
+    #:            'perfvar1': (40, -0.1, 0.1, 'GB/s')
+    #:        }
+    #:    }
     #:
     #: :type: A scoped dictionary with system names as scopes or :class:`None`
     #: :default: ``{}``
@@ -1096,20 +1114,18 @@ class RegressionTest:
             for tag, expr in self.perf_patterns.items():
                 value = evaluate(expr)
                 key = '%s:%s' % (self._current_partition.fullname, tag)
-                try:
-                    ref, low_thres, high_thres = self.reference[key]
-                except KeyError:
+                if not key in self.reference:
                     raise SanityError(
                         "tag `%s' not resolved in references for `%s'" %
                         (tag, self._current_partition.fullname))
 
                 perf_values.append((value, self.reference[key]))
                 self._perf_logger.log_performance(logging.INFO, tag, value,
-                                                  ref, low_thres, high_thres)
+                                                  *self.reference[key])
 
             for val, reference in perf_values:
-                refval, low_thres, high_thres = reference
-                evaluate(assert_reference(val, refval, low_thres, high_thres))
+                ref, low_thres, high_thres, *_ = reference
+                evaluate(assert_reference(val, ref, low_thres, high_thres))
 
     def _copy_job_files(self, job, dst):
         if job is None:

--- a/reframe/frontend/cli.py
+++ b/reframe/frontend/cli.py
@@ -260,7 +260,7 @@ def main():
         sys.exit(1)
 
     except (ConfigError, OSError) as e:
-        printer.error('configuration error %s' % e)
+        printer.error('configuration error: %s' % e)
         sys.exit(1)
 
     rt = runtime.runtime()

--- a/reframe/settings.py
+++ b/reframe/settings.py
@@ -90,7 +90,8 @@ class ReframeSettings:
                     '%(check_perf_var)s=%(check_perf_value)s|'
                     'ref=%(check_perf_ref)s '
                     '(l=%(check_perf_lower_thres)s, '
-                    'u=%(check_perf_upper_thres)s)'
+                    'u=%(check_perf_upper_thres)s)|'
+                    '%(check_perf_unit)s'
                 ),
                 'append': True
             }

--- a/tutorial/example7.py
+++ b/tutorial/example7.py
@@ -23,7 +23,7 @@ class Example7Test(rfm.RegressionTest):
         }
         self.reference = {
             'daint:gpu': {
-                'perf': (50.0, -0.1, 0.1),
+                'perf': (50.0, -0.1, 0.1, 'Gflop/s'),
             }
         }
         self.maintainers = ['you-can-type-your-email-here']

--- a/unittests/resources/checks/frontend_checks.py
+++ b/unittests/resources/checks/frontend_checks.py
@@ -11,7 +11,7 @@ class BaseFrontendCheck(rfm.RunOnlyRegressionTest):
     def __init__(self):
         super().__init__()
         self.local = True
-        self.executable = 'echo hello && echo perf: 10'
+        self.executable = 'echo hello && echo perf: 10 Gflop/s'
         self.sanity_patterns = sn.assert_found('hello', self.stdout)
         self.tags = {type(self).__name__}
         self.maintainers = ['VK']
@@ -75,7 +75,7 @@ class PerformanceFailureCheck(BaseFrontendCheck):
         }
         self.reference = {
             '*': {
-                'perf': (20, -0.1, 0.1)
+                'perf': (20, -0.1, 0.1, 'Gflop/s')
             }
         }
 

--- a/unittests/resources/settings.py
+++ b/unittests/resources/settings.py
@@ -138,7 +138,8 @@ class ReframeSettings:
                     '%(check_perf_var)s=%(check_perf_value)s|'
                     'ref=%(check_perf_ref)s '
                     '(l=%(check_perf_lower_thres)s, '
-                    'u=%(check_perf_upper_thres)s)'
+                    'u=%(check_perf_upper_thres)s)|'
+                    '%(check_perf_unit)s'
                 ),
                 'append': True
             }


### PR DESCRIPTION
- Reference tuple may optionally accept a fourth element specifying the unit of measurement of the performance value.
- The possibility of logging the units is also supplied.
- Unit tests are adjusted.
- CSCS performance logging configuration adjusted to log also the units.
- Documentation is added.

Fixes #321.