### PR TITLE
[feat] Remove support for passing options to the `RegressionTest.compile()` method

### DIFF
--- a/reframe/core/pipeline.py
+++ b/reframe/core/pipeline.py
@@ -924,11 +924,9 @@ class RegressionTest:
                           (url, self._stagedir))
         os_ext.git_clone(self.sourcesdir, self._stagedir)
 
-    def compile(self, **compile_opts):
+    def compile(self):
         """The compilation phase of the regression test pipeline.
 
-        :arg compile_opts: Extra options to be passed to the programming
-            environment for compiling the source code of the test.
         :raises reframe.core.exceptions.ReframeError: In case of errors.
         """
         if not self._current_environ:
@@ -988,20 +986,6 @@ class RegressionTest:
 
             self.build_system.srcfile = self.sourcepath
             self.build_system.executable = self.executable
-
-        if compile_opts:
-            user_deprecation_warning(
-                'passing options to the compile() method is deprecated; '
-                'please use a build system.')
-
-            # Remove source and executable from compile_opts
-            compile_opts.pop('source', None)
-            compile_opts.pop('executable', None)
-            try:
-                self.build_system.makefile = compile_opts['makefile']
-                self.build_system.options  = compile_opts['options']
-            except KeyError:
-                pass
 
         # Prepare build job
         build_commands = [
@@ -1204,7 +1188,7 @@ class RunOnlyRegressionTest(RegressionTest):
     module.
     """
 
-    def compile(self, **compile_opts):
+    def compile(self):
         """The compilation phase of the regression test pipeline.
 
         This is a no-op for this type of test.

--- a/reframe/core/pipeline.py
+++ b/reframe/core/pipeline.py
@@ -23,8 +23,7 @@ import reframe.utility.typecheck as typ
 from reframe.core.buildsystems import BuildSystem, BuildSystemField
 from reframe.core.deferrable import deferrable, _DeferredExpression, evaluate
 from reframe.core.environments import Environment, EnvironmentSnapshot
-from reframe.core.exceptions import (BuildError, PipelineError, SanityError,
-                                     user_deprecation_warning)
+from reframe.core.exceptions import BuildError, PipelineError, SanityError
 from reframe.core.launchers.registry import getlauncher
 from reframe.core.schedulers import Job
 from reframe.core.schedulers.registry import getscheduler


### PR DESCRIPTION
- It has been deprecated since 2.14.

This is a follow-up of #678.