### PR TITLE
[ci] Update system config for Kesch

### DIFF
--- a/config/cscs-ci.py
+++ b/config/cscs-ci.py
@@ -119,6 +119,19 @@ class ReframeSettings:
                     'cxx': 'g++',
                     'ftn': 'gfortran',
                 },
+                'PrgEnv-cray': {
+                    'type': 'ProgEnvironment',
+                    'modules': ['PE/17.06',
+                                'PrgEnv-CrayCCE/17.06'],
+                },
+                'PrgEnv-pgi': {
+                    'type': 'ProgEnvironment',
+                    'modules': ['PE/17.06',
+                                'PrgEnv-pgi/18.05'],
+                    'cc': 'mpicc',
+                    'cxx': 'mpicxx',
+                    'ftn': 'mpif90',
+                },
             },
             '*': {
                 'PrgEnv-cray': {

--- a/config/cscs-ci.py
+++ b/config/cscs-ci.py
@@ -111,7 +111,10 @@ class ReframeSettings:
             'kesch': {
                 'PrgEnv-gnu': {
                     'type': 'ProgEnvironment',
-                    'modules': ['PrgEnv-gnu'],
+                    'modules': [
+                        'PE/17.06',
+                        'PrgEnv-gnu'
+                    ],
                     'cc': 'gcc',
                     'cxx': 'g++',
                     'ftn': 'gfortran',
@@ -120,22 +123,26 @@ class ReframeSettings:
             '*': {
                 'PrgEnv-cray': {
                     'type': 'ProgEnvironment',
-                    'modules': ['PrgEnv-cray'],
+                    'modules': [
+                        'PE/17.06',
+                        'PrgEnv-CrayCCE/17.06'
+                    ],
                 },
 
                 'PrgEnv-gnu': {
                     'type': 'ProgEnvironment',
-                    'modules': ['PrgEnv-gnu'],
-                },
-
-                'PrgEnv-intel': {
-                    'type': 'ProgEnvironment',
-                    'modules': ['PrgEnv-intel'],
+                    'modules': [
+                        'PE/17.06',
+                        'PrgEnv-gnu'
+                    ],
                 },
 
                 'PrgEnv-pgi': {
                     'type': 'ProgEnvironment',
-                    'modules': ['PrgEnv-pgi'],
+                    'modules': [
+                        'PE/17.06',
+                        'PrgEnv-pgi'
+                    ],
                 },
 
                 'builtin': {

--- a/config/cscs-ci.py
+++ b/config/cscs-ci.py
@@ -123,26 +123,22 @@ class ReframeSettings:
             '*': {
                 'PrgEnv-cray': {
                     'type': 'ProgEnvironment',
-                    'modules': [
-                        'PE/17.06',
-                        'PrgEnv-CrayCCE/17.06'
-                    ],
+                    'modules': ['PrgEnv-cray'],
                 },
 
                 'PrgEnv-gnu': {
                     'type': 'ProgEnvironment',
-                    'modules': [
-                        'PE/17.06',
-                        'PrgEnv-gnu'
-                    ],
+                    'modules': ['PrgEnv-gnu'],
+                },
+
+                'PrgEnv-intel': {
+                    'type': 'ProgEnvironment',
+                    'modules': ['PrgEnv-intel'],
                 },
 
                 'PrgEnv-pgi': {
                     'type': 'ProgEnvironment',
-                    'modules': [
-                        'PE/17.06',
-                        'PrgEnv-pgi'
-                    ],
+                    'modules': ['PrgEnv-pgi'],
                 },
 
                 'builtin': {

--- a/config/cscs.py
+++ b/config/cscs.py
@@ -337,29 +337,34 @@ class ReframeSettings:
             'kesch': {
                 'PrgEnv-pgi-nompi': {
                     'type': 'ProgEnvironment',
-                    'modules': ['PrgEnv-pgi/17.10'],
+                    'modules': ['PE/17.06',
+                                'PrgEnv-pgi/18.05'],
                     'cc': 'pgcc',
                     'cxx': 'pgc++',
                     'ftn': 'pgf90',
                 },
                 'PrgEnv-pgi': {
                     'type': 'ProgEnvironment',
-                    'modules': ['PrgEnv-pgi/17.10_gdr'],
+                    'modules': ['PE/17.06',
+                                'PrgEnv-pgi/18.05'],
                     'cc': 'mpicc',
                     'cxx': 'mpicxx',
                     'ftn': 'mpif90',
                 },
                 'PrgEnv-cray': {
                     'type': 'ProgEnvironment',
-                    'modules': ['PrgEnv-cray/1.0.2_gdr'],
+                    'modules': ['PE/17.06',
+                                'PrgEnv-CrayCCE/17.06'],
                 },
                 'PrgEnv-cray-nompi': {
                     'type': 'ProgEnvironment',
-                    'modules': ['PrgEnv-cray'],
+                    'modules': ['PE/17.06',
+                                'PrgEnv-cray'],
                 },
                 'PrgEnv-gnu': {
                     'type': 'ProgEnvironment',
-                    'modules': ['gmvapich2/17.02_cuda_8.0_gdr'],
+                    'modules': ['PE/17.06',
+                                'gmvapich2/17.02_cuda_8.0_gdr'],
                     'variables': {
                         'LD_PRELOAD': '$(pkg-config --variable=libdir mvapich2-gdr)/libmpi.so'
                     },
@@ -369,7 +374,8 @@ class ReframeSettings:
                 },
                 'PrgEnv-gnu-nompi': {
                     'type': 'ProgEnvironment',
-                    'modules': ['PrgEnv-gnu'],
+                    'modules': ['PE/17.06',
+                                'PrgEnv-gnu'],
                     'cc': 'gcc',
                     'cxx': 'g++',
                     'ftn': 'gfortran',

--- a/config/cscs.py
+++ b/config/cscs.py
@@ -341,7 +341,7 @@ class ReframeSettings:
                 'PrgEnv-pgi-nompi': {
                     'type': 'ProgEnvironment',
                     'modules': ['PE/17.06',
-                                'PrgEnv-pgi/18.05'],
+                                'PrgEnv-pgi/18.5'],
                     'cc': 'pgcc',
                     'cxx': 'pgc++',
                     'ftn': 'pgf90',
@@ -349,7 +349,7 @@ class ReframeSettings:
                 'PrgEnv-pgi': {
                     'type': 'ProgEnvironment',
                     'modules': ['PE/17.06',
-                                'PrgEnv-pgi/18.05'],
+                                'PrgEnv-pgi/18.5'],
                     'cc': 'mpicc',
                     'cxx': 'mpicxx',
                     'ftn': 'mpif90',


### PR DESCRIPTION
Updating the environments to account for the new meta-modules, which became necessary to support two different toolchain versions. The config file targets the production PE/17.06.