### PR TITLE
[refactor] Fix abstract class definitions

### DIFF
--- a/reframe/core/buildsystems.py
+++ b/reframe/core/buildsystems.py
@@ -6,7 +6,7 @@ import reframe.utility.typecheck as typ
 from reframe.core.exceptions import BuildSystemError
 
 
-class BuildSystem:
+class BuildSystem(abc.ABC):
     """The abstract base class of any build system.
 
     Concrete build systems inherit from this class and must override the

--- a/reframe/frontend/executors/__init__.py
+++ b/reframe/frontend/executors/__init__.py
@@ -212,7 +212,7 @@ class RegressionTask:
             self.fail((type(exc), exc, None))
 
 
-class TaskEventListener:
+class TaskEventListener(abc.ABC):
     @abc.abstractmethod
     def on_task_run(self, task):
         """Called whenever the run() method of a RegressionTask is called."""
@@ -320,7 +320,7 @@ class Runner:
         self._policy.exit()
 
 
-class ExecutionPolicy:
+class ExecutionPolicy(abc.ABC):
     """Base abstract class for execution policies.
 
     An execution policy implements the regression check pipeline."""
@@ -369,7 +369,3 @@ class ExecutionPolicy:
 
         if self.force_local:
             case.check.local = True
-
-    @abc.abstractmethod
-    def getstats(self):
-        """Return test case statistics of the run."""

--- a/reframe/utility/versioning.py
+++ b/reframe/utility/versioning.py
@@ -67,7 +67,7 @@ class Version:
         return base + '-dev%s' % self._dev_number
 
 
-class _ValidatorImpl:
+class _ValidatorImpl(abc.ABC):
     """Abstract base class for the validation of version ranges."""
     @abc.abstractmethod
     def validate(version):
@@ -81,6 +81,7 @@ class _IntervalValidator(_ValidatorImpl):
     ``validate`` returns ``True`` if a given version string is inside
     the interval including the endpoints.
     """
+
     def __init__(self, condition):
         try:
             min_version_str, max_version_str = condition.split('..')
@@ -108,6 +109,7 @@ class _RelationalValidator(_ValidatorImpl):
     ``<bool_operator><version>``, and its method ``validate`` returns
     ``True`` if a given version string satisfies the relation.
     """
+
     def __init__(self, condition):
         self._op_actions = {
             ">":  lambda x, y: x > y,

--- a/unittests/test_buildsystems.py
+++ b/unittests/test_buildsystems.py
@@ -6,7 +6,7 @@ from reframe.core.environments import ProgEnvironment
 from reframe.core.exceptions import BuildSystemError
 
 
-class _BuildSystemTest:
+class _BuildSystemTest(abc.ABC):
     @abc.abstractmethod
     def create_build_system(self):
         pass

--- a/unittests/test_modules.py
+++ b/unittests/test_modules.py
@@ -10,7 +10,7 @@ from reframe.core.runtime import runtime
 from unittests.fixtures import TEST_MODULES
 
 
-class _TestModulesSystem:
+class _TestModulesSystem(abc.ABC):
     def setUp(self):
         self.environ_save = EnvironmentSnapshot()
         self.modules_system.searchpath_add(TEST_MODULES)

--- a/unittests/test_schedulers.py
+++ b/unittests/test_schedulers.py
@@ -18,7 +18,7 @@ from reframe.core.schedulers.registry import getscheduler
 from reframe.core.schedulers.slurm import SlurmNode
 
 
-class _TestJob:
+class _TestJob(abc.ABC):
     def setUp(self):
         self.workdir = tempfile.mkdtemp(dir='unittests')
         self.testjob = self.job_type(
@@ -71,7 +71,6 @@ class _TestJob:
 
         self.testjob.options += partition.access
 
-    @abc.abstractmethod
     def assertScriptSanity(self, script_file):
         """Assert the sanity of the produced script file."""
         with open(self.testjob.script_filename) as fp:


### PR DESCRIPTION
Abstract classes must derive from `abc.ABC`.