### PR TITLE
AutomaticArrays reference performance on Dom

### DIFF
--- a/cscs-checks/mch/automatic_arrays_acc.py
+++ b/cscs-checks/mch/automatic_arrays_acc.py
@@ -35,7 +35,7 @@ class AutomaticArraysCheck(rfm.RegressionTest):
         self.arrays_reference = {
             'PrgEnv-cray': {
                 'daint:gpu': {'time': (5.7E-05, None, 0.15)},
-                'dom:gpu': {'time': (5.8E-05, None, 0.15)},
+                'dom:gpu': {'time': (7.5E-05, None, 0.15)},
                 'kesch:cn': {'time': (2.9E-04, None, 0.15)},
             },
             'PrgEnv-pgi': {


### PR DESCRIPTION
Given the new results after the CLE 7 upgrade, the performance needs to be adapted: 
see https://jira.cscs.ch/browse/MAINT-108