### PR TITLE
[bugfix] Fix bug ignoring a partition defined in 'access'

### DIFF
--- a/reframe/core/schedulers/__init__.py
+++ b/reframe/core/schedulers/__init__.py
@@ -265,9 +265,9 @@ class Job(abc.ABC):
 
             return self.sched_flex_alloc_tasks
 
-        available_nodes = self.list_all_nodes()
-        getlogger().debug('flex_alloc_tasks: total available nodes %s '
-                          % len(available_nodes))
+        available_nodes = self.get_all_nodes()
+        getlogger().debug('flex_alloc_tasks: total available nodes %s ' %
+                          len(available_nodes))
 
         # Try to guess the number of tasks now
         available_nodes = self.filter_nodes(available_nodes,
@@ -285,8 +285,8 @@ class Job(abc.ABC):
         return num_tasks
 
     @abc.abstractmethod
-    def list_all_nodes(self):
-        # Lists all the available nodes
+    def get_all_nodes(self):
+        # Gets all the available nodes
         pass
 
     @abc.abstractmethod

--- a/reframe/core/schedulers/__init__.py
+++ b/reframe/core/schedulers/__init__.py
@@ -265,12 +265,13 @@ class Job(abc.ABC):
 
             return self.sched_flex_alloc_tasks
 
-        available_nodes = self.get_partition_nodes()
-        getlogger().debug('flex_alloc_tasks: total available nodes in current '
-                          'virtual partition: %s' % len(available_nodes))
+        available_nodes = self.list_all_nodes()
+        getlogger().debug('flex_alloc_tasks: total available nodes %s '
+                          % len(available_nodes))
 
         # Try to guess the number of tasks now
-        available_nodes = self.filter_nodes(available_nodes, self.options)
+        available_nodes = self.filter_nodes(available_nodes,
+                                            self.sched_access + self.options)
 
         if self.sched_flex_alloc_tasks == 'idle':
             available_nodes = {n for n in available_nodes
@@ -284,8 +285,8 @@ class Job(abc.ABC):
         return num_tasks
 
     @abc.abstractmethod
-    def get_partition_nodes(self):
-        # Get all nodes of the current virtual partition
+    def list_all_nodes(self):
+        # Lists all the available nodes
         pass
 
     @abc.abstractmethod

--- a/reframe/core/schedulers/local.py
+++ b/reframe/core/schedulers/local.py
@@ -60,7 +60,7 @@ class LocalJob(sched.Job):
     def emit_preamble(self):
         return []
 
-    def get_partition_nodes(self):
+    def list_all_nodes(self):
         raise NotImplementedError(
             'local scheduler does not support listing of available nodes')
 

--- a/reframe/core/schedulers/local.py
+++ b/reframe/core/schedulers/local.py
@@ -60,7 +60,7 @@ class LocalJob(sched.Job):
     def emit_preamble(self):
         return []
 
-    def list_all_nodes(self):
+    def get_all_nodes(self):
         raise NotImplementedError(
             'local scheduler does not support listing of available nodes')
 

--- a/reframe/core/schedulers/pbs.py
+++ b/reframe/core/schedulers/pbs.py
@@ -88,7 +88,7 @@ class PbsJob(sched.Job):
         preamble.append('cd %s' % self.workdir)
         return preamble
 
-    def get_partition_nodes(self):
+    def list_all_nodes(self):
         raise NotImplementedError('pbs backend does not support node listing')
 
     def filter_nodes(self, nodes, options):

--- a/reframe/core/schedulers/pbs.py
+++ b/reframe/core/schedulers/pbs.py
@@ -88,7 +88,7 @@ class PbsJob(sched.Job):
         preamble.append('cd %s' % self.workdir)
         return preamble
 
-    def list_all_nodes(self):
+    def get_all_nodes(self):
         raise NotImplementedError('pbs backend does not support node listing')
 
     def filter_nodes(self, nodes, options):

--- a/reframe/core/schedulers/slurm.py
+++ b/reframe/core/schedulers/slurm.py
@@ -152,7 +152,7 @@ class SlurmJob(sched.Job):
 
         self._jobid = int(jobid_match.group('jobid'))
 
-    def _get_all_nodes(self):
+    def list_all_nodes(self):
         try:
             completed = _run_strict('scontrol -a show -o nodes')
         except SpawnedProcessError as e:
@@ -169,10 +169,6 @@ class SlurmJob(sched.Job):
             return partition_match.group('partition')
 
         return None
-
-    def get_partition_nodes(self):
-        nodes = self._get_all_nodes()
-        return self.filter_nodes(nodes, self.sched_access)
 
     def filter_nodes(self, nodes, options):
         option_parser = ArgumentParser()
@@ -199,6 +195,8 @@ class SlurmJob(sched.Job):
         else:
             default_partition = self._get_default_partition()
             partitions = {default_partition} if default_partition else set()
+            getlogger().debug('flex_alloc_tasks: default partition: %s' %
+                              default_partition)
 
         nodes = {n for n in nodes if n.partitions >= partitions}
         getlogger().debug(
@@ -217,7 +215,7 @@ class SlurmJob(sched.Job):
             nodes &= self._get_nodes_by_name(nodelist)
             getlogger().debug(
                 'flex_alloc_tasks: filtering nodes by nodelist: %s '
-                'availablenodes now: %s' % (nodelist, len(nodes)))
+                'available nodes now: %s' % (nodelist, len(nodes)))
 
         if exclude_nodes:
             exclude_nodes = exclude_nodes.strip()
@@ -431,10 +429,11 @@ class SlurmNode:
             raise JobError('could not extract NodeName from node description')
 
         self._partitions = self._extract_attribute(
-            'Partitions', node_descr, sep=',')
+            'Partitions', node_descr, sep=',') or set()
         self._active_features = self._extract_attribute(
-            'ActiveFeatures', node_descr, sep=',')
-        self._states = self._extract_attribute('State', node_descr, sep='+')
+            'ActiveFeatures', node_descr, sep=',') or set()
+        self._states = self._extract_attribute(
+            'State', node_descr, sep='+') or set()
 
     def __eq__(self, other):
         if not isinstance(other, type(self)):

--- a/reframe/core/schedulers/slurm.py
+++ b/reframe/core/schedulers/slurm.py
@@ -152,7 +152,7 @@ class SlurmJob(sched.Job):
 
         self._jobid = int(jobid_match.group('jobid'))
 
-    def list_all_nodes(self):
+    def get_all_nodes(self):
         try:
             completed = _run_strict('scontrol -a show -o nodes')
         except SpawnedProcessError as e:

--- a/unittests/test_launchers.py
+++ b/unittests/test_launchers.py
@@ -22,7 +22,7 @@ class FakeJob(Job):
     def finished(self):
         pass
 
-    def list_all_nodes(self):
+    def get_all_nodes(self):
         pass
 
     def filter_nodes(self, nodes):

--- a/unittests/test_launchers.py
+++ b/unittests/test_launchers.py
@@ -22,7 +22,7 @@ class FakeJob(Job):
     def finished(self):
         pass
 
-    def get_partition_nodes(self):
+    def list_all_nodes(self):
         pass
 
     def filter_nodes(self, nodes):

--- a/unittests/test_schedulers.py
+++ b/unittests/test_schedulers.py
@@ -393,9 +393,9 @@ class TestSlurmJob(_TestJob, unittest.TestCase):
     def test_guess_num_tasks(self):
         self.testjob._num_tasks = 0
         self.testjob._sched_flex_alloc_tasks = 'all'
-        # monkey patch `get_partition_nodes()` to simulate extraction of
+        # monkey patch `list_all_nodes()` to simulate extraction of
         # slurm nodes through the use of `scontrol show`
-        self.testjob.get_partition_nodes = lambda: set()
+        self.testjob.list_all_nodes = lambda: set()
         # monkey patch `_get_default_partition()` to simulate extraction
         # of the default partition through the use of `scontrol show`
         self.testjob._get_default_partition = lambda: 'pdef'
@@ -566,6 +566,23 @@ class TestSlurmFlexibleNodeAllocation(unittest.TestCase):
                              'AllocTRES= CapWatts=n/a CurrentWatts=100 '
                              'LowestJoules=100000000 ConsumedJoules=0 '
                              'ExtSensorsJoules=n/s ExtSensorsWatts=0 '
+                             'ExtSensorsTemp=n/s Reason=Foo/ ',
+
+                             'NodeName=nid00005 Arch=x86_64 CoresPerSocket=12 '
+                             'CPUAlloc=0 CPUErr=0 CPUTot=24 CPULoad=0.00 '
+                             'AvailableFeatures=f5 ActiveFeatures=f5 '
+                             'Gres=gpu_mem:16280,gpu:1 NodeAddr=nid00003'
+                             'NodeHostName=nid00003 Version=10.00 OS=Linux '
+                             'RealMemory=32220 AllocMem=0 FreeMem=10000 '
+                             'Sockets=1 Boards=1 State=ALLOCATED '
+                             'ThreadsPerCore=2 TmpDisk=0 Weight=1 Owner=N/A '
+                             'MCS_label=N/A Partitions=p1,p3 '
+                             'BootTime=01 Jan 2018 '
+                             'SlurmdStartTime=01 Jan 2018 '
+                             'CfgTRES=cpu=24,mem=32220M '
+                             'AllocTRES= CapWatts=n/a CurrentWatts=100 '
+                             'LowestJoules=100000000 ConsumedJoules=0 '
+                             'ExtSensorsJoules=n/s ExtSensorsWatts=0 '
                              'ExtSensorsTemp=n/s Reason=Foo/ '
                              'failed [reframe_user@01 Jan 2018]']
 
@@ -589,9 +606,9 @@ class TestSlurmFlexibleNodeAllocation(unittest.TestCase):
             stdout=os.path.join(self.workdir, 'testjob.out'),
             stderr=os.path.join(self.workdir, 'testjob.err')
         )
-        # monkey patch `_get_all_nodes` to simulate extraction of
+        # monkey patch `list_all_nodes` to simulate extraction of
         # slurm nodes through the use of `scontrol show`
-        self.testjob._get_all_nodes = self.create_dummy_nodes
+        self.testjob.list_all_nodes = self.create_dummy_nodes
         # monkey patch `_get_default_partition` to simulate extraction
         # of the default partition
         self.testjob._get_default_partition = lambda: 'pdef'
@@ -631,6 +648,16 @@ class TestSlurmFlexibleNodeAllocation(unittest.TestCase):
         self.testjob._sched_access = ['--constraint=f1', '--partition=p2']
         self.prepare_job()
         self.assertEqual(self.testjob.num_tasks, 4)
+
+    def test_sched_access_partition(self):
+        self.testjob._sched_access = ['--partition=p1']
+        self.prepare_job()
+        self.assertEqual(self.testjob.num_tasks, 16)
+
+    def test_default_partition_all(self):
+        self.testjob._sched_flex_alloc_tasks = 'all'
+        self.prepare_job()
+        self.assertEqual(self.testjob.num_tasks, 16)
 
     def test_constraint_idle(self):
         self.testjob._sched_flex_alloc_tasks = 'idle'
@@ -876,7 +903,7 @@ class TestSlurmNode(unittest.TestCase):
         self.assertEqual(self.allocated_node.partitions, {'p1', 'p2'})
         self.assertEqual(self.allocated_node.active_features, {'f1', 'f2'})
         self.assertEqual(self.no_partition_node.name, 'nid00004')
-        self.assertEqual(self.no_partition_node.partitions, None)
+        self.assertEqual(self.no_partition_node.partitions, set())
         self.assertEqual(self.no_partition_node.active_features, {'f1', 'f2'})
 
     def test_str(self):

--- a/unittests/test_schedulers.py
+++ b/unittests/test_schedulers.py
@@ -393,9 +393,9 @@ class TestSlurmJob(_TestJob, unittest.TestCase):
     def test_guess_num_tasks(self):
         self.testjob._num_tasks = 0
         self.testjob._sched_flex_alloc_tasks = 'all'
-        # monkey patch `list_all_nodes()` to simulate extraction of
+        # monkey patch `get_all_nodes()` to simulate extraction of
         # slurm nodes through the use of `scontrol show`
-        self.testjob.list_all_nodes = lambda: set()
+        self.testjob.get_all_nodes = lambda: set()
         # monkey patch `_get_default_partition()` to simulate extraction
         # of the default partition through the use of `scontrol show`
         self.testjob._get_default_partition = lambda: 'pdef'
@@ -606,9 +606,9 @@ class TestSlurmFlexibleNodeAllocation(unittest.TestCase):
             stdout=os.path.join(self.workdir, 'testjob.out'),
             stderr=os.path.join(self.workdir, 'testjob.err')
         )
-        # monkey patch `list_all_nodes` to simulate extraction of
+        # monkey patch `get_all_nodes` to simulate extraction of
         # slurm nodes through the use of `scontrol show`
-        self.testjob.list_all_nodes = self.create_dummy_nodes
+        self.testjob.get_all_nodes = self.create_dummy_nodes
         # monkey patch `_get_default_partition` to simulate extraction
         # of the default partition
         self.testjob._get_default_partition = lambda: 'pdef'


### PR DESCRIPTION
* `SlurmNode` attributes are set to empty sets if they cannot be
  retrieved by the corresponding description.

* Create abstract method `get_all_nodes` on the base `Job` class.

* Remove method `get_partition_nodes`.

* Create more unittests for flexible allocation.

Fixes #692 