### PR TITLE
[feat] Update retries stage/output directory naming convention

### DIFF
--- a/reframe/core/pipeline.py
+++ b/reframe/core/pipeline.py
@@ -807,10 +807,10 @@ class RegressionTest:
             resources = rt.runtime().resources
             self._stagedir = resources.make_stagedir(
                 self.current_system.name, self._current_partition.name,
-                self._current_environ.name, self.name + resources.run_suffix())
+                self._current_environ.name, self.name)
             self._outputdir = resources.make_outputdir(
                 self.current_system.name, self._current_partition.name,
-                self._current_environ.name, self.name + resources.run_suffix())
+                self._current_environ.name, self.name)
         except OSError as e:
             raise PipelineError('failed to set up paths') from e
 

--- a/reframe/core/pipeline.py
+++ b/reframe/core/pipeline.py
@@ -804,12 +804,13 @@ class RegressionTest:
         """Setup the check's dynamic paths."""
         self.logger.debug('setting up paths')
         try:
-            self._stagedir = rt.runtime().resources.make_stagedir(
+            resources = rt.runtime().resources
+            self._stagedir = resources.make_stagedir(
                 self.current_system.name, self._current_partition.name,
-                self._current_environ.name, self.name)
-            self._outputdir = rt.runtime().resources.make_outputdir(
+                self._current_environ.name, self.name + resources.run_suffix())
+            self._outputdir = resources.make_outputdir(
                 self.current_system.name, self._current_partition.name,
-                self._current_environ.name, self.name)
+                self._current_environ.name, self.name + resources.run_suffix())
         except OSError as e:
             raise PipelineError('failed to set up paths') from e
 

--- a/reframe/core/runtime.py
+++ b/reframe/core/runtime.py
@@ -113,9 +113,18 @@ class HostResources:
         os.makedirs(ret, exist_ok=True)
         return ret
 
-    def run_suffix(self):
+    def _format_dirs(self, *dirs):
+        try:
+            last = dirs[-1]
+        except IndexError:
+            return dirs
+
         current_run = runtime().current_run
-        return '_retry%s' % current_run if current_run > 0 else ''
+        if current_run == 0:
+            return dirs
+
+        last += '@%s' % current_run
+        return (*dirs[:-1], last)
 
     @property
     def timestamp(self):
@@ -145,10 +154,12 @@ class HostResources:
             return self.perflogdir
 
     def make_stagedir(self, *dirs, wipeout=True):
-        return self._makedir(self.stage_prefix, *dirs, wipeout=wipeout)
+        return self._makedir(self.stage_prefix,
+                             *self._format_dirs(*dirs), wipeout=wipeout)
 
     def make_outputdir(self, *dirs, wipeout=True):
-        return self._makedir(self.output_prefix, *dirs, wipeout=wipeout)
+        return self._makedir(self.output_prefix,
+                             *self._format_dirs(*dirs), wipeout=wipeout)
 
 
 class RuntimeContext:

--- a/reframe/core/runtime.py
+++ b/reframe/core/runtime.py
@@ -113,9 +113,9 @@ class HostResources:
         os.makedirs(ret, exist_ok=True)
         return ret
 
-    def _run_suffix(self):
+    def run_suffix(self):
         current_run = runtime().current_run
-        return '_%s' % current_run if current_run > 0 else ''
+        return '_retry%s' % current_run if current_run > 0 else ''
 
     @property
     def timestamp(self):
@@ -125,21 +125,17 @@ class HostResources:
     def output_prefix(self):
         """The output prefix directory of ReFrame."""
         if self.outputdir is None:
-            return os.path.join(self.prefix, 'output' + self._run_suffix(),
-                                self.timestamp)
+            return os.path.join(self.prefix, 'output', self.timestamp)
         else:
-            return os.path.join(self.outputdir + self._run_suffix(),
-                                self.timestamp)
+            return os.path.join(self.outputdir, self.timestamp)
 
     @property
     def stage_prefix(self):
         """The stage prefix directory of ReFrame."""
         if self.stagedir is None:
-            return os.path.join(self.prefix, 'stage' + self._run_suffix(),
-                                self.timestamp)
+            return os.path.join(self.prefix, 'stage', self.timestamp)
         else:
-            return os.path.join(self.stagedir + self._run_suffix(),
-                                self.timestamp)
+            return os.path.join(self.stagedir, self.timestamp)
 
     @property
     def perflog_prefix(self):

--- a/reframe/core/runtime.py
+++ b/reframe/core/runtime.py
@@ -123,7 +123,7 @@ class HostResources:
         if current_run == 0:
             return dirs
 
-        last += '@%s' % current_run
+        last += '_retry%s' % current_run
         return (*dirs[:-1], last)
 
     @property


### PR DESCRIPTION
Modifies the behaviour of ReFrame to create stage and output folders as in the following example:
```
/path/to/stage/sys/part/env/testname
/path/to/stage/sys/part/env/testname_retry1
/path/to/stage/sys/part/env/testname_retry2
```

Closes  #536.