### PR TITLE
[test] Fix CUDA checks on Kesch

### DIFF
--- a/cscs-checks/cuda/cuda_checks.py
+++ b/cscs-checks/cuda/cuda_checks.py
@@ -16,7 +16,7 @@ class CudaCheck(rfm.RegressionTest):
         self.sourcesdir = os.path.join(self.current_system.resourcesdir,
                                        'CUDA', 'essentials')
         if self.current_system.name == 'kesch':
-            self.modules = ['craype-accel-nvidia35']
+            self.modules = ['cudatoolkit/8.0.61']
         else:
             self.modules = ['craype-accel-nvidia60']
 

--- a/cscs-checks/microbenchmarks/osu/osu_tests.py
+++ b/cscs-checks/microbenchmarks/osu/osu_tests.py
@@ -306,7 +306,7 @@ class G2GBandwidthTest(P2PBaseTest):
             self.modules = ['craype-accel-nvidia60']
             self.variables = {'MPICH_RDMA_ENABLED_CUDA': '1'}
         elif self.current_system.name == 'kesch':
-            self.modules = ['craype-accel-nvidia35']
+            self.modules = ['cudatoolkit/8.0.61']
             self.variables = {'MV2_USE_CUDA': '1'}
 
         self.build_system.cppflags = ['-D_ENABLE_CUDA_']
@@ -346,7 +346,7 @@ class G2GLatencyTest(P2PBaseTest):
             self.modules = ['craype-accel-nvidia60']
             self.variables = {'MPICH_RDMA_ENABLED_CUDA': '1'}
         elif self.current_system.name == 'kesch':
-            self.modules = ['craype-accel-nvidia35']
+            self.modules = ['cudatoolkit/8.0.61']
             self.variables = {'MV2_USE_CUDA': '1'}
 
         self.build_system.cppflags = ['-D_ENABLE_CUDA_']

--- a/cscs-checks/tools/profiling_and_debugging/cuda_gdb.py
+++ b/cscs-checks/tools/profiling_and_debugging/cuda_gdb.py
@@ -17,7 +17,7 @@ class CudaGdbCheck(rfm.RegressionTest):
         self.executable = 'cuda-gdb cuda_gdb_check'
         if self.current_system.name == 'kesch':
             self.exclusive_access = True
-            self.modules = ['craype-accel-nvidia35']
+            self.modules = ['cudatoolkit/8.0.61']
         else:
             self.modules = ['craype-accel-nvidia60']
 

--- a/cscs-checks/tools/profiling_and_debugging/ddt.py
+++ b/cscs-checks/tools/profiling_and_debugging/ddt.py
@@ -100,7 +100,7 @@ class DdtGpuCheck(DdtCheck):
         self.system_modules = {
             'daint': ['craype-accel-nvidia60'],
             'dom': ['craype-accel-nvidia60'],
-            'kesch': ['craype-accel-nvidia35']
+            'kesch': ['cudatoolkit/8.0.61']
         }
         sysname = self.current_system.name
         self.modules += self.system_modules.get(sysname, [])

--- a/cscs-checks/tools/profiling_and_debugging/nvprof.py
+++ b/cscs-checks/tools/profiling_and_debugging/nvprof.py
@@ -36,7 +36,7 @@ class NvprofCheck(rfm.RegressionTest):
         # the programming environment should be adapted / fixed
         if self.current_system.name == 'kesch':
             self.exclusive_access = True
-            self.modules = ['craype-accel-nvidia35']
+            self.modules = ['cudatoolkit/8.0.61']
             self.build_system.ldflags += ['-lcudart', '-lm']
         else:
             self.modules = ['craype-accel-nvidia60']


### PR DESCRIPTION
We need to change `craype-accel-nvidia35` with `cudatoolkit/8.0.61`, otherwise the first module will load the more recent `cudatoolkit/9.2.148` and the checks will fail. See the results at 
https://jenkins.cscs.ch/blue/organizations/jenkins/reframe-kesch-production-daily/detail/reframe-kesch-production-daily/165/pipeline/