### PR TITLE
[doc] Document verbosity option

### DIFF
--- a/docs/running.rst
+++ b/docs/running.rst
@@ -829,6 +829,20 @@ The ReFrame's ``graylog`` handler sends log messages in JSON format using an HTT
 More details on this log format may be found `here <http://docs.graylog.org/en/latest/pages/gelf.html#gelf-payload-specification>`__.
 
 
+Adjusting verbosity of output
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+ReFrame's output is handled by a logging mechanism.
+In fact, as revealed in the corresponding configuration entry (see `Configuring Logging <#configuring-logging>`__), a specific logging handler takes care of printing ReFrame's message in the standard output.
+One way to change the verbosity level of the output is by explicitly setting the value of the ``level`` key in the configuration of the output handler.
+Alternatively, you may increase the verbosity level from the command line by chaining the ``-v`` or ``--verbose`` option.
+Every time ``-v`` is specified, the next verbosity level will be selected for the output.
+For example, if the initial level of the output handler is set to ``INFO`` (in the configuration file), specifying ``-v`` twice will make ReFrame spit out all ``DEBUG`` messages.
+
+.. versionadded:: 2.16
+   ``-v`` and ``--verbose`` options are added.
+
+
 Asynchronous Execution of Regression Checks
 -------------------------------------------
 

--- a/reframe/frontend/cli.py
+++ b/reframe/frontend/cli.py
@@ -87,9 +87,6 @@ def main():
         '--save-log-files', action='store_true', default=False,
         help='Copy the log file from the work dir to the output dir at the '
              'end of the program')
-    output_options.add_argument(
-        '--verbose', '-v', action='count', default=0,
-        help='Increase verbosity level of output')
 
     # Check discovery options
     locate_options.add_argument(
@@ -230,6 +227,8 @@ def main():
         help='Print configuration of environment ENV and exit')
     misc_options.add_argument('-V', '--version', action='version',
                               version=reframe.VERSION)
+    misc_options.add_argument('-v', '--verbose', action='count', default=0,
+                              help='Increase verbosity level of output')
 
     if len(sys.argv) == 1:
         argparser.print_help()


### PR DESCRIPTION
- Also move `-v` to `misc_options`.

Fixes #659.