### PR TITLE
[bugfix] Do not crash when invalid regular expressions are passed to the test selection options

### DIFF
--- a/reframe/frontend/check_filters.py
+++ b/reframe/frontend/check_filters.py
@@ -7,8 +7,7 @@ from reframe.core.exceptions import ReframeError
 
 def re_compile(patt):
     try:
-        regex = re.compile(patt)
-        return regex
+        return re.compile(patt)
     except re.error:
         raise ReframeError("invalid regex: '%s'" % patt)
 

--- a/reframe/frontend/check_filters.py
+++ b/reframe/frontend/check_filters.py
@@ -2,10 +2,19 @@ import re
 
 import reframe.core.runtime as rt
 import reframe.utility.sanity as util
+from reframe.core.exceptions import ReframeError
+
+
+def re_compile(patt):
+    try:
+        regex = re.compile(patt)
+        return regex
+    except re.error:
+        raise ReframeError("invalid regex: '%s'" % patt)
 
 
 def have_name(patt):
-    regex = re.compile(patt)
+    regex = re_compile(patt)
 
     def _fn(c):
         return regex.match(c.name)
@@ -21,7 +30,7 @@ def have_not_name(patt):
 
 
 def have_tag(patt):
-    regex = re.compile(patt)
+    regex = re_compile(patt)
 
     def _fn(c):
         return any(regex.match(p) for p in c.tags)
@@ -30,7 +39,7 @@ def have_tag(patt):
 
 
 def have_prgenv(patt):
-    regex = re.compile(patt)
+    regex = re_compile(patt)
 
     def _fn(c):
         if '*' in c.valid_prog_environs:

--- a/unittests/test_check_filters.py
+++ b/unittests/test_check_filters.py
@@ -93,8 +93,8 @@ class TestCheckFilters(unittest.TestCase):
         self.assertEqual(1, self.count_checks(filters.have_cpu_only()))
 
     def test_invalid_regex(self):
-        # We need to explicitly call `evaluate` to trigger the exception
-        # to make sure the exception is triggered in all cases
+        # We need to explicitly call `evaluate` to make sure the exception
+        # is triggered in all cases
         with self.assertRaises(ReframeError):
             self.count_checks(filters.have_name('*foo')).evaluate()
 

--- a/unittests/test_check_filters.py
+++ b/unittests/test_check_filters.py
@@ -5,6 +5,7 @@ import reframe.frontend.check_filters as filters
 import reframe.utility.sanity as sn
 import unittests.fixtures as fixtures
 from reframe.core.pipeline import RegressionTest
+from reframe.core.exceptions import ReframeError
 
 
 class TestCheckFilters(unittest.TestCase):
@@ -90,3 +91,18 @@ class TestCheckFilters(unittest.TestCase):
 
     def test_have_cpu_only(self):
         self.assertEqual(1, self.count_checks(filters.have_cpu_only()))
+
+    def test_invalid_regex(self):
+        # We need to explicitly call `evaluate` to trigger the exception
+        # to make sure the exception is triggered in all cases
+        with self.assertRaises(ReframeError):
+            self.count_checks(filters.have_name('*foo')).evaluate()
+
+        with self.assertRaises(ReframeError):
+            self.count_checks(filters.have_not_name('*foo')).evaluate()
+
+        with self.assertRaises(ReframeError):
+            self.count_checks(filters.have_tag('*foo')).evaluate()
+
+        with self.assertRaises(ReframeError):
+            self.count_checks(filters.have_prgenv('*foo')).evaluate()


### PR DESCRIPTION
* Throw a `ReframeError` if an invalid regex is passed to one of the
  filtering functions.

* Add corresponding unittests.

Fixes #730 