### PR TITLE
[test] Update libsci_acc_symlink tests for PE19.03

### DIFF
--- a/cscs-checks/compile/libsci_acc_symlink.py
+++ b/cscs-checks/compile/libsci_acc_symlink.py
@@ -4,10 +4,8 @@ import reframe as rfm
 import reframe.utility.sanity as sn
 
 
-@rfm.parameterized_test(['libsci_acc_gnu_49_nv20'],
-                        ['libsci_acc_gnu_49_nv35'],
-                        ['libsci_acc_gnu_49_nv60'],
-                        ['libsci_acc_cray_nv20_openacc'],
+@rfm.parameterized_test(['libsci_acc_gnu_71_nv35'],
+                        ['libsci_acc_gnu_71_nv60'],
                         ['libsci_acc_cray_nv35_openacc'],
                         ['libsci_acc_cray_nv60_openacc'])
 class LibSciAccSymLinkTest(rfm.RunOnlyRegressionTest):


### PR DESCRIPTION
* Remove nv20 related tests.

* Use 71 for the compiler version.