### PR TITLE
[bugfix] Add version checks for TMod and TMod4

### DIFF
--- a/docs/configure.rst
+++ b/docs/configure.rst
@@ -97,8 +97,8 @@ The valid attributes of a system are the following:
 * ``modules_system``: The modules system that should be used for loading environment modules on this system (default :class:`None`).
   Three types of modules systems are currently supported:
 
-  - ``tmod``: The classic Tcl implementation of the `environment modules <https://sourceforge.net/projects/modules/files/Modules/modules-3.2.10/>`__.
-  - ``tmod4``: The version 4 of the Tcl implementation of the `environment modules <http://modules.sourceforge.net/>`__ (versions less than 4.1.0 are not supported).
+  - ``tmod``: The classic Tcl implementation of the `environment modules <https://sourceforge.net/projects/modules/files/Modules/modules-3.2.10/>`__ (versions less than 3.2 are not supported).
+  - ``tmod4``: The version 4 of the Tcl implementation of the `environment modules <http://modules.sourceforge.net/>`__ (versions less than 4.1 are not supported).
   - ``lmod``: The Lua implementation of the `environment modules <https://lmod.readthedocs.io/en/latest/>`__.
 * ``prefix``: Default regression prefix for this system (default ``.``).
 * ``stagedir``: Default stage directory for this system (default :class:`None`).

--- a/docs/configure.rst
+++ b/docs/configure.rst
@@ -97,8 +97,8 @@ The valid attributes of a system are the following:
 * ``modules_system``: The modules system that should be used for loading environment modules on this system (default :class:`None`).
   Three types of modules systems are currently supported:
 
-  - ``tmod``: The classic Tcl implementation of the `environment modules <https://sourceforge.net/projects/modules/files/Modules/modules-3.2.10/>`__ (versions less than 3.2 are not supported).
-  - ``tmod4``: The version 4 of the Tcl implementation of the `environment modules <http://modules.sourceforge.net/>`__ (versions less than 4.1 are not supported).
+  - ``tmod``: The classic Tcl implementation of the `environment modules <https://sourceforge.net/projects/modules/files/Modules/modules-3.2.10/>`__ (versions older than 3.2 are not supported).
+  - ``tmod4``: The version 4 of the Tcl implementation of the `environment modules <http://modules.sourceforge.net/>`__ (versions older than 4.1 are not supported).
   - ``lmod``: The Lua implementation of the `environment modules <https://lmod.readthedocs.io/en/latest/>`__.
 * ``prefix``: Default regression prefix for this system (default ``.``).
 * ``stagedir``: Default stage directory for this system (default :class:`None`).

--- a/docs/configure.rst
+++ b/docs/configure.rst
@@ -98,7 +98,7 @@ The valid attributes of a system are the following:
   Three types of modules systems are currently supported:
 
   - ``tmod``: The classic Tcl implementation of the `environment modules <https://sourceforge.net/projects/modules/files/Modules/modules-3.2.10/>`__.
-  - ``tmod4``: The version 4 of the Tcl implementation of the `environment modules <http://modules.sourceforge.net/>`__.
+  - ``tmod4``: The version 4 of the Tcl implementation of the `environment modules <http://modules.sourceforge.net/>`__ (versions less than 4.1.0 are not supported).
   - ``lmod``: The Lua implementation of the `environment modules <https://lmod.readthedocs.io/en/latest/>`__.
 * ``prefix``: Default regression prefix for this system (default ``.``).
 * ``stagedir``: Default stage directory for this system (default :class:`None`).

--- a/reframe/core/modules.py
+++ b/reframe/core/modules.py
@@ -397,8 +397,9 @@ class TModImpl(ModulesSystemImpl):
         version = version_match.group(1)
         try:
             ver_major, ver_minor, *_ = [int(v) for v in version.split('.')]
-        except ValueError as e:
-            raise ConfigError('could not parse TMod version') from e
+        except ValueError:
+            raise ConfigError(
+                'could not parse TMod version string: ' + version) from None
 
         if (ver_major, ver_minor) < self.MIN_VERSION:
             raise ConfigError(
@@ -519,8 +520,9 @@ class TMod4Impl(TModImpl):
         version = version_match.group(1)
         try:
             ver_major, ver_minor, *_ = [int(v) for v in version.split('.')]
-        except ValueError as e:
-            raise ConfigError('could not parse TMod4 version') from e
+        except ValueError:
+            raise ConfigError(
+                'could not parse TMod4 version string: ' + version) from None
 
         if (ver_major, ver_minor) < self.MIN_VERSION:
             raise ConfigError(

--- a/reframe/core/modules.py
+++ b/reframe/core/modules.py
@@ -376,6 +376,8 @@ class ModulesSystemImpl(abc.ABC):
 class TModImpl(ModulesSystemImpl):
     """Module system for TMod (Tcl)."""
 
+    MIN_VERSION = (3, 2)
+
     def __init__(self):
         # Try to figure out if we are indeed using the TCL version
         try:
@@ -392,7 +394,14 @@ class TModImpl(ModulesSystemImpl):
         if version_match is None or tcl_version_match is None:
             raise ConfigError('could not find a sane Tmod installation')
 
-        self._version = version_match.group(1)
+        version = version_match.group(1)
+        ver_major, ver_minor, *_ = [int(v) for v in version.split('.')]
+        if (ver_major, ver_minor) < self.MIN_VERSION:
+            raise ConfigError(
+                'unsupported TMod version: %s (required >= %s)' %
+                (version, self.MIN_VERSION))
+
+        self._version = version
         self._command = 'modulecmd python'
         try:
             # Try the Python bindings now
@@ -485,7 +494,7 @@ class TModImpl(ModulesSystemImpl):
 class TMod4Impl(TModImpl):
     """Module system for TMod 4."""
 
-    MIN_VERSION = ('4', '1', '0')
+    MIN_VERSION = (4, 1)
 
     def __init__(self):
         self._command = 'modulecmd python'
@@ -504,9 +513,11 @@ class TMod4Impl(TModImpl):
             raise ConfigError('could not retrieve the TMod4 version')
 
         version = version_match.group(1)
-        if tuple(version.split('.')) < self.MIN_VERSION:
+        ver_major, ver_minor, *_ = [int(v) for v in version.split('.')]
+        if (ver_major, ver_minor) < self.MIN_VERSION:
             raise ConfigError(
-                'version %s of TMod4 is not supported' % version)
+                'unsupported TMod4 version: %s (required >= %s)' %
+                (version, self.MIN_VERSION))
 
         self._version = version
 

--- a/reframe/core/modules.py
+++ b/reframe/core/modules.py
@@ -384,7 +384,7 @@ class TModImpl(ModulesSystemImpl):
             completed = os_ext.run_command('modulecmd -V')
         except OSError as e:
             raise ConfigError(
-                'could not find a sane Tmod installation: %s' % e) from e
+                'could not find a sane TMod installation: %s' % e) from e
 
         version_match = re.search(r'^VERSION=(\S+)', completed.stdout,
                                   re.MULTILINE)
@@ -392,10 +392,14 @@ class TModImpl(ModulesSystemImpl):
                                       re.MULTILINE)
 
         if version_match is None or tcl_version_match is None:
-            raise ConfigError('could not find a sane Tmod installation')
+            raise ConfigError('could not find a sane TMod installation')
 
         version = version_match.group(1)
-        ver_major, ver_minor, *_ = [int(v) for v in version.split('.')]
+        try:
+            ver_major, ver_minor, *_ = [int(v) for v in version.split('.')]
+        except ValueError as e:
+            raise ConfigError('could not parse TMod version') from e
+
         if (ver_major, ver_minor) < self.MIN_VERSION:
             raise ConfigError(
                 'unsupported TMod version: %s (required >= %s)' %
@@ -408,11 +412,11 @@ class TModImpl(ModulesSystemImpl):
             completed = os_ext.run_command(self._command)
         except OSError as e:
             raise ConfigError(
-                'could not get the Python bindings for Tmod: ' % e) from e
+                'could not get the Python bindings for TMod: ' % e) from e
 
         if re.search(r'Unknown shell type', completed.stderr):
             raise ConfigError(
-                'Python is not supported by this Tmod installation')
+                'Python is not supported by this TMod installation')
 
     def name(self):
         return 'tmod'
@@ -513,7 +517,11 @@ class TMod4Impl(TModImpl):
             raise ConfigError('could not retrieve the TMod4 version')
 
         version = version_match.group(1)
-        ver_major, ver_minor, *_ = [int(v) for v in version.split('.')]
+        try:
+            ver_major, ver_minor, *_ = [int(v) for v in version.split('.')]
+        except ValueError as e:
+            raise ConfigError('could not parse TMod4 version') from e
+
         if (ver_major, ver_minor) < self.MIN_VERSION:
             raise ConfigError(
                 'unsupported TMod4 version: %s (required >= %s)' %


### PR DESCRIPTION
* Throw `ConfigError` for TMod4 versions older than 4.1.0.
* Throw `ConfigError` for TMod versions older than 3.2.
* Change the corresponding docs.

Fixes #780  
Fixes #781 