### PR TITLE
[feat] Drop support for setting flags in environment

### DIFF
--- a/docs/configure.rst
+++ b/docs/configure.rst
@@ -302,8 +302,11 @@ The possible attributes of an environment are the following:
 * ``fflags``: The default Fortran compiler flags (default :class:`None`, valid for ``'ProgEnvironment'`` only).
 * ``ldflags``: The default linker flags (default :class:`None`, valid for ``'ProgEnvironment'`` only).
 
-.. note:: When defining programming environment flags, :class:`None` is treated differently from ``''`` for regression tests that are compiled through a Makefile.
-   If a flags variable is not :class:`None` it will be passed to the Makefile, which may affect the compilation process.
+.. note::
+   All flags for programming environments are now defined as list of strings instead of simple strings.
+
+   .. versionchanged:: 2.17
+
 
 System Auto-Detection
 ---------------------

--- a/reframe/core/buildsystems.py
+++ b/reframe/core/buildsystems.py
@@ -137,16 +137,6 @@ class BuildSystem:
 
         return None
 
-    def _fix_flags(self, flags):
-        # FIXME: That's a necessary workaround to the fact the environment
-        # defines flags as strings, but here as lists of strings. Should be
-        # removed as soon as setting directly the flags in an environment will
-        # be disabled.
-        if isinstance(flags, str):
-            return flags.split()
-        else:
-            return flags
-
     def _cc(self, environ):
         return self._resolve_flags('cc', environ)
 
@@ -160,19 +150,19 @@ class BuildSystem:
         return self._resolve_flags('nvcc', environ)
 
     def _cppflags(self, environ):
-        return self._fix_flags(self._resolve_flags('cppflags', environ))
+        return self._resolve_flags('cppflags', environ)
 
     def _cflags(self, environ):
-        return self._fix_flags(self._resolve_flags('cflags', environ))
+        return self._resolve_flags('cflags', environ)
 
     def _cxxflags(self, environ):
-        return self._fix_flags(self._resolve_flags('cxxflags', environ))
+        return self._resolve_flags('cxxflags', environ)
 
     def _fflags(self, environ):
-        return self._fix_flags(self._resolve_flags('fflags', environ))
+        return self._resolve_flags('fflags', environ)
 
     def _ldflags(self, environ):
-        return self._fix_flags(self._resolve_flags('ldflags', environ))
+        return self._resolve_flags('ldflags', environ)
 
 
 class Make(BuildSystem):

--- a/reframe/core/environments.py
+++ b/reframe/core/environments.py
@@ -237,104 +237,14 @@ class ProgEnvironment(Environment):
     :attr:`propagate` attribute to :class:`False`.
     """
 
-    #: The C compiler of this programming environment.
-    #:
-    #: :type: :class:`str`
-    cc = fields.DeprecatedField(fields.TypedField('cc', str),
-                                'setting this field is deprecated; '
-                                'please set it through a build system',
-                                fields.DeprecatedField.OP_SET)
-    _cc = fields.TypedField('cc', str)
-
-    #: The C++ compiler of this programming environment.
-    #:
-    #: :type: :class:`str` or :class:`None`
-    cxx = fields.DeprecatedField(fields.TypedField('cxx', str, type(None)),
-                                 'setting this field is deprecated; '
-                                 'please set it through a build system',
-                                 fields.DeprecatedField.OP_SET)
-    _cxx = fields.TypedField('cxx', str, type(None))
-
-    #: The Fortran compiler of this programming environment.
-    #:
-    #: :type: :class:`str` or :class:`None`
-    ftn = fields.DeprecatedField(fields.TypedField('ftn', str, type(None)),
-                                 'setting this field is deprecated; '
-                                 'please set it through a build system',
-                                 fields.DeprecatedField.OP_SET)
-    _ftn = fields.TypedField('ftn', str, type(None))
-
-    #: The preprocessor flags of this programming environment.
-    #:
-    #: :type: :class:`str` or :class:`None`
-    cppflags = fields.DeprecatedField(
-        fields.TypedField('cppflags', str, type(None)),
-        'setting this field is deprecated; '
-        'please set it through a build system',
-        fields.DeprecatedField.OP_SET)
-    _cppflags = fields.TypedField('cppflags', str, type(None))
-
-    #: The C compiler flags of this programming environment.
-    #:
-    #: :type: :class:`str` or :class:`None`
-    cflags = fields.DeprecatedField(
-        fields.TypedField('cflags', str, type(None)),
-        'setting this field is deprecated; '
-        'please set it through a build system',
-        fields.DeprecatedField.OP_SET)
-    _cflags = fields.TypedField('cflags', str, type(None))
-
-    #: The C++ compiler flags of this programming environment.
-    #:
-    #: :type: :class:`str` or :class:`None`
-    cxxflags = fields.DeprecatedField(
-        fields.TypedField('cxxflags', str, type(None)),
-        'setting this field is deprecated; '
-        'please set it through a build system',
-        fields.DeprecatedField.OP_SET)
-    _cxxflags = fields.TypedField('cxxflags', str, type(None))
-
-    #: The Fortran compiler flags of this programming environment.
-    #:
-    #: :type: :class:`str` or :class:`None`
-    fflags = fields.DeprecatedField(
-        fields.TypedField('fflags', str, type(None)),
-        'setting this field is deprecated; '
-        'please set it through a build system',
-        fields.DeprecatedField.OP_SET)
-    _fflags = fields.TypedField('fflags', str, type(None))
-
-    #: The linker flags of this programming environment.
-    #:
-    #: :type: :class:`str` or :class:`None`
-    ldflags = fields.DeprecatedField(
-        fields.TypedField('ldflags', str, type(None)),
-        'setting this field is deprecated; '
-        'please set it through a build system',
-        fields.DeprecatedField.OP_SET)
-    _ldflags = fields.TypedField('ldflags', str, type(None))
-
-    #: The include search path of this programming environment.
-    #:
-    #: :type: :class:`list` of :class:`str`
-    #: :default: ``[]``
-    include_search_path = fields.DeprecatedField(
-        fields.TypedField('include_search_path', typ.List[str]),
-        'setting this field is deprecated; '
-        'please set it through a build system',
-        fields.DeprecatedField.OP_SET)
-    _include_search_path = fields.TypedField('include_search_path',
-                                             typ.List[str])
-
-    #: Propagate the compilation flags to the ``make`` invocation.
-    #:
-    #: :type: :class:`bool`
-    #: :default: :class:`True`
-    propagate = fields.DeprecatedField(fields.TypedField('propagate', bool),
-                                       'setting this field is deprecated; '
-                                       'please set it through a build system',
-                                       fields.DeprecatedField.OP_SET)
-    _propagate = fields.TypedField('propagate', bool)
+    _cc = fields.TypedField('_cc', str)
+    _cxx = fields.TypedField('_cxx', str)
+    _ftn = fields.TypedField('_ftn', str)
+    _cppflags = fields.TypedField('_cppflags', typ.List[str], type(None))
+    _cflags = fields.TypedField('_cflags', typ.List[str], type(None))
+    _cxxflags = fields.TypedField('_cxxflags', typ.List[str], type(None))
+    _fflags = fields.TypedField('_fflags', typ.List[str], type(None))
+    _ldflags = fields.TypedField('_ldflags', typ.List[str], type(None))
 
     def __init__(self,
                  name,
@@ -360,8 +270,70 @@ class ProgEnvironment(Environment):
         self._cxxflags = cxxflags
         self._fflags = fflags
         self._ldflags = ldflags
-        self._include_search_path = []
-        self._propagate = True
+
+    @property
+    def cc(self):
+        """The C compiler of this programming environment.
+
+        :type: :class:`str`
+        """
+        return self._cc
+
+    @property
+    def cxx(self):
+        """The C++ compiler of this programming environment.
+
+        :type: :class:`str` or :class:`None`
+        """
+        return self._cxx
+
+    @property
+    def ftn(self):
+        """The Fortran compiler of this programming environment.
+
+        :type: :class:`str` or :class:`None`
+        """
+        return self._ftn
+
+    @property
+    def cppflags(self):
+        """The preprocessor flags of this programming environment.
+
+        :type: :class:`str` or :class:`None`
+        """
+        return self._cppflags
+
+    @property
+    def cflags(self):
+        """The C compiler flags of this programming environment.
+
+        :type: :class:`str` or :class:`None`
+        """
+        return self._cflags
+
+    @property
+    def cxxflags(self):
+        """The C++ compiler flags of this programming environment.
+
+        :type: :class:`str` or :class:`None`
+        """
+        return self._cxxflags
+
+    @property
+    def fflags(self):
+        """The Fortran compiler flags of this programming environment.
+
+        :type: :class:`str` or :class:`None`
+        """
+        return self._fflags
+
+    @property
+    def ldflags(self):
+        """The linker flags of this programming environment.
+
+        :type: :class:`str` or :class:`None`
+        """
+        return self._ldflags
 
     @property
     def nvcc(self):

--- a/reframe/core/fields.py
+++ b/reframe/core/fields.py
@@ -64,8 +64,8 @@ class TypedField(Field):
         if not any(isinstance(value, t) for t in self._types):
             typedescr = '|'.join(t.__name__ for t in self._types)
             raise TypeError(
-                "failed to set field '%s': type mismatch: "
-                "required type is '%s'" % (self._name, typedescr))
+                "failed to set field '%s': '%s' is not of type '%s'" %
+                (self._name, value, typedescr))
 
     def __set__(self, obj, value):
         self._check_type(value)

--- a/reframe/frontend/cli.py
+++ b/reframe/frontend/cli.py
@@ -3,6 +3,7 @@ import inspect
 import json
 import socket
 import sys
+import traceback
 
 import reframe
 import reframe.core.config as config
@@ -273,9 +274,9 @@ def main():
         printer.error("could not auto-detect system; please use the "
                       "`--system' option to specify one explicitly")
         sys.exit(1)
-
-    except (ConfigError, OSError) as e:
+    except Exception as e:
         printer.error('configuration error: %s' % e)
+        printer.verbose(''.join(traceback.format_exception(*sys.exc_info())))
         sys.exit(1)
 
     rt = runtime.runtime()

--- a/unittests/test_buildsystems.py
+++ b/unittests/test_buildsystems.py
@@ -16,11 +16,11 @@ class _BuildSystemTest:
                                        cc='gcc',
                                        cxx='g++',
                                        ftn='gfortran',
-                                       cppflags='-DNDEBUG',
-                                       cflags='-Wall -std=c99',
-                                       cxxflags='-Wall -std=c++11',
-                                       fflags='-Wall',
-                                       ldflags='-dynamic')
+                                       cppflags=['-DNDEBUG'],
+                                       cflags=['-Wall', '-std=c99'],
+                                       cxxflags=['-Wall', '-std=c++11'],
+                                       fflags=['-Wall'],
+                                       ldflags=['-dynamic'])
         self.build_system = self.create_build_system()
 
     def setup_base_buildsystem(self):

--- a/unittests/test_environments.py
+++ b/unittests/test_environments.py
@@ -192,6 +192,36 @@ class TestEnvironment(unittest.TestCase):
         commands.append('foo')
         self.assertNotIn('foo', self.environ.emit_load_commands())
 
+        # Test ProgEnvironment
+        prgenv = renv.ProgEnvironment('foo_prgenv')
+        self.assertIsInstance(prgenv, renv.Environment)
+        with self.assertRaises(AttributeError):
+            prgenv.cc = 'gcc'
+
+        with self.assertRaises(AttributeError):
+            prgenv.cxx = 'g++'
+
+        with self.assertRaises(AttributeError):
+            prgenv.ftn = 'gfortran'
+
+        with self.assertRaises(AttributeError):
+            prgenv.nvcc = 'clang'
+
+        with self.assertRaises(AttributeError):
+            prgenv.cppflags = ['-DFOO']
+
+        with self.assertRaises(AttributeError):
+            prgenv.cflags = ['-O1']
+
+        with self.assertRaises(AttributeError):
+            prgenv.cxxflags = ['-O1']
+
+        with self.assertRaises(AttributeError):
+            prgenv.fflags = ['-O1']
+
+        with self.assertRaises(AttributeError):
+            prgenv.ldflags = ['-lm']
+
     def test_immutability_after_load(self):
         self.environ.load()
         self.test_immutability()


### PR DESCRIPTION
This has been deprecated since 2.14. This change will also break configuration files that were setting the compiler flags through simple strings. Currently, a list of strings is required there as well. A message about the type mismatch is now being printed in such cases. This PR also brings a better message for type mismatches in attribute validation.