### PR TITLE
[ci] Ignore irrelevant `@` comments when triggering the CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,7 +16,7 @@ stage('Initialization') {
             echo sh(script: 'env|sort', returnStdout: true)
 
             def githubComment = env.ghprbCommentBody
-            if (githubComment == 'null') {
+            if (githubComment == 'null' || !githubComment.trim().startsWith('@jenkins-cscs')) {
                 machinesToRun = machinesList
                 currentBuild.result = 'SUCCESS'
                 return


### PR DESCRIPTION
* This solves the problem of the ci trying to interpret github comments of 3rd party tools like codecov/pep8speaks.
 
* The comment is only taken into account if it starts with "@jenkins-cscs".