### PR TITLE
[ci] Require full tag names in genrelnotes.py script

### DIFF
--- a/ci-scripts/genrelnotes.py
+++ b/ci-scripts/genrelnotes.py
@@ -22,7 +22,7 @@ if __name__ == '__main__':
 
     prev_release, curr_release, *_ = sys.argv[1:]
     try:
-        git_cmd = 'git log --merges v%s..v%s' % (prev_release, curr_release)
+        git_cmd = 'git log --merges %s..%s' % (prev_release, curr_release)
         completed = subprocess.run(git_cmd.split(),
                                    stdout=subprocess.PIPE,
                                    stderr=subprocess.STDOUT,


### PR DESCRIPTION
This allows us to get temporary release notes with any tag or `HEAD`, for example:

```
./ci-scripts/genrelnotes.py v2.17 HEAD
```