### PR TITLE
[feat] Print performance variable name in case of performance errors

### DIFF
--- a/reframe/core/pipeline.py
+++ b/reframe/core/pipeline.py
@@ -1131,7 +1131,7 @@ class RegressionTest:
                 tag, val, ref, low_thres, high_thres, *_ = values
                 try:
                     evaluate(assert_reference(val, ref, low_thres, high_thres,
-                                              tag))
+                                              "'%s'" % tag))
                 except SanityError as e:
                     raise PerformanceError(e)
 

--- a/reframe/core/pipeline.py
+++ b/reframe/core/pipeline.py
@@ -1130,8 +1130,13 @@ class RegressionTest:
             for values in self._perfvalues.values():
                 tag, val, ref, low_thres, high_thres, *_ = values
                 try:
-                    evaluate(assert_reference(val, ref, low_thres, high_thres,
-                                              "'%s'" % tag))
+                    evaluate(
+                        assert_reference(
+                            val, ref, low_thres, high_thres,
+                            msg=('failed to meet reference: %s={0}, '
+                                 'expected {1} (l={2}, u={3})' % tag),
+                        )
+                    )
                 except SanityError as e:
                     raise PerformanceError(e)
 

--- a/reframe/core/pipeline.py
+++ b/reframe/core/pipeline.py
@@ -1123,14 +1123,15 @@ class RegressionTest:
                         "tag `%s' not resolved in references for `%s'" %
                         (tag, self._current_partition.fullname))
 
-                self._perfvalues[key] = (value, *self.reference[key])
+                self._perfvalues[key] = (tag, value, *self.reference[key])
                 self._perf_logger.log_performance(logging.INFO, tag, value,
                                                   *self.reference[key])
 
-            for val, *reference in self._perfvalues.values():
-                ref, low_thres, high_thres, *_ = reference
+            for values in self._perfvalues.values():
+                tag, val, ref, low_thres, high_thres, *_ = values
                 try:
-                    evaluate(assert_reference(val, ref, low_thres, high_thres))
+                    evaluate(assert_reference(val, ref, low_thres, high_thres,
+                                              tag))
                 except SanityError as e:
                     raise PerformanceError(e)
 

--- a/reframe/utility/sanity.py
+++ b/reframe/utility/sanity.py
@@ -514,7 +514,7 @@ def assert_reference(val, ref, lower_thres=None, upper_thres=None, msg=None):
     try:
         evaluate(assert_bounded(val, lower, upper))
     except SanityError:
-        error_msg = '%s ' % msg or ''
+        error_msg = '%s ' % msg if msg else ''
         error_msg += '{0} is beyond reference value {1} (l={2}, u={3})'
         raise SanityError(_format(error_msg, val, ref, lower, upper))
     else:

--- a/reframe/utility/sanity.py
+++ b/reframe/utility/sanity.py
@@ -466,7 +466,7 @@ def assert_bounded(val, lower=None, upper=None, msg=None):
 
 
 @deferrable
-def assert_reference(val, ref, lower_thres=None, upper_thres=None, msg=None):
+def assert_reference(val, ref, lower_thres=None, upper_thres=None, tag=None):
     """Assert that value ``val`` respects the reference value ``ref``.
 
     :arg val: The value to check.
@@ -479,6 +479,7 @@ def assert_reference(val, ref, lower_thres=None, upper_thres=None, msg=None):
         of the reference value. Must be in [0, inf] for ref >= 0.0 and
         in [0, 1] for ref < 0.0.
         If ``None``, no upper thresholds is applied.
+    :arg tag: The tag of the reference value.
     :returns: ``True`` on success.
     :raises reframe.core.exceptions.SanityError: if assertion fails or if the
         lower and upper thresholds do not have appropriate values.
@@ -515,7 +516,10 @@ def assert_reference(val, ref, lower_thres=None, upper_thres=None, msg=None):
         evaluate(assert_bounded(val, lower, upper))
     except SanityError:
         error_msg = '{0} is beyond reference value {1} (l={2}, u={3})'
-        raise SanityError(_format(error_msg, val, ref, lower, upper))
+        if tag:
+            error_msg = "'%s' " % tag  + error_msg
+
+        raise SanityError(_format(error_msg, val, ref, lower, upper,))
     else:
         return True
 

--- a/reframe/utility/sanity.py
+++ b/reframe/utility/sanity.py
@@ -466,7 +466,7 @@ def assert_bounded(val, lower=None, upper=None, msg=None):
 
 
 @deferrable
-def assert_reference(val, ref, lower_thres=None, upper_thres=None, tag=None):
+def assert_reference(val, ref, lower_thres=None, upper_thres=None, msg=None):
     """Assert that value ``val`` respects the reference value ``ref``.
 
     :arg val: The value to check.
@@ -479,7 +479,6 @@ def assert_reference(val, ref, lower_thres=None, upper_thres=None, tag=None):
         of the reference value. Must be in [0, inf] for ref >= 0.0 and
         in [0, 1] for ref < 0.0.
         If ``None``, no upper thresholds is applied.
-    :arg tag: The tag of the reference value.
     :returns: ``True`` on success.
     :raises reframe.core.exceptions.SanityError: if assertion fails or if the
         lower and upper thresholds do not have appropriate values.
@@ -515,11 +514,9 @@ def assert_reference(val, ref, lower_thres=None, upper_thres=None, tag=None):
     try:
         evaluate(assert_bounded(val, lower, upper))
     except SanityError:
-        error_msg = '{0} is beyond reference value {1} (l={2}, u={3})'
-        if tag:
-            error_msg = "'%s' " % tag  + error_msg
-
-        raise SanityError(_format(error_msg, val, ref, lower, upper,))
+        error_msg = '%s ' % msg or ''
+        error_msg += '{0} is beyond reference value {1} (l={2}, u={3})'
+        raise SanityError(_format(error_msg, val, ref, lower, upper))
     else:
         return True
 

--- a/reframe/utility/sanity.py
+++ b/reframe/utility/sanity.py
@@ -514,8 +514,7 @@ def assert_reference(val, ref, lower_thres=None, upper_thres=None, msg=None):
     try:
         evaluate(assert_bounded(val, lower, upper))
     except SanityError:
-        error_msg = '%s ' % msg if msg else ''
-        error_msg += '{0} is beyond reference value {1} (l={2}, u={3})'
+        error_msg = msg or '{0} is beyond reference value {1} (l={2}, u={3})'
         raise SanityError(_format(error_msg, val, ref, lower, upper))
     else:
         return True


### PR DESCRIPTION
* Allow `assert_reference` to accept a `tag` parameter.

* Use the performance tag in `assert_reference` at the
  `check_performance` stage.

Fixes #753 