### PR TITLE
[bugfix] Fix Slurm backend failures when trying node lists with inexistent nodes

### DIFF
--- a/reframe/core/schedulers/slurm.py
+++ b/reframe/core/schedulers/slurm.py
@@ -240,7 +240,7 @@ class SlurmJob(sched.Job):
         return {SlurmNode(descr) for descr in node_descriptions}
 
     def _get_nodes_by_name(self, nodespec):
-        completed = _run_command('scontrol -a show -o node %s' % nodespec)
+        completed = run_command('scontrol -a show -o node %s' % nodespec)
         node_descriptions = completed.stdout.splitlines()
         nodes_avail = set()
         for descr in node_descriptions:

--- a/reframe/core/schedulers/slurm.py
+++ b/reframe/core/schedulers/slurm.py
@@ -240,7 +240,8 @@ class SlurmJob(sched.Job):
         return {SlurmNode(descr) for descr in node_descriptions}
 
     def _get_nodes_by_name(self, nodespec):
-        completed = run_command('scontrol -a show -o node %s' % nodespec)
+        completed = os_ext.run_command('scontrol -a show -o node %s'
+                                       % nodespec)
         node_descriptions = completed.stdout.splitlines()
         nodes_avail = set()
         for descr in node_descriptions:

--- a/reframe/core/schedulers/slurm.py
+++ b/reframe/core/schedulers/slurm.py
@@ -240,8 +240,8 @@ class SlurmJob(sched.Job):
         return {SlurmNode(descr) for descr in node_descriptions}
 
     def _get_nodes_by_name(self, nodespec):
-        completed = os_ext.run_command('scontrol -a show -o node %s'
-                                       % nodespec)
+        completed = os_ext.run_command('scontrol -a show -o node %s' %
+                                       nodespec)
         node_descriptions = completed.stdout.splitlines()
         nodes_avail = set()
         for descr in node_descriptions:

--- a/reframe/core/schedulers/slurm.py
+++ b/reframe/core/schedulers/slurm.py
@@ -240,14 +240,16 @@ class SlurmJob(sched.Job):
         return {SlurmNode(descr) for descr in node_descriptions}
 
     def _get_nodes_by_name(self, nodespec):
-        try:
-            completed = _run_strict('scontrol -a show -o node %s' % nodespec)
-        except SpawnedProcessError as e:
-            raise JobError('could not retrieve the node description '
-                           'of nodes: %s' % nodespec) from e
-
+        completed = _run_command('scontrol -a show -o node %s' % nodespec)
         node_descriptions = completed.stdout.splitlines()
-        return {SlurmNode(descr) for descr in node_descriptions}
+        nodes_avail = set()
+        for descr in node_descriptions:
+            try:
+                nodes_avail.add(SlurmNode(descr))
+            except JobError:
+                pass
+
+        return nodes_avail
 
     def _set_nodelist(self, nodespec):
         if self._nodelist is not None:


### PR DESCRIPTION
Modifying the way the set of available nodes is built in SLURM, in order to prevent erroneous entries (e. g. "not found")

Fixes #694 