### PR TITLE
[feat] Fall back to a generic system configuration if system auto-detection fails

### DIFF
--- a/docs/configure.rst
+++ b/docs/configure.rst
@@ -314,17 +314,57 @@ The possible attributes of an environment are the following:
 System Auto-Detection
 ---------------------
 
-When the ReFrame is launched, it tries to auto-detect the current system based on its site configuration. The auto-detection process is as follows:
+When the ReFrame is launched, it tries to detect the current system and select the correct site configuration entry. The auto-detection process is as follows:
 
 ReFrame first tries to obtain the hostname from ``/etc/xthostname``, which provides the unqualified *machine name* in Cray systems.
-If this cannot be found the hostname will be obtained from the standard ``hostname`` command. Having retrieved the hostname, ReFrame goes through all the systems in its configuration and tries to match the hostname against any of the patterns in the ``hostnames`` attribute of `system configuration <#system-configuration>`__.
+If this cannot be found the hostname will be obtained from the standard ``hostname`` command. 
+Having retrieved the hostname, ReFrame goes through all the systems in its configuration and tries to match the hostname against any of the patterns in the ``hostnames`` attribute of `system configuration <#system-configuration>`__.
 The detection process stops at the first match found, and the system it belongs to is considered as the current system.
-If the system cannot be auto-detected, ReFrame will fail with an error message.
+If the system cannot be auto-detected, ReFrame will issue a warning and fall back to a generic system configuration, which is equivalent to the following:
+
+.. code-block:: python
+
+   site_configuration = {
+       'systems': {
+           'generic': {
+               'descr': 'Generic fallback system configuration',
+               'hostnames': ['localhost'],
+               'partitions': {
+                   'login': {
+                       'scheduler': 'local',
+                       'environs': ['builtin-gcc'],
+                       'descr': 'Login nodes'
+                   }
+               }
+           }
+       },
+       'environments': {
+           '*': {
+               'builtin-gcc': {
+                   'type': 'ProgEnvironment',
+                   'cc':  'gcc',
+                   'cxx': 'g++',
+                   'ftn': 'gfortran',
+               }
+           }
+       }
+   }
+
+
+
+
 You can override completely the auto-detection process by specifying a system or a system partition with the ``--system`` option (e.g., ``--system daint`` or ``--system daint:gpu``).
 
+.. note::
+   Instead of issuing an error, ReFrame falls back to a generic system configuration in case system auto-detection fails.
 
-Showing configuration
----------------------
+   .. versionchanged:: 2.19
+
+
+
+
+Viewing the current system configuration
+----------------------------------------
 
 .. versionadded:: 2.16
 

--- a/docs/configure.rst
+++ b/docs/configure.rst
@@ -314,7 +314,7 @@ The possible attributes of an environment are the following:
 System Auto-Detection
 ---------------------
 
-When the ReFrame is launched, it tries to detect the current system and select the correct site configuration entry. The auto-detection process is as follows:
+When ReFrame is launched, it tries to detect the current system and select the correct site configuration entry. The auto-detection process is as follows:
 
 ReFrame first tries to obtain the hostname from ``/etc/xthostname``, which provides the unqualified *machine name* in Cray systems.
 If this cannot be found the hostname will be obtained from the standard ``hostname`` command. 

--- a/reframe/frontend/cli.py
+++ b/reframe/frontend/cli.py
@@ -266,9 +266,36 @@ def main():
     try:
         runtime.init_runtime(settings.site_configuration, options.system)
     except SystemAutodetectionError:
-        printer.error("could not auto-detect system; please use the "
-                      "`--system' option to specify one explicitly")
-        sys.exit(1)
+        printer.warning(
+            'could not find a configuration entry for the current system; '
+            'falling back to a generic system configuration; '
+            'please check the online documentation on how to configure '
+            'ReFrame for your system.'
+        )
+        settings.site_configuration['systems'] = {
+            'generic': {
+                'descr': 'Generic fallback system configuration',
+                'hostnames': ['localhost'],
+                'partitions': {
+                    'login': {
+                        'scheduler': 'local',
+                        'environs': ['builtin-gcc'],
+                        'descr': 'Login nodes'
+                    }
+                }
+            }
+        }
+        settings.site_configuration['environments'] = {
+            '*': {
+                'builtin-gcc': {
+                    'type': 'ProgEnvironment',
+                    'cc':  'gcc',
+                    'cxx': 'g++',
+                    'ftn': 'gfortran',
+                }
+            }
+        }
+        runtime.init_runtime(settings.site_configuration, 'generic')
     except Exception as e:
         printer.error('configuration error: %s' % e)
         printer.verbose(''.join(traceback.format_exception(*sys.exc_info())))

--- a/reframe/settings.py
+++ b/reframe/settings.py
@@ -11,11 +11,8 @@ class ReframeSettings:
     checks_path_recurse = True
     site_configuration = {
         'systems': {
-            # Generic system used also in unit tests
             'generic': {
                 'descr': 'Generic example system',
-
-                # Adjust to your system's hostname
                 'hostnames': ['localhost'],
                 'partitions': {
                     'login': {


### PR DESCRIPTION
We now issue a warning instead of an error and we fall back to a default system configuration, that is generic enough to allow ReFrame to run anywhere. User is pointed to the documentation for configuring ReFrame for her system.

Fixes #832.