### PR TITLE
[bugfix] Fix wrong error message emitted when a user module is loaded with the `-m` option

### DIFF
--- a/reframe/frontend/cli.py
+++ b/reframe/frontend/cli.py
@@ -497,7 +497,6 @@ def main():
         for m in options.user_modules:
             try:
                 rt.modules_system.load_module(m, force=True)
-                raise EnvironError("test")
             except EnvironError as e:
                 printer.warning("could not load module '%s' correctly: "
                                 "Skipping..." % m)


### PR DESCRIPTION
- This line was producing a fake error message when trying to load user modules
  with the `-m` option.

Fixes #885.