### PR TITLE
[feat] Enable environment variable substitution in shell code emitted by build systems

### DIFF
--- a/reframe/core/buildsystems.py
+++ b/reframe/core/buildsystems.py
@@ -172,7 +172,7 @@ class Make(BuildSystem):
 
     .. code::
 
-      make -j [N] [-f MAKEFILE] [-C SRCDIR] CC='X' CXX='X' FC='X' NVCC='X' CPPFLAGS='X' CFLAGS='X' CXXFLAGS='X' FCFLAGS='X' LDFLAGS='X' OPTIONS
+      make -j [N] [-f MAKEFILE] [-C SRCDIR] CC="X" CXX="X" FC="X" NVCC="X" CPPFLAGS="X" CFLAGS="X" CXXFLAGS="X" FCFLAGS="X" LDFLAGS="X" OPTIONS
 
     The compiler and compiler flags variables will only be passed if they are
     not :class:`None`.
@@ -246,31 +246,31 @@ class Make(BuildSystem):
         fflags   = self._fflags(environ)
         ldflags  = self._ldflags(environ)
         if cc is not None:
-            cmd_parts += ["CC='%s'" % cc]
+            cmd_parts += ['CC="%s"' % cc]
 
         if cxx is not None:
-            cmd_parts += ["CXX='%s'" % cxx]
+            cmd_parts += ['CXX="%s"' % cxx]
 
         if ftn is not None:
-            cmd_parts += ["FC='%s'" % ftn]
+            cmd_parts += ['FC="%s"' % ftn]
 
         if nvcc is not None:
-            cmd_parts += ["NVCC='%s'" % nvcc]
+            cmd_parts += ['NVCC="%s"' % nvcc]
 
         if cppflags is not None:
-            cmd_parts += ["CPPFLAGS='%s'" % ' '.join(cppflags)]
+            cmd_parts += ['CPPFLAGS="%s"' % ' '.join(cppflags)]
 
         if cflags is not None:
-            cmd_parts += ["CFLAGS='%s'" % ' '.join(cflags)]
+            cmd_parts += ['CFLAGS="%s"' % ' '.join(cflags)]
 
         if cxxflags is not None:
-            cmd_parts += ["CXXFLAGS='%s'" % ' '.join(cxxflags)]
+            cmd_parts += ['CXXFLAGS="%s"' % ' '.join(cxxflags)]
 
         if fflags is not None:
-            cmd_parts += ["FCFLAGS='%s'" % ' '.join(fflags)]
+            cmd_parts += ['FCFLAGS="%s"' % ' '.join(fflags)]
 
         if ldflags is not None:
-            cmd_parts += ["LDFLAGS='%s'" % ' '.join(ldflags)]
+            cmd_parts += ['LDFLAGS="%s"' % ' '.join(ldflags)]
 
         if self.options:
             cmd_parts += self.options
@@ -521,28 +521,28 @@ class CMake(ConfigureBasedBuildSystem):
         fflags   = self._combine_flags(cppflags, self._fflags(environ))
         ldflags  = self._ldflags(environ)
         if cc is not None:
-            cmake_cmd += ["-DCMAKE_C_COMPILER='%s'" % cc]
+            cmake_cmd += ['-DCMAKE_C_COMPILER="%s"' % cc]
 
         if cxx is not None:
-            cmake_cmd += ["-DCMAKE_CXX_COMPILER='%s'" % cxx]
+            cmake_cmd += ['-DCMAKE_CXX_COMPILER="%s"' % cxx]
 
         if ftn is not None:
-            cmake_cmd += ["-DCMAKE_Fortran_COMPILER='%s'" % ftn]
+            cmake_cmd += ['-DCMAKE_Fortran_COMPILER="%s"' % ftn]
 
         if nvcc is not None:
-            cmake_cmd += ["-DCMAKE_CUDA_COMPILER='%s'" % nvcc]
+            cmake_cmd += ['-DCMAKE_CUDA_COMPILER="%s"' % nvcc]
 
         if cflags is not None:
-            cmake_cmd += ["-DCMAKE_C_FLAGS='%s'" % ' '.join(cflags)]
+            cmake_cmd += ['-DCMAKE_C_FLAGS="%s"' % ' '.join(cflags)]
 
         if cxxflags is not None:
-            cmake_cmd += ["-DCMAKE_CXX_FLAGS='%s'" % ' '.join(cxxflags)]
+            cmake_cmd += ['-DCMAKE_CXX_FLAGS="%s"' % ' '.join(cxxflags)]
 
         if fflags is not None:
-            cmake_cmd += ["-DCMAKE_Fortran_FLAGS='%s'" % ' '.join(fflags)]
+            cmake_cmd += ['-DCMAKE_Fortran_FLAGS="%s"' % ' '.join(fflags)]
 
         if ldflags is not None:
-            cmake_cmd += ["-DCMAKE_EXE_LINKER_FLAGS='%s'" % ' '.join(ldflags)]
+            cmake_cmd += ['-DCMAKE_EXE_LINKER_FLAGS="%s"' % ' '.join(ldflags)]
 
         if self.config_opts:
             cmake_cmd += self.config_opts
@@ -599,28 +599,28 @@ class Autotools(ConfigureBasedBuildSystem):
         fflags   = self._fflags(environ)
         ldflags  = self._ldflags(environ)
         if cc is not None:
-            configure_cmd += ["CC='%s'" % cc]
+            configure_cmd += ['CC="%s"' % cc]
 
         if cxx is not None:
-            configure_cmd += ["CXX='%s'" % cxx]
+            configure_cmd += ['CXX="%s"' % cxx]
 
         if ftn is not None:
-            configure_cmd += ["FC='%s'" % ftn]
+            configure_cmd += ['FC="%s"' % ftn]
 
         if cppflags is not None:
-            configure_cmd += ["CPPFLAGS='%s'" % ' '.join(cppflags)]
+            configure_cmd += ['CPPFLAGS="%s"' % ' '.join(cppflags)]
 
         if cflags is not None:
-            configure_cmd += ["CFLAGS='%s'" % ' '.join(cflags)]
+            configure_cmd += ['CFLAGS="%s"' % ' '.join(cflags)]
 
         if cxxflags is not None:
-            configure_cmd += ["CXXFLAGS='%s'" % ' '.join(cxxflags)]
+            configure_cmd += ['CXXFLAGS="%s"' % ' '.join(cxxflags)]
 
         if fflags is not None:
-            configure_cmd += ["FCFLAGS='%s'" % ' '.join(fflags)]
+            configure_cmd += ['FCFLAGS="%s"' % ' '.join(fflags)]
 
         if ldflags is not None:
-            configure_cmd += ["LDFLAGS='%s'" % ' '.join(ldflags)]
+            configure_cmd += ['LDFLAGS="%s"' % ' '.join(ldflags)]
 
         if self.config_opts:
             configure_cmd += self.config_opts

--- a/unittests/test_buildsystems.py
+++ b/unittests/test_buildsystems.py
@@ -45,10 +45,10 @@ class TestMake(_BuildSystemTest, unittest.TestCase):
         self.build_system.options = ['FOO=1']
         self.build_system.max_concurrency = 32
         expected = [
-            "make -f Makefile_foo -C foodir -j 32 CC='gcc' CXX='g++' "
-            "FC='gfortran' NVCC='nvcc' CPPFLAGS='-DNDEBUG' "
-            "CFLAGS='-Wall -std=c99' CXXFLAGS='-Wall -std=c++11' "
-            "FCFLAGS='-Wall' LDFLAGS='-dynamic' FOO=1"
+            'make -f Makefile_foo -C foodir -j 32 CC="gcc" CXX="g++" '
+            'FC="gfortran" NVCC="nvcc" CPPFLAGS="-DNDEBUG" '
+            'CFLAGS="-Wall -std=c99" CXXFLAGS="-Wall -std=c++11" '
+            'FCFLAGS="-Wall" LDFLAGS="-dynamic" FOO=1'
         ]
         self.assertEqual(expected,
                          self.build_system.emit_build_commands(self.environ))
@@ -60,10 +60,10 @@ class TestMake(_BuildSystemTest, unittest.TestCase):
         self.build_system.options = ['FOO=1']
         self.build_system.max_concurrency = None
         expected = [
-            "make -f Makefile_foo -C foodir -j CC='cc' CXX='CC' FC='ftn' "
-            "NVCC='clang' CPPFLAGS='-DFOO' CFLAGS='-Wall -std=c99 -O3' "
-            "CXXFLAGS='-Wall -std=c++11 -O3' FCFLAGS='-Wall -O3' "
-            "LDFLAGS='-static' FOO=1"
+            'make -f Makefile_foo -C foodir -j CC="cc" CXX="CC" FC="ftn" '
+            'NVCC="clang" CPPFLAGS="-DFOO" CFLAGS="-Wall -std=c99 -O3" '
+            'CXXFLAGS="-Wall -std=c++11 -O3" FCFLAGS="-Wall -O3" '
+            'LDFLAGS="-static" FOO=1'
         ]
         self.assertEqual(expected,
                          self.build_system.emit_build_commands(self.environ))
@@ -85,17 +85,17 @@ class TestCMake(_BuildSystemTest, unittest.TestCase):
         self.build_system.make_opts = ['install']
         self.build_system.max_concurrency = 32
         expected = [
-            "cd src",
-            "mkdir -p build/foo",
-            "cd build/foo",
-            "cmake -DCMAKE_C_COMPILER='gcc' -DCMAKE_CXX_COMPILER='g++' "
-            "-DCMAKE_Fortran_COMPILER='gfortran' "
-            "-DCMAKE_CUDA_COMPILER='nvcc' "
-            "-DCMAKE_C_FLAGS='-DNDEBUG -Wall -std=c99' "
-            "-DCMAKE_CXX_FLAGS='-DNDEBUG -Wall -std=c++11' "
-            "-DCMAKE_Fortran_FLAGS='-DNDEBUG -Wall' "
-            "-DCMAKE_EXE_LINKER_FLAGS='-dynamic' -DFOO=1 ../..",
-            "make -j 32 install"
+            'cd src',
+            'mkdir -p build/foo',
+            'cd build/foo',
+            'cmake -DCMAKE_C_COMPILER="gcc" -DCMAKE_CXX_COMPILER="g++" '
+            '-DCMAKE_Fortran_COMPILER="gfortran" '
+            '-DCMAKE_CUDA_COMPILER="nvcc" '
+            '-DCMAKE_C_FLAGS="-DNDEBUG -Wall -std=c99" '
+            '-DCMAKE_CXX_FLAGS="-DNDEBUG -Wall -std=c++11" '
+            '-DCMAKE_Fortran_FLAGS="-DNDEBUG -Wall" '
+            '-DCMAKE_EXE_LINKER_FLAGS="-dynamic" -DFOO=1 ../..',
+            'make -j 32 install'
 
         ]
         self.assertEqual(expected,
@@ -107,15 +107,15 @@ class TestCMake(_BuildSystemTest, unittest.TestCase):
         self.build_system.config_opts = ['-DFOO=1']
         self.build_system.max_concurrency = None
         expected = [
-            "mkdir -p build/foo",
-            "cd build/foo",
-            "cmake -DCMAKE_C_COMPILER='cc' -DCMAKE_CXX_COMPILER='CC' "
-            "-DCMAKE_Fortran_COMPILER='ftn' -DCMAKE_CUDA_COMPILER='clang' "
-            "-DCMAKE_C_FLAGS='-DFOO -Wall -std=c99 -O3' "
-            "-DCMAKE_CXX_FLAGS='-DFOO -Wall -std=c++11 -O3' "
-            "-DCMAKE_Fortran_FLAGS='-DFOO -Wall -O3' "
-            "-DCMAKE_EXE_LINKER_FLAGS='-static' -DFOO=1 ../..",
-            "make -j"
+            'mkdir -p build/foo',
+            'cd build/foo',
+            'cmake -DCMAKE_C_COMPILER="cc" -DCMAKE_CXX_COMPILER="CC" '
+            '-DCMAKE_Fortran_COMPILER="ftn" -DCMAKE_CUDA_COMPILER="clang" '
+            '-DCMAKE_C_FLAGS="-DFOO -Wall -std=c99 -O3" '
+            '-DCMAKE_CXX_FLAGS="-DFOO -Wall -std=c++11 -O3" '
+            '-DCMAKE_Fortran_FLAGS="-DFOO -Wall -O3" '
+            '-DCMAKE_EXE_LINKER_FLAGS="-static" -DFOO=1 ../..',
+            'make -j'
 
         ]
         print(self.build_system.emit_build_commands(self.environ))
@@ -139,14 +139,14 @@ class TestAutotools(_BuildSystemTest, unittest.TestCase):
         self.build_system.make_opts = ['check']
         self.build_system.max_concurrency = 32
         expected = [
-            "cd src",
-            "mkdir -p build/foo",
-            "cd build/foo",
-            "../../configure CC='gcc' CXX='g++' FC='gfortran' "
-            "CPPFLAGS='-DNDEBUG' CFLAGS='-Wall -std=c99' "
-            "CXXFLAGS='-Wall -std=c++11' FCFLAGS='-Wall' "
-            "LDFLAGS='-dynamic' FOO=1",
-            "make -j 32 check"
+            'cd src',
+            'mkdir -p build/foo',
+            'cd build/foo',
+            '../../configure CC="gcc" CXX="g++" FC="gfortran" '
+            'CPPFLAGS="-DNDEBUG" CFLAGS="-Wall -std=c99" '
+            'CXXFLAGS="-Wall -std=c++11" FCFLAGS="-Wall" '
+            'LDFLAGS="-dynamic" FOO=1',
+            'make -j 32 check'
 
         ]
         self.assertEqual(expected,
@@ -158,13 +158,13 @@ class TestAutotools(_BuildSystemTest, unittest.TestCase):
         self.build_system.config_opts = ['FOO=1']
         self.build_system.max_concurrency = None
         expected = [
-            "mkdir -p build/foo",
-            "cd build/foo",
-            "../../configure CC='cc' CXX='CC' FC='ftn' "
-            "CPPFLAGS='-DFOO' CFLAGS='-Wall -std=c99 -O3' "
-            "CXXFLAGS='-Wall -std=c++11 -O3' FCFLAGS='-Wall -O3' "
-            "LDFLAGS='-static' FOO=1",
-            "make -j"
+            'mkdir -p build/foo',
+            'cd build/foo',
+            '../../configure CC="cc" CXX="CC" FC="ftn" '
+            'CPPFLAGS="-DFOO" CFLAGS="-Wall -std=c99 -O3" '
+            'CXXFLAGS="-Wall -std=c++11 -O3" FCFLAGS="-Wall -O3" '
+            'LDFLAGS="-static" FOO=1',
+            'make -j'
 
         ]
         print(self.build_system.emit_build_commands(self.environ))


### PR DESCRIPTION
This was achieved by simply using double quotes instead of single ones in the emitted variables, e.g., `CXXFLAGS="-Wall -std=c++11 $MOREFLAGS". In your test you may write things like the following:

```python
self.build_system.cxxflags = '-Wall -std=c++11 $MOREFLAGS'
```

Fixes #702.