### PR TITLE
[doc] Move documentation to readthedocs.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Users can create their own test hierarchies, create test factories for generatin
 
 ## Documentation
 
-The official documentation is maintained [here](https://reframe-hpc.readthedocs.org).
+The official documentation is maintained [here](https://eth-cscs.github.io/reframe/index.html).
 It corresponds to the [latest](https://github.com/eth-cscs/reframe/releases/latest) stable release and not to the current status of the `master`.
 
 ### Building the documentation from master

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/eth-cscs/reframe.svg?branch=master)](https://travis-ci.org/eth-cscs/reframe) [![codecov.io](https://codecov.io/gh/eth-cscs/reframe/branch/master/graph/badge.svg)](https://codecov.io/github/eth-cscs/reframe) [![Documentation Status](https://readthedocs.org/projects/reframe-hpc/badge/?version=stable)](https://reframe-hpc.readthedocs.io/en/stable/?badge=stable) 
+[![Build Status](https://travis-ci.org/eth-cscs/reframe.svg?branch=master)](https://travis-ci.org/eth-cscs/reframe) [![codecov.io](https://codecov.io/gh/eth-cscs/reframe/branch/master/graph/badge.svg)](https://codecov.io/github/eth-cscs/reframe) [![Documentation Status](https://readthedocs.org/projects/reframe-hpc/badge/?version=stable)](https://reframe-hpc.readthedocs.io/en/stable/?badge=stable)
 
 # ReFrame
 
@@ -16,12 +16,12 @@ Users can create their own test hierarchies, create test factories for generatin
 
 ## Documentation
 
-The official documentation is maintained [here](https://eth-cscs.github.io/reframe/index.html).
+The official documentation is maintained [here](https://reframe-hpc.readthedocs.org).
 It corresponds to the [latest](https://github.com/eth-cscs/reframe/releases/latest) stable release and not to the current status of the `master`.
 
 ### Building the documentation from master
 
-You may build the documentation of the master either with Python 2 or Python 3 (<= 3.5).
+You may build the documentation of the master either with Python 2 or Python 3.
 Here is how to do it:
 
 ```

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/eth-cscs/reframe.svg?branch=master)](https://travis-ci.org/eth-cscs/reframe) [![codecov.io](https://codecov.io/gh/eth-cscs/reframe/branch/master/graph/badge.svg)](https://codecov.io/github/eth-cscs/reframe) [![Documentation Status](https://readthedocs.org/projects/reframe-hpc/badge/?version=stable)](https://reframe-hpc.readthedocs.io/en/stable/?badge=stable)
+[![Build Status](https://travis-ci.org/eth-cscs/reframe.svg?branch=master)](https://travis-ci.org/eth-cscs/reframe) [![codecov.io](https://codecov.io/gh/eth-cscs/reframe/branch/master/graph/badge.svg)](https://codecov.io/github/eth-cscs/reframe) [![Documentation Status](https://readthedocs.org/projects/reframe-hpc/badge/?version=latest)](https://reframe-hpc.readthedocs.io/en/latest/?badge=latest)
 
 # ReFrame
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-[![Build Status](https://travis-ci.org/eth-cscs/reframe.svg?branch=master)](https://travis-ci.org/eth-cscs/reframe) [![codecov.io](https://codecov.io/gh/eth-cscs/reframe/branch/master/graph/badge.svg)](https://codecov.io/github/eth-cscs/reframe) [![Documentation Status](https://readthedocs.org/projects/reframe-hpc/badge/?version=latest)](https://reframe-hpc.readthedocs.io/en/latest/?badge=latest)
+[![Build Status](https://travis-ci.org/eth-cscs/reframe.svg?branch=master)](https://travis-ci.org/eth-cscs/reframe)
+[![Documentation Status](https://readthedocs.org/projects/reframe-hpc/badge/?version=latest)](https://reframe-hpc.readthedocs.io/en/latest/?badge=latest)
+[![codecov.io](https://codecov.io/gh/eth-cscs/reframe/branch/master/graph/badge.svg)](https://codecov.io/github/eth-cscs/reframe)
 
 # ReFrame
 
@@ -16,12 +18,15 @@ Users can create their own test hierarchies, create test factories for generatin
 
 ## Documentation
 
-The official documentation is maintained [here](https://eth-cscs.github.io/reframe/index.html).
-It corresponds to the [latest](https://github.com/eth-cscs/reframe/releases/latest) stable release and not to the current status of the `master`.
+You may find the official documentation of the latest release and the current master in the following links:
 
-### Building the documentation from master
+- [Latest release](https://reframe-hpc.readthedocs.io)
+- [Current master](https://reframe-hpc.readthedocs.io/en/latest)
 
-You may build the documentation of the master either with Python 2 or Python 3.
+
+### Building the documentation locally
+
+You may build the documentation of the master locally either with Python 2 or Python 3.
 Here is how to do it:
 
 ```

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/eth-cscs/reframe.svg?branch=master)](https://travis-ci.org/eth-cscs/reframe) [![codecov.io](https://codecov.io/gh/eth-cscs/reframe/branch/master/graph/badge.svg)](https://codecov.io/github/eth-cscs/reframe)
+[![Build Status](https://travis-ci.org/eth-cscs/reframe.svg?branch=master)](https://travis-ci.org/eth-cscs/reframe) [![codecov.io](https://codecov.io/gh/eth-cscs/reframe/branch/master/graph/badge.svg)](https://codecov.io/github/eth-cscs/reframe) [![Documentation Status](https://readthedocs.org/projects/reframe-hpc/badge/?version=stable)](https://reframe-hpc.readthedocs.io/en/stable/?badge=stable) 
 
 # ReFrame
 

--- a/ci-scripts/deploy.sh
+++ b/ci-scripts/deploy.sh
@@ -44,25 +44,13 @@ if [ $found_version != $version ]; then
     exit 1
 fi
 
-python3 -m venv venv.docs
-source venv.docs/bin/activate
+python3 -m venv venv.deployment
+source venv.deployment/bin/activate
 pip install --upgrade pip
 pip install -r requirements.txt
-pip install -r docs/requirements.txt
 ./test_reframe.py
 git tag -a v$version -m "ReFrame $version"
 git push origin --tags
-make -C docs
-cd ..
-git clone -b gh-pages https://github.com/eth-cscs/reframe.git reframe-doc
-cd reframe-doc
-rsync -avz ../reframe/docs/html/ .
-echo "Please visit http://localhost:8000/ and " \
-     "check that the documentation is fine."
-echo "Press Ctrl-C to continue when ready."
-python3 -m http.server
-git commit -a -m "ReFrame $version documentation"
-git push origin gh-pages
 deactivate
 cd $oldpwd
 echo "Deployment was successful!"

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -7,11 +7,9 @@ PYTHON      = python3
 SPHINXOPTS  =
 SPHINXBUILD =  -msphinx
 SPHINXPROJ  = ReFrame
-SPHINX_VERS = sphinx-versioning
 SOURCEDIR   = .
 BUILDDIR    = $(VERSION)
 RM          = /bin/rm -rf
-TAG_VERS    = '^v\d+(\.\d+)*[a-z]*'
 
 TARGET_DOCS := \
 	help \
@@ -39,9 +37,6 @@ TARGET_DOCS := \
 	doctest \
 	coverage
 
-all:
-	@$(SPHINX_VERS) -l conf.py build docs/ html/
-
 latest:
 	@make html
 	@touch html/.nojekyll
@@ -55,4 +50,4 @@ $(TARGET_DOCS): Makefile
 
 
 
-.PHONY: all clean latest Makefile
+.PHONY: clean latest Makefile

--- a/docs/_templates/breadcrumbs.html
+++ b/docs/_templates/breadcrumbs.html
@@ -1,5 +1,6 @@
 <div role="navigation" aria-label="breadcrumbs navigation">
   <div style="text-align: center; margin-bottom: -1.5em; display: block"></div>
+  <div style="text-align: center; margin-bottom: 0.5em; display: block; color:#2980B9"><b>ReFrame v{{version}}</b></div>
   <ul class="wy-breadcrumbs">
     <li><a href="{{ pathto(master_doc) }}">Docs</a> &raquo;</li>
       {% for doc in parents %}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -63,7 +63,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'ReFrame'
-copyright = '2017-2018, CSCS'
+copyright = '2017-2019, CSCS'
 author = 'CSCS'
 
 # The version info for the project you're documenting, acts as replacement for
@@ -112,7 +112,7 @@ html_theme_options = {
     'collapse_navigation': True,
     'display_version': True,
     'navigation_depth': 5,
-    'analytics_id': 'UA-86976416-6',
+    # 'analytics_id': 'UA-86976416-6',
     #     # 'canonical_url': True,
 }
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -112,7 +112,6 @@ html_theme_options = {
     'collapse_navigation': True,
     'display_version': True,
     'navigation_depth': 5,
-    # 'analytics_id': 'UA-86976416-6',
     #     # 'canonical_url': True,
 }
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -18,7 +18,7 @@ requests>=2.18.4
 setuptools>=31.0.1
 six>=1.11.0
 snowballstemmer>=1.2.1
-Sphinx<=1.6.7
+Sphinx
 sphinx-autobuild>=0.7.1
 sphinx-bootstrap-theme>=0.5.3
 sphinx-fakeinv>=1.0.0


### PR DESCRIPTION
Modifications based on moving the documentation to [readthedocs.org](reframe-hpc.readthedocs.org)

Closes #688 