### PR TITLE
[feat] Omit printing "start/finished ..." for completely skipped tests

### DIFF
--- a/reframe/frontend/cli.py
+++ b/reframe/frontend/cli.py
@@ -45,6 +45,7 @@ def list_checks(checks, printer, detailed=False):
     printer.info('Found %d check(s).' % len(checks))
 
 
+# FIXME: This function is a duplicate of the corresponding function in the class Runner.
 def partition_supported(check, partition, options):
     if options.skip_system_check:
         return True
@@ -52,6 +53,7 @@ def partition_supported(check, partition, options):
     return check.supports_system(partition.name)
 
 
+# FIXME: This function is a duplicate of the corresponding function in the class Runner.
 def environ_supported(check, environ, options):
     ret = True
     if options.prgenv:

--- a/reframe/frontend/executors/__init__.py
+++ b/reframe/frontend/executors/__init__.py
@@ -170,7 +170,7 @@ class Runner:
     def runall(self, checks):
         try:
             self._printer.separator('short double line',
-                                    'Running %d check(s)' % len(checks))
+                                    'Processing %d check(s)' % len(checks))
             self._printer.timestamp('Started on', 'short double line')
             self._printer.info()
             self._runall(checks)
@@ -227,6 +227,8 @@ class Runner:
         self._policy.enter()
         for c in checks:
             self._policy.enter_check(c)
+            is_running = False
+            skip_count = 0
             for p in system.partitions:
                 if not self._partition_supported(c, p):
                     self._printer.status('SKIP',
@@ -245,6 +247,13 @@ class Runner:
                                              level=logging.VERBOSE)
                         continue
 
+                    if not is_running:
+                        is_running = True
+                        self._printer.separator(
+                            'short single line',
+                            'started running %s (%s)' % (c.name, c.descr)
+                        )
+
                     self._sandbox.system  = p
                     self._sandbox.environ = e
                     self._sandbox.check   = c
@@ -260,6 +269,14 @@ class Runner:
                                               self._sandbox.environ)
 
                 self._policy.exit_partition(c, p)
+
+            if is_running:
+                self._printer.separator(
+                    'short single line',
+                    'finished running %s (%s)' % (c.name, c.descr)
+                )
+            else:
+                skip_count += 1
 
             self._policy.exit_check(c)
 
@@ -307,15 +324,17 @@ class ExecutionPolicy:
         pass
 
     def enter_check(self, check):
-        self.printer.separator(
+        self.printer.status(
             'short single line',
-            'started processing %s (%s)' % (check.name, check.descr)
+            'started processing %s (%s)' % (check.name, check.descr),
+            level = logging.VERBOSE
         )
 
     def exit_check(self, check):
-        self.printer.separator(
+        self.printer.status(
             'short single line',
-            'finished processing %s (%s)\n' % (check.name, check.descr)
+            'finished processing %s (%s)\n' % (check.name, check.descr),
+            level=logging.VERBOSE
         )
 
     def enter_partition(self, c, p):

--- a/reframe/frontend/executors/__init__.py
+++ b/reframe/frontend/executors/__init__.py
@@ -170,7 +170,7 @@ class Runner:
     def runall(self, checks):
         try:
             self._printer.separator('short double line',
-                                    'Processing %d check(s)' % len(checks))
+                                    'Running %d check(s)' % len(checks))
             self._printer.timestamp('Started on', 'short double line')
             self._printer.info()
             self._runall(checks)
@@ -227,8 +227,6 @@ class Runner:
         self._policy.enter()
         for c in checks:
             self._policy.enter_check(c)
-            is_running = False
-            skip_count = 0
             for p in system.partitions:
                 if not self._partition_supported(c, p):
                     self._printer.status('SKIP',
@@ -247,13 +245,6 @@ class Runner:
                                              level=logging.VERBOSE)
                         continue
 
-                    if not is_running:
-                        is_running = True
-                        self._printer.separator(
-                            'short single line',
-                            'started running %s (%s)' % (c.name, c.descr)
-                        )
-
                     self._sandbox.system  = p
                     self._sandbox.environ = e
                     self._sandbox.check   = c
@@ -269,14 +260,6 @@ class Runner:
                                               self._sandbox.environ)
 
                 self._policy.exit_partition(c, p)
-
-            if is_running:
-                self._printer.separator(
-                    'short single line',
-                    'finished running %s (%s)' % (c.name, c.descr)
-                )
-            else:
-                skip_count += 1
 
             self._policy.exit_check(c)
 
@@ -324,17 +307,15 @@ class ExecutionPolicy:
         pass
 
     def enter_check(self, check):
-        self.printer.status(
+        self.printer.separator(
             'short single line',
-            'started processing %s (%s)' % (check.name, check.descr),
-            level = logging.VERBOSE
+            'started processing %s (%s)' % (check.name, check.descr)
         )
 
     def exit_check(self, check):
-        self.printer.status(
+        self.printer.separator(
             'short single line',
-            'finished processing %s (%s)\n' % (check.name, check.descr),
-            level=logging.VERBOSE
+            'finished processing %s (%s)\n' % (check.name, check.descr)
         )
 
     def enter_partition(self, c, p):


### PR DESCRIPTION
There are the following two possible solutions to improve the output of ReFrame:
1) filter first all test cases (printing filter results only in verbose mode), then run only the filtered test cases (print also in non-verbose mode). Seems to be a straightforward and clean solution; however, it is a considerable change to the implementation of ReFrame for filtering/launching tests (which could turn out actually also better for other issues).
2) filter the tests simply for one additional criteria: whether the test has test cases to be launched, given the partition and environments. This is the simplest solution; it leads though to a little bit of duplication of code currently; once #488 is solved, most of it will be removable.
3) keep the current implementation of ReFrame for filtering/launching tests cases (go through each test case, and run or skip it immediately) and improve the non-verbose output by delaying the "start processing/running <test>" until it is sure that at least one test case of <test> is run (this way the output is omitted if no test case is run). Problem: requires independent printing calls for verbose and non-verbose and needs in general quite some changes to the printing/logging mechanisms.

The solution 2 was chosen as it is simple and has several advantages over solution 3 (solution 1 would require many fundamental changes that we do not want - at least not now).

closes #411 