### PR TITLE
[feat] Validate test case graph

### DIFF
--- a/reframe/frontend/dependency.py
+++ b/reframe/frontend/dependency.py
@@ -3,6 +3,7 @@
 #
 
 import collections
+import itertools
 
 import reframe as rfm
 from reframe.core.exceptions import DependencyError
@@ -79,3 +80,44 @@ def print_deps(graph):
 
 def validate_deps(graph):
     """Validate dependency graph."""
+
+    # Reduce test case graph to a test name only graph; this disallows
+    # pseudo-dependencies as follows:
+    #
+    # (t0, e1) -> (t1, e1)
+    # (t1, e0) -> (t0, e0)
+    #
+    # This reduction step will result in a graph description with duplicate
+    # entries in the adjacency list; this is not a problem, cos they will be
+    # filtered out during the DFS traversal below.
+    test_graph = {}
+    for case, deps in graph.items():
+        test_deps = [d.check.name for d in deps]
+        try:
+            test_graph[case.check.name] += test_deps
+        except KeyError:
+            test_graph[case.check.name] = test_deps
+
+    # Check for cyclic dependencies in the test name graph
+    visited = set()
+    unvisited = list(
+        itertools.zip_longest(test_graph.keys(), [], fillvalue=None)
+    )
+    path = []
+    while unvisited:
+        node, parent = unvisited.pop()
+        while path and path[-1] != parent:
+            path.pop()
+
+        adjacent = reversed(test_graph[node])
+        path.append(node)
+        for n in adjacent:
+            if n in path:
+                cycle_str = '->'.join(path + [n])
+                raise DependencyError(
+                    'found cyclic dependency between tests: ' + cycle_str)
+
+            if n not in visited:
+                unvisited.append((n, node))
+
+        visited.add(node)

--- a/unittests/test_policies.py
+++ b/unittests/test_policies.py
@@ -589,6 +589,10 @@ class TestDependencies(unittest.TestCase):
         deps = dependency.build_deps(executors.generate_testcases(checks))
         assert num_deps(deps, 'Test1_default') == 4
 
+    @rt.switch_runtime(fixtures.TEST_SITE_CONFIG, 'sys0')
+    def test_build_deps_empty(self):
+        assert {} == dependency.build_deps([])
+
     def create_test(self, name):
         test = rfm.RegressionTest()
         test.name = name
@@ -601,14 +605,14 @@ class TestDependencies(unittest.TestCase):
     @rt.switch_runtime(fixtures.TEST_SITE_CONFIG, 'sys0')
     def test_valid_deps(self):
         #
-        #       t0
-        #       ^
-        #       |
-        #   +-->t1<--+
-        #   |        |
-        #   t2<------t3
-        #   ^        ^
-        #   |        |
+        #       t0       +-->t5<--+
+        #       ^        |        |
+        #       |        |        |
+        #   +-->t1<--+   t6       t7
+        #   |        |            ^
+        #   t2<------t3           |
+        #   ^        ^            |
+        #   |        |            t8
         #   +---t4---+
         #
         t0 = self.create_test('t0')
@@ -616,29 +620,37 @@ class TestDependencies(unittest.TestCase):
         t2 = self.create_test('t2')
         t3 = self.create_test('t3')
         t4 = self.create_test('t4')
+        t5 = self.create_test('t5')
+        t6 = self.create_test('t6')
+        t7 = self.create_test('t7')
+        t8 = self.create_test('t8')
         t1.depends_on('t0')
         t2.depends_on('t1')
         t3.depends_on('t1')
         t3.depends_on('t2')
         t4.depends_on('t2')
         t4.depends_on('t3')
+        t6.depends_on('t5')
+        t7.depends_on('t5')
+        t8.depends_on('t7')
         dependency.validate_deps(
             dependency.build_deps(
-                executors.generate_testcases([t0, t1, t2, t3, t4])
+                executors.generate_testcases([t0, t1, t2, t3, t4,
+                                              t5, t6, t7, t8])
             )
         )
 
     @rt.switch_runtime(fixtures.TEST_SITE_CONFIG, 'sys0')
     def test_cyclic_deps(self):
         #
-        #       t0
-        #       ^
-        #       |
-        #   +-->t1<--+
-        #   |   |    |
-        #   t2  |    t3
-        #   ^   |    ^
-        #   |   v    |
+        #       t0       +-->t5<--+
+        #       ^        |        |
+        #       |        |        |
+        #   +-->t1<--+   t6       t7
+        #   |   |    |            ^
+        #   t2  |    t3           |
+        #   ^   |    ^            |
+        #   |   v    |            t8
         #   +---t4---+
         #
         t0 = self.create_test('t0')
@@ -646,6 +658,10 @@ class TestDependencies(unittest.TestCase):
         t2 = self.create_test('t2')
         t3 = self.create_test('t3')
         t4 = self.create_test('t4')
+        t5 = self.create_test('t5')
+        t6 = self.create_test('t6')
+        t7 = self.create_test('t7')
+        t8 = self.create_test('t8')
         t1.depends_on('t0')
         t1.depends_on('t4')
         t2.depends_on('t1')
@@ -653,8 +669,12 @@ class TestDependencies(unittest.TestCase):
         t3.depends_on('t2')
         t4.depends_on('t2')
         t4.depends_on('t3')
+        t6.depends_on('t5')
+        t7.depends_on('t5')
+        t8.depends_on('t7')
         deps = dependency.build_deps(
-            executors.generate_testcases([t0, t1, t2, t3, t4])
+            executors.generate_testcases([t0, t1, t2, t3, t4,
+                                          t5, t6, t7, t8])
         )
 
         with pytest.raises(DependencyError) as exc_info:
@@ -681,3 +701,7 @@ class TestDependencies(unittest.TestCase):
 
         assert ('t1->t0->t1' in str(exc_info.value) or
                 't0->t1->t0' in str(exc_info.value))
+
+    @rt.switch_runtime(fixtures.TEST_SITE_CONFIG, 'sys0')
+    def test_validate_deps_empty(self):
+        dependency.validate_deps({})

--- a/unittests/test_policies.py
+++ b/unittests/test_policies.py
@@ -660,7 +660,12 @@ class TestDependencies(unittest.TestCase):
         with pytest.raises(DependencyError) as exc_info:
             dependency.validate_deps(deps)
 
-        assert 't4->t2->t1->t4' in str(exc_info.value)
+        assert ('t4->t2->t1->t4' in str(exc_info.value) or
+                't2->t1->t4->t2' in str(exc_info.value) or
+                't1->t4->t2->t1' in str(exc_info.value) or
+                't1->t4->t3->t1' in str(exc_info.value) or
+                't4->t3->t1->t4' in str(exc_info.value) or
+                't3->t1->t4->t3' in str(exc_info.value))
 
     @rt.switch_runtime(fixtures.TEST_SITE_CONFIG, 'sys0')
     def test_cyclic_deps_by_env(self):
@@ -674,4 +679,5 @@ class TestDependencies(unittest.TestCase):
         with pytest.raises(DependencyError) as exc_info:
             dependency.validate_deps(deps)
 
-        assert 't1->t0->t1' in str(exc_info.value)
+        assert ('t1->t0->t1' in str(exc_info.value) or
+                't0->t1->t0' in str(exc_info.value))


### PR DESCRIPTION
This PR adds the validation routine for the test graph. Dependencies are validated at the test level only, so pseudo-dependencies like the following are not allowed:

```
(t0, e1) -> (t1, e1)
(t1, e0) -> (t0, e0)
```

Fixes [UES-283](https://jira.cscs.ch/browse/UES-283).