### PR TITLE
[bugfix] Check if 'UnavailableNodes' are down to cancel job

### DIFF
--- a/unittests/test_schedulers.py
+++ b/unittests/test_schedulers.py
@@ -802,7 +802,18 @@ class TestSlurmNode(unittest.TestCase):
     def test_str(self):
         self.assertEqual('nid00001', str(self.allocated_node))
 
+    def test_in_state(self):
+        self.assertTrue(self.allocated_node.in_state('ALLOCATED'))
+        self.assertFalse(self.idle_node.in_state('MAINT'))
+        self.assertTrue(self.idle_drained.in_state('IDLE'))
+        self.assertTrue(self.idle_drained.in_state('DRAIN'))
+
     def test_is_available(self):
         self.assertFalse(self.allocated_node.is_available())
         self.assertTrue(self.idle_node.is_available())
         self.assertFalse(self.idle_drained.is_available())
+
+    def test_is_down(self):
+        self.assertFalse(self.allocated_node.is_down())
+        self.assertFalse(self.idle_node.is_down())
+        self.assertTrue(self.idle_drained.is_down())


### PR DESCRIPTION
* Use scontrol to retrieve the state of the nodes reported
  as unavailable and cancel the job if they are down.

* Add methods `in_state` and `is_down` to `SlurmNode` class.

* Add unittests for the above methods.

Fixes #303 