### PR TITLE
Fix performance report

### DIFF
--- a/reframe/frontend/statistics.py
+++ b/reframe/frontend/statistics.py
@@ -127,7 +127,7 @@ class TestStats:
 
                 report.append('   - %s' % t.check.current_environ)
 
-            for key, ref in t.check.perfvalues.items():
+            for ref in t.check.perfvalues.values():
                 var = ref[0]
                 val = ref[1]
                 try:

--- a/reframe/frontend/statistics.py
+++ b/reframe/frontend/statistics.py
@@ -128,10 +128,10 @@ class TestStats:
                 report.append('   - %s' % t.check.current_environ)
 
             for key, ref in t.check.perfvalues.items():
-                var = key.split(':')[-1]
-                val = ref[0]
+                var = ref[0]
+                val = ref[1]
                 try:
-                    unit = ref[4]
+                    unit = ref[5]
                 except IndexError:
                     unit = '(no unit specified)'
 


### PR DESCRIPTION
This MR fixes the performance report output.

Before:
```
==============================================================================
PERFORMANCE REPORT
------------------------------------------------------------------------------
misc-perf
- bluebear:sandybridge
   - default
      * perf: perf 0.1
------------------------------------------------------------------------------
```

After:
```
==============================================================================
PERFORMANCE REPORT
------------------------------------------------------------------------------
misc-perf
- bluebear:sandybridge
   - default
      * perf: 10.0 unit/s
------------------------------------------------------------------------------
```