### PR TITLE
Fix openacc_cuda_mpi_cppstd.F90

### DIFF
--- a/cscs-checks/mch/src/compute_cuda.cu
+++ b/cscs-checks/mch/src/compute_cuda.cu
@@ -28,9 +28,9 @@ void cuda_kernel_no_copy(float* a, float* b, int n)
   const int THREADS_PER_BLOCK = 1;
   const int NUMBER_OF_BLOCKS = 10;
 
-  cudaThreadSynchronize();
+  cudaDeviceSynchronize();
   simple_add<<<NUMBER_OF_BLOCKS, THREADS_PER_BLOCK>>>(a, b, n);
-  cudaThreadSynchronize();
+  cudaDeviceSynchronize();
 
   cudaCheckErrors("cuda error");
 }
@@ -47,9 +47,9 @@ void cuda_kernel_with_copy(float* a, float* b, int n)
   cudaMemcpy(d_a, a, n*sizeof(float), cudaMemcpyHostToDevice);
   cudaMemcpy(d_b, b, n*sizeof(float), cudaMemcpyHostToDevice);
     
-  cudaThreadSynchronize();
+  cudaDeviceSynchronize();
   simple_add<<<NUMBER_OF_BLOCKS, THREADS_PER_BLOCK>>>(d_a, d_b, n);
-  cudaThreadSynchronize();
+  cudaDeviceSynchronize();
 
   cudaMemcpy(a, d_a, n*sizeof(float), cudaMemcpyDeviceToHost);
   

--- a/cscs-checks/mch/src/openacc_cuda_mpi_cppstd.F90
+++ b/cscs-checks/mch/src/openacc_cuda_mpi_cppstd.F90
@@ -74,9 +74,9 @@ program openacc_cuda_mpi_cppstd
     if (sum(f1) /= EXPECTED_CUDA_SUM) then
       write (*,*) "Result : FAIL"
       write (*,*) "Expected value sum(f1): ", EXPECTED_CUDA_SUM, "actual value:", sum(f1)
-    else if (sum(f3) /= EXPECTED_CPP_STD_SUM) then
+    else if (sum(f2) /= EXPECTED_CPP_STD_SUM) then
       write (*,*) "Result : FAIL"
-      write (*,*) "Expected value sum(f3): ", EXPECTED_CPP_STD_SUM, "actual value:", sum(f3)
+      write (*,*) "Expected value sum(f2): ", EXPECTED_CPP_STD_SUM, "actual value:", sum(f2)
     else if (data_sum(1) /= ref_val) then
       write (*,*) "Result : FAIL"
       write (*,*) "Expected value data_sum: ", ref_val, "actual value:", data_sum(1)

--- a/cscs-checks/mch/src/openacc_cuda_mpi_cppstd.F90
+++ b/cscs-checks/mch/src/openacc_cuda_mpi_cppstd.F90
@@ -76,7 +76,7 @@ program openacc_cuda_mpi_cppstd
       write (*,*) "Expected value sum(f1): ", EXPECTED_CUDA_SUM, "actual value:", sum(f1)
     else if (sum(f3) /= EXPECTED_CUDA_SUM) then
       write (*,*) "Result : FAIL"
-      write (*,*) "Expected value sum(f2): ", EXPECTED_CPP_STD_SUM, "actual value:", sum(f2)
+      write (*,*) "Expected value sum(f3): ", EXPECTED_CUDA_SUM, "actual value:", sum(f3)
     else if (data_sum(1) /= ref_val) then
       write (*,*) "Result : FAIL"
       write (*,*) "Expected value data_sum: ", ref_val, "actual value:", data_sum(1)

--- a/cscs-checks/mch/src/openacc_cuda_mpi_cppstd.F90
+++ b/cscs-checks/mch/src/openacc_cuda_mpi_cppstd.F90
@@ -74,7 +74,7 @@ program openacc_cuda_mpi_cppstd
     if (sum(f1) /= EXPECTED_CUDA_SUM) then
       write (*,*) "Result : FAIL"
       write (*,*) "Expected value sum(f1): ", EXPECTED_CUDA_SUM, "actual value:", sum(f1)
-    else if (sum(f2) /= EXPECTED_CPP_STD_SUM) then
+    else if (sum(f3) /= EXPECTED_CUDA_SUM) then
       write (*,*) "Result : FAIL"
       write (*,*) "Expected value sum(f2): ", EXPECTED_CPP_STD_SUM, "actual value:", sum(f2)
     else if (data_sum(1) /= ref_val) then


### PR DESCRIPTION
After merging the pull request #888, we are getting the following error:
```
 MPI test on GPU with OpenACC using  8 tasks
 Result : FAIL
 Expected value sum(f3):  55. actual value: 110.
``` 
I think that there is a mistake in the fix submitted by @cosunae: the array that should be checked for the `EXPECTED_CPP_STD_SUM` is `f2` and not `f3`, since only the first one is called as argument in `call_cpp_std`. What do you think @lxavier?

P.S.: I have replaced `cudaThreadSynchronize()` with `cudaDeviceSynchronize()` in `compute_cuda.cu` since the first one is deprecated.