### PR TITLE
[test] Set `num_cpus_per_task` to the TensorFlow Horovod test

### DIFF
--- a/cscs-checks/apps/tensorflow/tf_horovod_check.py
+++ b/cscs-checks/apps/tensorflow/tf_horovod_check.py
@@ -33,6 +33,7 @@ class TensorFlowHorovodTest(rfm.RunOnlyRegressionTest):
             }
 
         self.num_tasks_per_node = 1
+        self.num_cpus_per_task = 12
         self.perf_patterns = {
             'throughput': sn.avg(sn.extractall(
                 r'total images/sec:\s+(?P<throughput>\S+)',


### PR DESCRIPTION
@jgphpc found that in this test, doing `export OMP_NUM_THREADS=$SLURM_CPUS_PER_TASK` produce the message `libgomp: Invalid value for environment variable OMP_NUM_THREADS` because as `--cpus-per-task` is not defined, `SLURM_CPUS_PER_TASK` has no value. This PR adds `self.num_cpus_per_task = 12` to the test.