### PR TITLE
[bugfix] Fix crash in flexible task allocation due to refactoring of `SystemPartition`

### DIFF
--- a/reframe/core/schedulers/__init__.py
+++ b/reframe/core/schedulers/__init__.py
@@ -270,8 +270,10 @@ class Job(abc.ABC):
                           len(available_nodes))
 
         # Try to guess the number of tasks now
-        available_nodes = self.filter_nodes(available_nodes,
-                                            self.sched_access + self.options)
+        # Append `options` to a list containing the elements of `sched_access`
+        # whis is immutable.
+        available_nodes = self.filter_nodes(
+            available_nodes, list(self.sched_access) + self.options)
 
         if self.sched_flex_alloc_tasks == 'idle':
             available_nodes = {n for n in available_nodes

--- a/reframe/core/schedulers/__init__.py
+++ b/reframe/core/schedulers/__init__.py
@@ -270,10 +270,8 @@ class Job(abc.ABC):
                           len(available_nodes))
 
         # Try to guess the number of tasks now
-        # Append `options` to a list containing the elements of `sched_access`
-        # whis is immutable.
-        available_nodes = self.filter_nodes(
-            available_nodes, list(self.sched_access) + self.options)
+        available_nodes = self.filter_nodes(available_nodes,
+                                            self.sched_access + self.options)
 
         if self.sched_flex_alloc_tasks == 'idle':
             available_nodes = {n for n in available_nodes

--- a/reframe/utility/__init__.py
+++ b/reframe/utility/__init__.py
@@ -273,6 +273,21 @@ class SequenceView(collections.abc.Sequence):
     def __reversed__(self, *args, **kwargs):
         return self.__container.__reversed__(*args, **kwargs)
 
+    def __add__(self, other):
+        if not isinstance(other, collections.abc.Sequence):
+            return NotImplemented
+
+        return SequenceView(self.__container + other)
+
+    def __iadd__(self, other):
+        return NotImplemented
+
+    def __eq__(self, other):
+        if not isinstance(other, collections.abc.Sequence):
+            return NotImplemented
+
+        return self.__container == other
+
 
 class MappingView(collections.abc.Mapping):
     """A read-only view of a mapping."""

--- a/unittests/test_utility.py
+++ b/unittests/test_utility.py
@@ -771,14 +771,22 @@ class TestReadOnlyViews(unittest.TestCase):
         self.assertEqual(2, l.count(2))
 
         # Assert immutability
+        m = l + [3, 4]
+        self.assertEqual([1, 2, 2, 3, 4], m)
+        self.assertIsInstance(m, util.SequenceView)
+
+        m = l
+        l += [3, 4]
+        self.assertIsNot(m, l)
+        self.assertEqual([1, 2, 2], m)
+        self.assertEqual([1, 2, 2, 3, 4], l)
+        self.assertIsInstance(l, util.SequenceView)
+
         with self.assertRaises(TypeError):
             l[1] = 3
 
         with self.assertRaises(TypeError):
             l[1:2] = [3]
-
-        with self.assertRaises(TypeError):
-            l += [3, 4]
 
         with self.assertRaises(TypeError):
             l *= 3


### PR DESCRIPTION
* Create a list with the contents of `sched_access` and append
  the `options` to it.

Fixes #728 