### PR TITLE
[docs] Add Google Analytics track to documentation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -112,6 +112,7 @@ html_theme_options = {
     'collapse_navigation': True,
     'display_version': True,
     'navigation_depth': 5,
+    'analytics_id': 'UA-86976416-6',
     #     # 'canonical_url': True,
 }
 


### PR DESCRIPTION
Include Google Analytics tracking capabilities to the documentation. 

The information on how to do it was taken from [here](
https://sphinx-rtd-theme.readthedocs.io/en/latest/configuring.html#project-wide-configuration).