### PR TITLE
Add option to increase output verbosity level

### DIFF
--- a/reframe/frontend/cli.py
+++ b/reframe/frontend/cli.py
@@ -86,6 +86,9 @@ def main():
         '--save-log-files', action='store_true', default=False,
         help='Copy the log file from the work dir to the output dir at the '
              'end of the program')
+    output_options.add_argument(
+        '--verbose', '-v', action='count',
+        help='Increase output verbosity level')
 
     # Check discovery options
     locate_options.add_argument(
@@ -258,6 +261,7 @@ def main():
     # Setup printer
     printer = PrettyPrinter()
     printer.colorize = options.colorize
+    printer.set_verbose_level(options.verbose)
 
     try:
         runtime.init_runtime(settings.site_configuration, options.system)
@@ -452,7 +456,7 @@ def main():
                 rt.modules_system.load_module(m, force=True)
                 raise EnvironError("test")
             except EnvironError as e:
-                printer.warning("could not load module '%s' correctly: " 
+                printer.warning("could not load module '%s' correctly: "
                                 "Skipping..." % m)
                 printer.debug(str(e))
 

--- a/reframe/frontend/printer.py
+++ b/reframe/frontend/printer.py
@@ -61,6 +61,14 @@ class PrettyPrinter:
     def __repr__(self):
         return debug.repr(self)
 
+    def set_verbose_level(self, number):
+        if not number:
+            self._logger.setLevel(logging.INFO)
+        elif number == 1:
+            self._logger.setLevel(logging.VERBOSE)
+        elif number >= 2:
+            self._logger.setLevel(logging.DEBUG)
+
     def separator(self, linestyle, msg=''):
         if linestyle == 'short double line':
             line = self.status_width * '='


### PR DESCRIPTION
This PR adds the option to increase the verbosity level of the
PrettyPrinter. However, there is only one call to printer.debug and
there is on call to printer.verbose in the entire code. The former is
related to a module not being properly loaded, which is difficult to
reproduce, since we do have correct checks on ReFrame.

I am not sure if it is part of the issue to also add the printer.debug
and printer.verbose calls into the code.