### PR TITLE
[bugfix] Fix duplicate module commands emitted while executing test cases

### DIFF
--- a/reframe/frontend/executors/__init__.py
+++ b/reframe/frontend/executors/__init__.py
@@ -23,9 +23,7 @@ class TestCase:
         self.__check_orig = check
         self.__check = copy.deepcopy(check)
         self.__environ = copy.deepcopy(environ)
-
-        # Partitions are immutable; no need to clone them
-        self.__partition = partition
+        self.__partition = copy.deepcopy(partition)
 
     def __iter__(self):
         # Allow unpacking a test case with a single liner:

--- a/reframe/frontend/executors/__init__.py
+++ b/reframe/frontend/executors/__init__.py
@@ -10,7 +10,6 @@ from reframe.core.exceptions import (AbortTaskError, JobNotStartedError,
                                      ReframeFatalError, TaskExit)
 from reframe.frontend.printer import PrettyPrinter
 from reframe.frontend.statistics import TestStats
-from reframe.utility.sandbox import Sandbox
 
 ABORT_REASONS = (KeyboardInterrupt, ReframeFatalError, AssertionError)
 
@@ -23,10 +22,10 @@ class TestCase:
     def __init__(self, check, partition, environ):
         self.__check_orig = check
         self.__check = copy.deepcopy(check)
+        self.__environ = copy.deepcopy(environ)
 
-        # Environments and partitions are immutable; no need to clone them
+        # Partitions are immutable; no need to clone them
         self.__partition = partition
-        self.__environ = environ
 
     def __iter__(self):
         # Allow unpacking a test case with a single liner:
@@ -220,7 +219,6 @@ class Runner:
         self._stats = TestStats()
         self._policy.stats = self._stats
         self._policy.printer = self._printer
-        self._sandbox = Sandbox()
         self._environ_snapshot = EnvironmentSnapshot()
 
     def __repr__(self):

--- a/reframe/utility/sandbox.py
+++ b/reframe/utility/sandbox.py
@@ -1,8 +1,0 @@
-from reframe.core.fields import CopyOnWriteField
-
-
-class Sandbox:
-    """Sandbox class for manipulating shared resources."""
-    environ = CopyOnWriteField('environ')
-    system  = CopyOnWriteField('system')
-    check   = CopyOnWriteField('check')

--- a/unittests/test_fields.py
+++ b/unittests/test_fields.py
@@ -108,21 +108,6 @@ class TestFields(unittest.TestCase):
         self.assertRaises(ValueError, exec, 'tester.field = (100, 3, 65)',
                           globals(), locals())
 
-    def test_sandbox(self):
-        from reframe.core.environments import Environment
-        from reframe.core.systems import System
-        from reframe.utility.sandbox import Sandbox
-
-        environ = Environment('myenv')
-        system  = System('mysystem')
-
-        sandbox = Sandbox()
-        sandbox.environ = environ
-        sandbox.system  = system
-
-        self.assertIsNot(system, sandbox.system)
-        self.assertIsNot(environ, sandbox.environ)
-
     def test_proxy_field(self):
         class Target:
             def __init__(self):


### PR DESCRIPTION
- This fixes the problem with the duplicate module commands. Essentially, we revert back to the original solution of deep-copying the environments and the partitions. Environments are not immutable, since they hold a state. Similarly, since a partition holds a reference to its local environment, it's not immutable as well.
- This PR removes also the stale `Sandbox` class.

Fixes #737.