### PR TITLE
[feat] Limit concurrent build jobs to `1` by default in build systems

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -68,17 +68,14 @@ In this case, ``make`` will be invoked as follows:
   make -j 1 CPPFLAGS='-DMESSAGE'
 
 Notice that the ``-j 1`` option is always generated.
-If you want to set the maximum build concurrency, you can do it as follows:
+You may change the maximum build concurrency as follows:
 
 .. code-block:: python
 
   self.build_system.max_concurrency = 4
 
-otherwise, if you do not want to limit the build concurrency, :attr:`max_concurrency` has to be set to :class:`None` as follows:
-
-.. code-block:: python
-
-  self.build_system.max_concurrency = None
+By setting :attr:`max_concurrency <reframe.core.buildsystems.Make.max_concurrency>` to :class:`None`, no limit for concurrent parallel jobs will be placed.
+This means that ``make -j`` will be used for building.
 
 Finally, you may also customize the name of the ``Makefile``.
 You can achieve that by setting the corresponding variable of the :class:`Make <reframe.core.buildsystems.Make>` build system:

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -74,7 +74,7 @@ If you want to set the maximum build concurrency, you can do it as follows:
 
   self.build_system.max_concurrency = 4
 
-otherwise, if you do not want limit the build concurrency, :attr:`max_concurrency` has to be set to :class:`None` as follows:
+otherwise, if you do not want to limit the build concurrency, :attr:`max_concurrency` has to be set to :class:`None` as follows:
 
 .. code-block:: python
 

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -52,7 +52,7 @@ ReFrame will invoke ``make`` as follows:
 
 .. code::
 
-  make -j CC='cc' CXX='CC' FC='ftn' NVCC='nvcc' CPPFLAGS='-DMESSAGE'
+  make -j 1 CC='cc' CXX='CC' FC='ftn' NVCC='nvcc' CPPFLAGS='-DMESSAGE'
 
 The compiler variables (``CC``, ``CXX`` etc.) are set based on the corresponding values specified in the `coniguration of the current environment <configure.html#environments-configuration>`__.
 You may instruct the build system to ignore the default values from the environment by setting the following:
@@ -65,15 +65,20 @@ In this case, ``make`` will be invoked as follows:
 
 .. code::
 
-  make -j CPPFLAGS='-DMESSAGE'
+  make -j 1 CPPFLAGS='-DMESSAGE'
 
-Notice that the ``-j`` option is always generated.
-If you want to limit build concurrency, you can do it as follows:
+Notice that the ``-j 1`` option is always generated.
+If you want to set the maximum build concurrency, you can do it as follows:
 
 .. code-block:: python
 
   self.build_system.max_concurrency = 4
 
+otherwise, if you do not want limit the build concurrency, :attr:`max_concurrency` has to be set to :class:`None` as follows:
+
+.. code-block:: python
+
+  self.build_system.max_concurrency = None
 
 Finally, you may also customize the name of the ``Makefile``.
 You can achieve that by setting the corresponding variable of the :class:`Make <reframe.core.buildsystems.Make>` build system:
@@ -140,7 +145,7 @@ The generated build script then will have the following lines:
 .. code-block:: bash
 
   ./custom_configure -with-mylib
-  make -j CPPFLAGS='-DHAVE_FOO'
+  make -j 1 CPPFLAGS='-DHAVE_FOO'
 
 
 Implementing a Run-Only Regression Test

--- a/reframe/core/buildsystems.py
+++ b/reframe/core/buildsystems.py
@@ -214,7 +214,11 @@ class Make(BuildSystem):
     #: Otherwise, it will invoked as ``make -j``.
     #:
     #: :type: integer
-    #: :default: :class:`None`
+    #: :default: ``1``
+    #:
+    #: .. note::
+    #:     .. versionchanged:: 2.19
+    #:        The default value is now ``1``
     max_concurrency = fields.TypedField('max_concurrency', int, type(None))
 
     def __init__(self):
@@ -222,7 +226,7 @@ class Make(BuildSystem):
         self.options = []
         self.makefile = None
         self.srcdir = None
-        self.max_concurrency = None
+        self.max_concurrency = 1
 
     def emit_build_commands(self, environ):
         cmd_parts = ['make']
@@ -467,7 +471,7 @@ class ConfigureBasedBuildSystem(BuildSystem):
     #: Same as for the :attr:`Make` build system.
     #:
     #: :type: integer
-    #: :default: :class:`None`
+    #: :default: ``1``
     max_concurrency = fields.TypedField('max_concurrency', int, type(None))
 
     def __init__(self):
@@ -476,7 +480,7 @@ class ConfigureBasedBuildSystem(BuildSystem):
         self.builddir = None
         self.config_opts = []
         self.make_opts = []
-        self.max_concurrency = None
+        self.max_concurrency = 1
 
 
 class CMake(ConfigureBasedBuildSystem):

--- a/unittests/test_buildsystems.py
+++ b/unittests/test_buildsystems.py
@@ -70,7 +70,7 @@ class TestMake(_BuildSystemTest, unittest.TestCase):
 
     def test_emit_no_env_defaults(self):
         self.build_system.flags_from_environ = False
-        self.assertEqual(['make -j'],
+        self.assertEqual(['make -j 1'],
                          self.build_system.emit_build_commands(self.environ))
 
 
@@ -124,7 +124,7 @@ class TestCMake(_BuildSystemTest, unittest.TestCase):
 
     def test_emit_no_env_defaults(self):
         self.build_system.flags_from_environ = False
-        self.assertEqual(['cmake .', 'make -j'],
+        self.assertEqual(['cmake .', 'make -j 1'],
                          self.build_system.emit_build_commands(self.environ))
 
 
@@ -173,7 +173,7 @@ class TestAutotools(_BuildSystemTest, unittest.TestCase):
 
     def test_emit_no_env_defaults(self):
         self.build_system.flags_from_environ = False
-        self.assertEqual(['./configure', 'make -j'],
+        self.assertEqual(['./configure', 'make -j 1'],
                          self.build_system.emit_build_commands(self.environ))
 
 


### PR DESCRIPTION
* Limit the default `max_concurrency` for make based build systems
  to `1`.

* Make the corresponding changes to unittests and docs.

Fixes #792 