### PR TITLE
[feat] Remove deprecated `--logdir` command-line option and the corresponding attribute in the logging configuration

### DIFF
--- a/docs/configure.rst
+++ b/docs/configure.rst
@@ -104,16 +104,19 @@ The valid attributes of a system are the following:
 * ``stagedir``: Default stage directory for this system (default :class:`None`).
 * ``outputdir``: Default output directory for this system (default :class:`None`).
 * ``perflogdir``: Default directory prefix for storing performance logs for this system (default :class:`None`).
-* ``logdir``: `Deprecated since version 2.14 please use` ``perflogdir`` `instead.`
 * ``resourcesdir``: Default directory for storing large resources (e.g., input data files, etc.) needed by regression tests for this system (default ``.``).
 * ``partitions``: A set of key/value pairs defining the partitions of this system and their properties (default ``{}``).
   Partition configuration is discussed in the `next section <#partition-configuration>`__.
+
+For a more detailed description of the ``prefix``, ``stagedir``, ``outputdir`` and ``perflogdir`` directories, please refer to the `"Configuring ReFrame Directories" <running.html#configuring-reframe-directories>`__ and `"Performance Logging" <running.html#performance-logging>`__ sections.
 
 .. note::
   .. versionadded:: 2.8
     The ``modules_system`` key was introduced for specifying custom modules systems for different systems.
 
-For a more detailed description of the ``prefix``, ``stagedir``, ``outputdir`` and ``perflogdir`` directories, please refer to the `"Configuring ReFrame Directories" <running.html#configuring-reframe-directories>`__ and `"Performance Logging" <running.html#performance-logging>`__ sections.
+.. warning::
+   .. versionchanged:: 2.18
+    The ``logdir`` key is no more supported; please use ``perflogdir`` instead.
 
 Partition Configuration
 -----------------------

--- a/reframe/core/config.py
+++ b/reframe/core/config.py
@@ -7,9 +7,7 @@ import reframe.utility as util
 import reframe.utility.os_ext as os_ext
 import reframe.utility.typecheck as types
 from reframe.core.exceptions import (ConfigError,
-                                     ReframeError,
-                                     ReframeFatalError,
-                                     user_deprecation_warning)
+                                     ReframeError, ReframeFatalError)
 
 
 _settings = None
@@ -159,13 +157,6 @@ class SiteConfiguration:
 
             if sys_outputdir:
                 sys_outputdir = os_ext.expandvars(sys_outputdir)
-
-            if sys_logdir:
-                user_deprecation_warning(
-                    "`logdir' attribute in system config is deprecated; "
-                    "please use `perflogdir' instead"
-                )
-                sys_perflogdir = os_ext.expandvars(sys_logdir)
 
             if sys_perflogdir:
                 sys_perflogdir = os_ext.expandvars(sys_perflogdir)

--- a/reframe/frontend/cli.py
+++ b/reframe/frontend/cli.py
@@ -75,9 +75,6 @@ def main():
         '-s', '--stage', action='store', metavar='DIR',
         help='Set regression stage directory to DIR')
     output_options.add_argument(
-        '--logdir', action='store', metavar='DIR',
-        help='(deprecated) Use --perflogdir instead.')
-    output_options.add_argument(
         '--perflogdir', action='store', metavar='DIR',
         help='Set directory prefix for the performance logs '
         '(default: ${prefix}/perflogs, '
@@ -238,12 +235,6 @@ def main():
 
     # Parse command line
     options = argparser.parse_args()
-
-    if options.logdir:
-        sys.stderr.write('WARNING: --logdir option is deprecated; '
-                         'please use --perflogdir instead.\n')
-        if not options.perflogdir:
-            options.perflogdir = options.logdir
 
     # Load configuration
     try:


### PR DESCRIPTION
Closes https://jira.cscs.ch/browse/UES-254