### PR TITLE
[feat] Implement topological sort of the test cases

### DIFF
--- a/reframe/frontend/dependency.py
+++ b/reframe/frontend/dependency.py
@@ -6,6 +6,7 @@ import collections
 import itertools
 
 import reframe as rfm
+import reframe.utility as util
 from reframe.core.exceptions import DependencyError
 
 
@@ -50,7 +51,6 @@ def build_deps(cases):
 
     graph = {}
     for c in cases:
-        graph[c] = c.deps
         cname = c.check.name
         pname = c.partition.fullname
         ename = c.environ.name
@@ -70,12 +70,27 @@ def build_deps(cases):
                         c.deps.append(resolve_dep(c, cases_revmap,
                                                   tname, pname, te))
 
+        graph[c] = util.OrderedSet(c.deps)
+
     return graph
 
 
 def print_deps(graph):
     for c, deps in graph.items():
         print(c, '->', deps)
+
+
+def _reduce_deps(graph):
+    """Reduce test case graph to a test-only graph."""
+    ret = {}
+    for case, deps in graph.items():
+        test_deps = util.OrderedSet(d.check.name for d in deps)
+        try:
+            ret[case.check.name] |= test_deps
+        except KeyError:
+            ret[case.check.name] = test_deps
+
+    return ret
 
 
 def validate_deps(graph):
@@ -87,16 +102,7 @@ def validate_deps(graph):
     # (t0, e1) -> (t1, e1)
     # (t1, e0) -> (t0, e0)
     #
-    # This reduction step will result in a graph description with duplicate
-    # entries in the adjacency list; this is not a problem, cos they will be
-    # filtered out during the DFS traversal below.
-    test_graph = {}
-    for case, deps in graph.items():
-        test_deps = [d.check.name for d in deps]
-        try:
-            test_graph[case.check.name] += test_deps
-        except KeyError:
-            test_graph[case.check.name] = test_deps
+    test_graph = _reduce_deps(graph)
 
     # Check for cyclic dependencies in the test name graph
     visited = set()
@@ -112,7 +118,8 @@ def validate_deps(graph):
             while path and path[-1] != parent:
                 path.pop()
 
-            adjacent = reversed(test_graph[node])
+            #adjacent = reversed(test_graph[node])
+            adjacent = test_graph[node]
             path.append(node)
             for n in adjacent:
                 if n in path:
@@ -126,3 +133,71 @@ def validate_deps(graph):
             visited.add(node)
 
         sources -= visited
+
+
+def _reverse_deps(graph):
+    ret = {}
+    for n, deps in graph.items():
+        ret.setdefault(n, util.OrderedSet({}))
+        for d in deps:
+            try:
+                ret[d] |= {n}
+            except KeyError:
+                ret[d] = util.OrderedSet({n})
+
+    return ret
+
+
+def toposort(graph):
+    # NOTES on implementation:
+    #
+    # 1. This function assumes a directed acyclic graph.
+    # 2. The purpose of this function is to topologically sort the test cases,
+    #    not only the tests. However, since we do not allow cycles between
+    #    tests in any case (even if this could be classified a
+    #    pseudo-dependency), we first do a topological sort of the tests and we
+    #    subsequently sort the test cases by partition and by programming
+    #    environment.
+    # 3. To achieve this 3-step sorting with a single sort operations, we rank
+    #    the test cases by associating them with an integer key based on the
+    #    result of the topological sort of the tests and by choosing an
+    #    arbitrary ordering of the partitions and the programming environment.
+
+    test_graph = _reduce_deps(graph)
+    revgraph = _reverse_deps(test_graph)
+
+    # We do a BFS traversal from each root
+    visited = {}
+    roots = set(t for t, deps in test_graph.items() if not deps)
+    for r in roots:
+        unvisited = [r]
+        visited[r] = util.OrderedSet()
+        while unvisited:
+            node = unvisited.pop(0)
+            adjacent = revgraph[node]
+            unvisited += [n for n in adjacent if n not in visited]
+            visited[r].add(node)
+
+    # Combine all individual sequences into a single one
+    ordered_tests = util.OrderedSet()
+    for tests in visited.values():
+        ordered_tests |= tests
+
+    # Get all partitions and programming environments from test cases
+    partitions = util.OrderedSet()
+    environs = util.OrderedSet()
+    for c in graph.keys():
+        partitions.add(c.partition.fullname)
+        environs.add(c.environ.name)
+
+    # Rank test cases; we first need to calculate the base for the rank number
+    base = max(len(partitions), len(environs)) + 1
+    ranks = {}
+    for i, test in enumerate(ordered_tests):
+        for j, part in enumerate(partitions):
+            for k, env in enumerate(environs):
+                ranks[test, part, env] = i*base**2 + j*base + k
+
+    return sorted(graph.keys(),
+                  key=lambda x: ranks[x.check.name,
+                                      x.partition.fullname, x.environ.name])

--- a/reframe/frontend/dependency.py
+++ b/reframe/frontend/dependency.py
@@ -173,7 +173,7 @@ def toposort(graph):
         unvisited = util.OrderedSet([r])
         visited[r] = util.OrderedSet()
         while unvisited:
-            # Next node is one whose all dependencies are visited
+            # Next node is one whose all dependencies are already visited
             node = None
             for n in unvisited:
                 if test_deps[n] <= visited[r]:
@@ -187,7 +187,8 @@ def toposort(graph):
             unvisited.remove(node)
             adjacent = rev_deps[node]
             unvisited |= util.OrderedSet(
-                n for n in adjacent if n not in visited)
+                n for n in adjacent if n not in visited
+            )
             visited[r].add(node)
 
     # Combine all individual sequences into a single one

--- a/reframe/frontend/dependency.py
+++ b/reframe/frontend/dependency.py
@@ -173,6 +173,7 @@ def toposort(graph):
         visited[r] = util.OrderedSet()
         while unvisited:
             # Next node is one whose all dependencies are already visited
+            # FIXME: This makes sorting's complexity O(V^2)
             node = None
             for n in unvisited:
                 if test_deps[n] <= visited[r]:

--- a/reframe/frontend/dependency.py
+++ b/reframe/frontend/dependency.py
@@ -118,7 +118,6 @@ def validate_deps(graph):
             while path and path[-1] != parent:
                 path.pop()
 
-            #adjacent = reversed(test_graph[node])
             adjacent = test_graph[node]
             path.append(node)
             for n in adjacent:

--- a/reframe/utility/__init__.py
+++ b/reframe/utility/__init__.py
@@ -284,7 +284,7 @@ class OrderedSet(collections.abc.MutableSet):
         return iter(self.__data)
 
     def __len__(self):
-        return len(self.__data.keys())
+        return len(self.__data)
 
     # Set i/face
     #

--- a/unittests/test_policies.py
+++ b/unittests/test_policies.py
@@ -1,4 +1,5 @@
 import collections
+import itertools
 import os
 import pytest
 import tempfile
@@ -742,7 +743,6 @@ class TestDependencies(unittest.TestCase):
                                           t5, t6, t7, t8])
         )
         cases = dependency.toposort(deps)
-        print(cases)
         cases_order = []
         tests = util.OrderedSet()
         visited_tests = set()
@@ -757,10 +757,16 @@ class TestDependencies(unittest.TestCase):
                 assert d.check.name in visited_tests
 
         # Check the order of systems and prog. environments
-        expected_order = []
-        for t in tests:
-            for p in ['sys0:p0', 'sys0:p1']:
-                for e in ['e0', 'e1']:
-                    expected_order.append((t, p, e))
+        # We are checking against all possible orderings
+        valid_orderings = []
+        for partitions in itertools.permutations(['sys0:p0', 'sys0:p1']):
+            for environs in itertools.permutations(['e0', 'e1']):
+                ordering = []
+                for t in tests:
+                    for p in partitions:
+                        for e in environs:
+                            ordering.append((t, p, e))
 
-        assert cases_order == expected_order
+                valid_orderings.append(ordering)
+
+        assert cases_order in valid_orderings

--- a/unittests/test_policies.py
+++ b/unittests/test_policies.py
@@ -742,24 +742,25 @@ class TestDependencies(unittest.TestCase):
                                           t5, t6, t7, t8])
         )
         cases = dependency.toposort(deps)
+        print(cases)
+        cases_order = []
+        tests = util.OrderedSet()
+        visited_tests = set()
+        for c in cases:
+            check, part, env = c
+            cases_order.append((check.name, part.fullname, env.name))
+            tests.add(check.name)
+            visited_tests.add(check.name)
 
-        # Check the order of cases by test
-        tests = list(util.OrderedSet(c.check.name for c in cases))
-        assert (tests == ['t0', 't1', 't2', 't3', 't4',
-                          't5', 't6', 't7', 't8'] or
-                tests == ['t5', 't6', 't7', 't8',
-                          't0', 't1', 't2', 't3', 't4'] or
-                tests == ['t0', 't1', 't2', 't3', 't4',
-                          't5', 't7', 't6', 't8'] or
-                tests == ['t5', 't7', 't6', 't8',
-                          't0', 't1', 't2', 't3', 't4'])
+            # Assert that all dependencies of c have been visited before
+            for d in deps[c]:
+                assert d.check.name in visited_tests
 
+        # Check the order of systems and prog. environments
         expected_order = []
         for t in tests:
             for p in ['sys0:p0', 'sys0:p1']:
                 for e in ['e0', 'e1']:
                     expected_order.append((t, p, e))
 
-        cases_order = [(c.check.name, c.partition.fullname, c.environ.name)
-                       for c in cases]
         assert cases_order == expected_order

--- a/unittests/test_typecheck.py
+++ b/unittests/test_typecheck.py
@@ -117,7 +117,7 @@ class TestTypes(unittest.TestCase):
                          types.Dict[str, types.List[int]].__name__)
         self.assertEqual('Tuple[int,Set[float],str]',
                          types.Tuple[int, types.Set[float], str].__name__)
-        self.assertEqual("List[Str[r'\d+']]",
+        self.assertEqual(r"List[Str[r'\d+']]",
                          types.List[types.Str[r'\d+']].__name__)
 
     def test_custom_types(self):

--- a/unittests/test_utility.py
+++ b/unittests/test_utility.py
@@ -1,4 +1,6 @@
 import os
+import pytest
+import random
 import shutil
 import sys
 import tempfile
@@ -853,3 +855,124 @@ class TestReadOnlyViews(unittest.TestCase):
 
         with self.assertRaises(AttributeError):
             d.setdefault('c', 3)
+
+
+class TestOrderedSet(unittest.TestCase):
+    def setUp(self):
+        # Initialize all tests with the same seed
+        random.seed(1)
+
+    def test_construction(self):
+        l = list(range(10))
+        random.shuffle(l)
+
+        s = util.OrderedSet(l + l)
+        assert len(s) == 10
+        for i in range(10):
+            assert i in s
+
+        assert list(s) == l
+
+    def test_construction_empty(self):
+        s = util.OrderedSet()
+        assert s == set()
+        assert set() == s
+
+    def test_str(self):
+        l = list(range(10))
+        random.shuffle(l)
+
+        s = util.OrderedSet(l)
+        assert str(s) == str(l).replace('[', '{').replace(']', '}')
+
+        s = util.OrderedSet()
+        assert str(s) == type(s).__name__ + '()'
+
+    def test_construction_error(self):
+        with pytest.raises(TypeError):
+            s = util.OrderedSet(2)
+
+        with pytest.raises(TypeError):
+            s = util.OrderedSet(1, 2, 3)
+
+    def test_operators(self):
+        s0 = util.OrderedSet(range(10))
+        s1 = util.OrderedSet(range(20))
+        s2 = util.OrderedSet(range(10, 20))
+
+        assert s0 == set(range(10))
+        assert set(range(10)) == s0
+        assert s0 != s1
+        assert s1 != s0
+
+        assert s0 < s1
+        assert s0 <= s1
+        assert s0 <= s0
+        assert s1 > s0
+        assert s1 >= s0
+        assert s1 >= s1
+
+        assert s0.issubset(s1)
+        assert s1.issuperset(s0)
+
+        assert (s0 & s1) == s0
+        assert (s0 & s2) == set()
+        assert (s0 | s2) == s1
+
+        assert (s1 - s0) == s2
+        assert (s2 - s0) == s2
+
+        assert (s0 ^ s1) == s2
+
+        assert s0.isdisjoint(s2)
+        assert not s0.isdisjoint(s1)
+        assert s0.symmetric_difference(s1) == s2
+
+    def test_union(self):
+        l0 = list(range(10))
+        l1 = list(range(10, 20))
+        l2 = list(range(20, 30))
+        random.shuffle(l0)
+        random.shuffle(l1)
+        random.shuffle(l2)
+
+        s0 = util.OrderedSet(l0)
+        s1 = util.OrderedSet(l1)
+        s2 = util.OrderedSet(l2)
+
+        assert list(s0.union(s1, s2)) == l0 + l1 + l2
+
+    def test_intersection(self):
+        l0 = list(range(10, 40))
+        l1 = list(range(20, 40))
+        l2 = list(range(20, 30))
+        random.shuffle(l0)
+        random.shuffle(l1)
+        random.shuffle(l2)
+
+        s0 = util.OrderedSet(l0)
+        s1 = util.OrderedSet(l1)
+        s2 = util.OrderedSet(l2)
+
+        assert s0.intersection(s1, s2) == s2
+
+    def test_difference(self):
+        l0 = list(range(10, 40))
+        l1 = list(range(20, 40))
+        l2 = list(range(20, 30))
+        random.shuffle(l0)
+        random.shuffle(l1)
+        random.shuffle(l2)
+
+        s0 = util.OrderedSet(l0)
+        s1 = util.OrderedSet(l1)
+        s2 = util.OrderedSet(l2)
+
+        assert s0.difference(s1, s2) == set(range(10, 20))
+
+    def test_reversed(self):
+        l = list(range(10))
+        random.shuffle(l)
+
+        s = util.OrderedSet(l)
+        assert list(reversed(s)) == list(reversed(l))


### PR DESCRIPTION
- This is a necessary step for running interdependent tests with the
  serial execution policy.
- This commit adds also an implementation of an ordered set.
  This data structure is quite useful in several contexts and is indeed
  used extensively in implementing the test dependencies. Its
  implementation is based on an `OrderedDict`, but it provides the
  complete `Set` and `MutableSet` interfaces.

Fixes UES-284.