### PR TITLE
[test] Make CUDA kernel latency tests generic

### DIFF
--- a/cscs-checks/microbenchmarks/kernel_latency/kernel_latency.py
+++ b/cscs-checks/microbenchmarks/kernel_latency/kernel_latency.py
@@ -21,7 +21,7 @@ class KernelLatencyTest(rfm.RegressionTest):
             self.modules = ['craype-accel-nvidia60']
             self.valid_prog_environs = ['PrgEnv-cray', 'PrgEnv-pgi',
                                         'PrgEnv-gnu']
-        elif self.current_system == 'kesch':
+        elif self.current_system.name == 'kesch':
             self.num_gpus_per_node = 16
             self.valid_prog_environs = ['PrgEnv-cray', 'PrgEnv-pgi']
             self.modules = ['craype-accel-nvidia35']

--- a/cscs-checks/microbenchmarks/kernel_latency/kernel_latency.py
+++ b/cscs-checks/microbenchmarks/kernel_latency/kernel_latency.py
@@ -19,13 +19,20 @@ class KernelLatencyTest(rfm.RegressionTest):
             gpu_arch = '60'
             self.modules = ['craype-accel-nvidia60']
             self.valid_prog_environs += ['PrgEnv-gnu']
-        else:
+        elif self.current_system == 'kesch':
             self.num_gpus_per_node = 16
             self.modules = ['craype-accel-nvidia35']
             gpu_arch = '37'
+        else:
+            # Enable test running on an unknown system
+            self.valid_systems = ['*']
+            self.valid_prog_environs = ['*']
+            gpu_arch = None
 
-        self.build_system.cxxflags = ['-arch=compute_%s' % gpu_arch,
-                                      '-code=sm_%s' % gpu_arch, '-std=c++11']
+        self.build_system.cxxflags = ['-std=c++11']
+        if gpu_arch:
+            self.build_system.cxxflags += ['-arch=compute_%s' % gpu_arch,
+                                          '-code=sm_%s' % gpu_arch]
 
         if kernel_version == 'sync':
             self.build_system.cppflags = ['-D SYNCKERNEL=1']
@@ -59,6 +66,9 @@ class KernelLatencyTest(rfm.RegressionTest):
                 'kesch:cn': {
                     'latency': (12.0, None, 0.10, 'us')
                 },
+                '*': {
+                    'latency': (0.0, None, None, 'us')
+                }
             },
             'async': {
                 'dom:gpu': {
@@ -70,6 +80,9 @@ class KernelLatencyTest(rfm.RegressionTest):
                 'kesch:cn': {
                     'latency': (5.7, None, 0.10, 'us')
                 },
+                '*': {
+                    'latency': (0.0, None, None, 'us')
+                }
             },
         }
 

--- a/cscs-checks/microbenchmarks/kernel_latency/kernel_latency.py
+++ b/cscs-checks/microbenchmarks/kernel_latency/kernel_latency.py
@@ -7,29 +7,31 @@ import reframe.utility.sanity as sn
 class KernelLatencyTest(rfm.RegressionTest):
     def __init__(self, kernel_version):
         super().__init__()
-        self.sourcepath = 'kernel_latency.cu'
-        self.build_system = 'SingleSource'
+        # List known partitions here so as to avoid specifying them every time
+        # with --system
         self.valid_systems = ['daint:gpu', 'dom:gpu', 'kesch:cn']
-        self.valid_prog_environs = ['PrgEnv-cray', 'PrgEnv-pgi']
         self.num_tasks = 0
         self.num_tasks_per_node = 1
-
+        self.sourcepath = 'kernel_latency.cu'
+        self.build_system = 'SingleSource'
+        self.build_system.cxxflags = ['-std=c++11']
         if self.current_system.name in {'dom', 'daint'}:
             self.num_gpus_per_node = 1
             gpu_arch = '60'
             self.modules = ['craype-accel-nvidia60']
-            self.valid_prog_environs += ['PrgEnv-gnu']
+            self.valid_prog_environs = ['PrgEnv-cray', 'PrgEnv-pgi',
+                                        'PrgEnv-gnu']
         elif self.current_system == 'kesch':
             self.num_gpus_per_node = 16
+            self.valid_prog_environs = ['PrgEnv-cray', 'PrgEnv-pgi']
             self.modules = ['craype-accel-nvidia35']
             gpu_arch = '37'
         else:
-            # Enable test running on an unknown system
+            # Enable test when running on an unknown system
             self.valid_systems = ['*']
             self.valid_prog_environs = ['*']
             gpu_arch = None
 
-        self.build_system.cxxflags = ['-std=c++11']
         if gpu_arch:
             self.build_system.cxxflags += ['-arch=compute_%s' % gpu_arch,
                                            '-code=sm_%s' % gpu_arch]

--- a/cscs-checks/microbenchmarks/kernel_latency/kernel_latency.py
+++ b/cscs-checks/microbenchmarks/kernel_latency/kernel_latency.py
@@ -28,6 +28,7 @@ class KernelLatencyTest(rfm.RegressionTest):
             gpu_arch = '37'
         else:
             # Enable test when running on an unknown system
+            self.num_gpus_per_node = 1
             self.valid_systems = ['*']
             self.valid_prog_environs = ['*']
             gpu_arch = None

--- a/cscs-checks/microbenchmarks/kernel_latency/kernel_latency.py
+++ b/cscs-checks/microbenchmarks/kernel_latency/kernel_latency.py
@@ -32,7 +32,7 @@ class KernelLatencyTest(rfm.RegressionTest):
         self.build_system.cxxflags = ['-std=c++11']
         if gpu_arch:
             self.build_system.cxxflags += ['-arch=compute_%s' % gpu_arch,
-                                          '-code=sm_%s' % gpu_arch]
+                                           '-code=sm_%s' % gpu_arch]
 
         if kernel_version == 'sync':
             self.build_system.cppflags = ['-D SYNCKERNEL=1']


### PR DESCRIPTION
The idea of making a test generic is to make no assumption as of what is `self.current_system`. This essentially means the following:

1. If you check against `self.current_system` or `self.current_partition` or `self.current_environ`, make sure you handle the case of an unknown system or environment.
2. If you are running on an unknown system, make sure to include `*` in `self.valid_systems` and `self.valid_prog_environs`.
3. If you are on a performance test, make sure that a `*` entry exists inside the `references` dictionary.   Its value should be `(0, None, None, 'unit')`.

Addresses [UES-339](https://jira.cscs.ch/browse/UES-339)