### PR TITLE
[feat] Add new syntax for attaching arbitrary regression test methods to pipeline stages

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -31,6 +31,18 @@ Regression test classes and related utilities
    .. versionadded:: 2.13
 
 
+.. py:decorator:: reframe.run_after
+
+   This is an alias of :func:`reframe.core.decorators.run_after`.
+
+   .. versionadded:: 2.20
+
+.. py:decorator:: reframe.run_before
+
+   This is an alias of :func:`reframe.core.decorators.run_before`.
+
+   .. versionadded:: 2.20
+
 .. py:decorator:: reframe.simple_test
 
    This is an alias of :func:`reframe.core.decorators.simple_test`.

--- a/reframe/core/decorators.py
+++ b/reframe/core/decorators.py
@@ -1,11 +1,15 @@
 #
-# Decorators for registering tests with the framework
+# Decorators used for the definition of tests
 #
 
-__all__ = ['parameterized_test', 'simple_test', 'required_version']
+__all__ = [
+    'parameterized_test', 'simple_test', 'required_version',
+    'run_before', 'run_after'
+]
 
 
 import collections
+import functools
 import inspect
 import sys
 import traceback
@@ -155,3 +159,27 @@ def required_version(*versions):
         return cls
 
     return _skip_tests
+
+
+def _runx(phase):
+    def deco(func):
+        if hasattr(func, '_rfm_attach'):
+            func._rfm_attach.append(phase)
+        else:
+            func._rfm_attach = [phase]
+
+        @functools.wraps(func)
+        def _fn(*args, **kwargs):
+            func(*args, **kwargs)
+
+        return _fn
+
+    return deco
+
+
+def run_before(phase):
+    return _runx('pre_' + phase)
+
+
+def run_after(phase):
+    return _runx('post_' + phase)

--- a/reframe/core/decorators.py
+++ b/reframe/core/decorators.py
@@ -177,9 +177,23 @@ def _runx(phase):
     return deco
 
 
-def run_before(phase):
-    return _runx('pre_' + phase)
+def run_before(stage):
+    '''Run the decorated function before the specified pipeline stage.
+
+    The decorated function must be a method of a regression test.
+
+    .. versionadded:: 2.20
+
+    '''
+    return _runx('pre_' + stage)
 
 
-def run_after(phase):
-    return _runx('post_' + phase)
+def run_after(stage):
+    '''Run the decorated function after the specified pipeline stage.
+
+    The decorated function must be a method of a regression test.
+
+    .. versionadded:: 2.20
+
+    '''
+    return _runx('post_' + stage)

--- a/reframe/core/meta.py
+++ b/reframe/core/meta.py
@@ -1,0 +1,21 @@
+#
+# Met-class for creating regression tests.
+#
+
+
+class RegressionTestMeta(type):
+    def __init__(cls, name, bases, namespace, **kwargs):
+        super().__init__(name, bases, namespace, **kwargs)
+
+        # Set up the hooks for the pipeline stages based on the _rfm_attach
+        # attribute
+        hooks = {}
+        for v in namespace.values():
+            if hasattr(v, '_rfm_attach'):
+                for phase in v._rfm_attach:
+                    try:
+                        hooks[phase].append(v)
+                    except KeyError:
+                        hooks[phase] = [v]
+
+        cls._rfm_pipeline_hooks = hooks

--- a/tutorial/advanced/advanced_example8.py
+++ b/tutorial/advanced/advanced_example8.py
@@ -45,8 +45,8 @@ class MatrixVectorTest(rfm.RegressionTest):
         self.maintainers = ['you-can-type-your-email-here']
         self.tags = {'tutorial'}
 
-    def setup(self, partition, environ, **job_opts):
+    @rfm.run_before('compile')
+    def setflags(self):
         if self.prgenv_flags is not None:
-            self.build_system.cflags = self.prgenv_flags[environ.name]
-
-        super().setup(partition, environ, **job_opts)
+            env = self.current_environ.name
+            self.build_system.cflags = self.prgenv_flags[env]

--- a/tutorial/example2.py
+++ b/tutorial/example2.py
@@ -20,17 +20,17 @@ class Example2aTest(rfm.RegressionTest):
         self.maintainers = ['you-can-type-your-email-here']
         self.tags = {'tutorial'}
 
-    def setup(self, partition, environ, **job_opts):
-        if environ.name == 'PrgEnv-cray':
+    @rfm.run_before('compile')
+    def setflags(self):
+        env = self.current_environ.name
+        if env == 'PrgEnv-cray':
             self.build_system.cflags = ['-homp']
-        elif environ.name == 'PrgEnv-gnu':
+        elif env == 'PrgEnv-gnu':
             self.build_system.cflags = ['-fopenmp']
-        elif environ.name == 'PrgEnv-intel':
+        elif env == 'PrgEnv-intel':
             self.build_system.cflags = ['-openmp']
-        elif environ.name == 'PrgEnv-pgi':
+        elif env == 'PrgEnv-pgi':
             self.build_system.cflags = ['-mp']
-
-        super().setup(partition, environ, **job_opts)
 
 
 @rfm.simple_test
@@ -57,6 +57,6 @@ class Example2bTest(rfm.RegressionTest):
         self.maintainers = ['you-can-type-your-email-here']
         self.tags = {'tutorial'}
 
-    def setup(self, partition, environ, **job_opts):
-        self.build_system.cflags = self.prgenv_flags[environ.name]
-        super().setup(partition, environ, **job_opts)
+    @rfm.run_before('compile')
+    def setflags(self):
+        self.build_system.cflags = self.prgenv_flags[self.current_environ.name]

--- a/tutorial/example3.py
+++ b/tutorial/example3.py
@@ -29,6 +29,6 @@ class Example3Test(rfm.RegressionTest):
         self.maintainers = ['you-can-type-your-email-here']
         self.tags = {'tutorial'}
 
-    def setup(self, partition, environ, **job_opts):
-        self.build_system.cflags = self.prgenv_flags[environ.name]
-        super().setup(partition, environ, **job_opts)
+    @rfm.run_before('compile')
+    def setflags(self):
+        self.build_system.cflags = self.prgenv_flags[self.current_environ.name]

--- a/tutorial/example4.py
+++ b/tutorial/example4.py
@@ -22,6 +22,6 @@ class Example4Test(rfm.RegressionTest):
         self.maintainers = ['you-can-type-your-email-here']
         self.tags = {'tutorial'}
 
-    def setup(self, partition, environ, **job_opts):
-        self.build_system.cflags = self.prgenv_flags[environ.name]
-        super().setup(partition, environ, **job_opts)
+    @rfm.run_before('compile')
+    def setflags(self):
+        self.build_system.cflags = self.prgenv_flags[self.current_environ.name]

--- a/tutorial/example8.py
+++ b/tutorial/example8.py
@@ -26,11 +26,11 @@ class BaseMatrixVectorTest(rfm.RegressionTest):
         self.maintainers = ['you-can-type-your-email-here']
         self.tags = {'tutorial'}
 
-    def setup(self, partition, environ, **job_opts):
+    @rfm.run_before('compile')
+    def setflags(self):
         if self.prgenv_flags is not None:
-            self.build_system.cflags = self.prgenv_flags[environ.name]
-
-        super().setup(partition, environ, **job_opts)
+            env = self.current_environ.name
+            self.build_system.cflags = self.prgenv_flags[env]
 
 
 @rfm.simple_test


### PR DESCRIPTION
This PR offers a new syntax for attaching arbitrary regression test methods to pipeline stages. This is achieved using the `@run_before(stage)` or `@run_after(stage)` decorators, where `stage` is a string representing a pipeline stage. Valid pipeline stages are the following: `setup`, `compile`, `run`, `sanity`, `performance` and `cleanup`. This syntax will render less common or even obsolete the overriding of the pipeline methods, such as `setup()` for doing common tasks, such as setting the compilation flags. Users will not have to remember the signatures of the pipeline methods and to always call `super()`. For example, setting the compilation flags based on the programming environment can now be written very nicely as follows:

```python
@rfm.simple_test
class Example2bTest(rfm.RegressionTest):
    def __init__(self):
        self.descr = 'Matrix-vector multiplication example with OpenMP'
        self.valid_systems = ['*']
        self.valid_prog_environs = ['PrgEnv-cray', 'PrgEnv-gnu',
                                    'PrgEnv-intel', 'PrgEnv-pgi']
        self.sourcepath = 'example_matrix_vector_multiplication_openmp.c'
        self.build_system = 'SingleSource'
        self.executable_opts = ['1024', '100']
        self.prgenv_flags = {
            'PrgEnv-cray':  ['-homp'],
            'PrgEnv-gnu':   ['-fopenmp'],
            'PrgEnv-intel': ['-openmp'],
            'PrgEnv-pgi':   ['-mp']
        }
        self.variables = {
            'OMP_NUM_THREADS': '4'
        }
        self.sanity_patterns = sn.assert_found(
            r'time for single matrix vector multiplication', self.stdout)
        self.maintainers = ['you-can-type-your-email-here']
        self.tags = {'tutorial'}

    @rfm.run_before('compile')
    def setflags(self):
        self.build_system.cflags = self.prgenv_flags[self.current_environ.name]
```

Some pipeline stages, namely `compile` and `run`, are implemented as two phases: (a) launch the operation asynchronously and (b) wait for the operation to complete. In such cases the `@run_after` decorated functions will run after the stage is completed (i.e., after it is waited for).

This is still WIP, because I need to update the documentation. Other than that, you are free to review.