### PR TITLE
[bugfix] Define the set of run environments correctly when `-p` option is used with regular expressions

### DIFF
--- a/reframe/frontend/cli.py
+++ b/reframe/frontend/cli.py
@@ -1,6 +1,7 @@
 import inspect
 import json
 import os
+import re
 import socket
 import sys
 import traceback
@@ -452,6 +453,12 @@ def main():
 
         checks_matched = [c for c in checks_matched]
 
+        # Determine the programming environments to run with
+        run_environs = {e.name
+                        for env_patt in options.prgenv
+                        for p in rt.system.partitions
+                        for e in p.environs if re.match(env_patt, e.name)}
+
         # Act on checks
 
         # Unload regression's module and load user-specified modules
@@ -496,7 +503,7 @@ def main():
             exec_policy.skip_environ_check = options.skip_prgenv_check
             exec_policy.skip_sanity_check = options.skip_sanity_check
             exec_policy.skip_performance_check = options.skip_performance_check
-            exec_policy.only_environs = options.prgenv
+            exec_policy.only_environs = run_environs
             exec_policy.keep_stage_files = options.keep_stage_files
             try:
                 errmsg = "invalid option for --flex-alloc-tasks: '{0}'"

--- a/unittests/test_cli.py
+++ b/unittests/test_cli.py
@@ -148,12 +148,16 @@ class TestFrontend(unittest.TestCase):
         self.local = False
         self.system = partition.fullname
 
-        # pick up the programming environment of the partition
-        self.environs = [partition.environs[0].name]
+        # Pick up the programming environment of the partition
+        # Prepend ^ and append $ so as to much exactly the given name
+        self.environs = ['^' + partition.environs[0].name + '$']
 
         returncode, stdout, _ = self._run_reframe()
         self.assertNotIn('FAILED', stdout)
         self.assertIn('PASSED', stdout)
+
+        # Assert that we have run only one test case
+        self.assertIn('Ran 1 test case(s)', stdout)
         self.assertEqual(0, returncode)
 
     def test_check_failure(self):


### PR DESCRIPTION
This PR fixes the behaviour of the `-p` option when it is used with regular expressions. The `-p` option has also the effect of restricting the programming environments to run with. Although this still works fine in old-style cases, e.g., `-p PrgEnv-gnu`, it fails to do so when passing regular expressions, for example, `-p PrgEnv-(gnu|pgi)`. Although this will select all the tests that support either `PrgEnv-gnu` or `PrgEnv-pgi`, it will not run them. This PR fixes this.