### PR TITLE
[bugfix] Fix deadlock in the flexible task allocation when the node list output is too large

### DIFF
--- a/reframe/utility/os_ext.py
+++ b/reframe/utility/os_ext.py
@@ -21,17 +21,17 @@ from reframe.core.exceptions import (ReframeError, SpawnedProcessError,
 def run_command(cmd, check=False, timeout=None, shell=False):
     try:
         proc = run_command_async(cmd, shell=shell, start_new_session=True)
-        proc.wait(timeout=timeout)
+        proc_stdout, proc_stderr = proc.communicate(timeout=timeout)
     except subprocess.TimeoutExpired as e:
         os.killpg(proc.pid, signal.SIGKILL)
         raise SpawnedProcessTimeout(e.cmd,
-                                    proc.stdout.read(),
-                                    proc.stderr.read(), timeout) from None
+                                    proc.stdout,
+                                    proc.stderr, timeout) from None
 
     completed = subprocess.CompletedProcess(args=shlex.split(cmd),
                                             returncode=proc.returncode,
-                                            stdout=proc.stdout.read(),
-                                            stderr=proc.stderr.read())
+                                            stdout=proc_stdout,
+                                            stderr=proc_stderr)
 
     if check and proc.returncode != 0:
         raise SpawnedProcessError(completed.args,


### PR DESCRIPTION
* Replace `wait` with `communicate` for a spawned subprocess which
  doesn't block when the output is relatively large.

Closes #557 
