### PR TITLE
[bugfix] Do not ignore `sourcepath` if build system is explicitly set

### DIFF
--- a/reframe/core/pipeline.py
+++ b/reframe/core/pipeline.py
@@ -645,8 +645,8 @@ class RegressionTest:
     # Export read-only views to interesting fields
     @property
     def current_environ(self):
-        """The programming environment that the regression test is currently executing
-        with.
+        """The programming environment that the regression test is currently
+        executing with.
 
         This is set by the framework during the :func:`setup` phase.
 
@@ -1000,7 +1000,7 @@ class RegressionTest:
                 else:
                     self.build_system = 'Make'
 
-                self.build_system.srcdir = self.sourcepath
+            self.build_system.srcdir = self.sourcepath
         else:
             if not self.build_system:
                 self.build_system = 'SingleSource'

--- a/unittests/resources/checks/src/code/Makefile
+++ b/unittests/resources/checks/src/code/Makefile
@@ -1,0 +1,7 @@
+.PHONY: clean
+
+hello: ../hello.c
+	$(CC) $(CFLAGS) -o $@ $<
+
+clean:
+	/bin/rm -f $(PROGRAMS)

--- a/unittests/test_pipeline.py
+++ b/unittests/test_pipeline.py
@@ -260,6 +260,17 @@ class TestRegressionTest(unittest.TestCase):
         test.valid_systems = ['*']
         self.assertRaises(ReframeError, self._run_test, test)
 
+    def test_sourcesdir_build_system(self):
+        test = RegressionTest('hellocheck_make', 'unittests/resources/checks')
+        test.build_system = 'Make'
+        test.sourcepath = 'code'
+        test.executable = './code/hello'
+        test.local = True
+        test.valid_systems = ['*']
+        test.valid_prog_environs = ['*']
+        test.sanity_patterns = sn.assert_found(r'Hello, World\!', test.stdout)
+        self._run_test(test)
+
     def test_sourcesdir_none_generated_sources(self):
         test = RegressionTest('hellocheck_generated_sources',
                               'unittests/resources/checks')


### PR DESCRIPTION
* Create corresponding unittest.

Fixes #860 