### PR TITLE
[feat] Improve and simplify the topological sorting of the test cases

### DIFF
--- a/reframe/frontend/dependency.py
+++ b/reframe/frontend/dependency.py
@@ -140,17 +140,23 @@ def toposort(graph):
     test_deps = _reduce_deps(graph)
     visited = util.OrderedSet()
 
-    def visit(node):
+    def visit(node, path):
+        # We assume an acyclic graph
+        assert node not in path
+
+        path.add(node)
+
         # Do a DFS visit of all the adjacent nodes
         for adj in test_deps[node]:
             if adj not in visited:
-                visit(adj)
+                visit(adj, path)
 
+        path.pop()
         visited.add(node)
 
     for r in test_deps.keys():
         if r not in visited:
-            visit(r)
+            visit(r, util.OrderedSet())
 
     # Index test cases by test name
     cases_by_name = {}

--- a/reframe/frontend/dependency.py
+++ b/reframe/frontend/dependency.py
@@ -145,69 +145,61 @@ def _reverse_deps(graph):
 
 
 def toposort(graph):
-    # NOTES on implementation:
-    #
-    # 1. This function assumes a directed acyclic graph.
-    # 2. The purpose of this function is to topologically sort the test cases,
-    #    not only the tests. However, since we do not allow cycles between
-    #    tests in any case (even if this could be classified a
-    #    pseudo-dependency), we first do a topological sort of the tests and we
-    #    subsequently sort the test cases by partition and by programming
-    #    environment.
-    # 3. To achieve this 3-step sorting with a single sort operations, we rank
-    #    the test cases by associating them with an integer key based on the
-    #    result of the topological sort of the tests and by choosing an
-    #    arbitrary ordering of the partitions and the programming environment.
-
     test_deps = _reduce_deps(graph)
     rev_deps  = _reverse_deps(test_deps)
+    levels = {}
+    visited = util.OrderedSet()
 
-    # We do a BFS traversal from each root
-    visited = {}
+    def dfs_visit(node, lvl):
+        lvl += 1
+        try:
+            levels[node] = max(levels[node], lvl)
+        except KeyError:
+            levels[node] = lvl
+
+        for adj in rev_deps[node]:
+            if adj not in visited:
+                dfs_visit(adj, lvl)
+
+        visited.add(node)
+
     roots = set(t for t, deps in test_deps.items() if not deps)
     for r in roots:
-        unvisited = util.OrderedSet([r])
-        visited[r] = util.OrderedSet()
-        while unvisited:
-            # Next node is one whose all dependencies are already visited
-            # FIXME: This makes sorting's complexity O(V^2)
-            node = None
-            for n in unvisited:
-                if test_deps[n] <= visited[r]:
-                    node = n
-                    break
+        dfs_visit(r, -1)
 
-            # If node is None, graph has a cycle and this is a bug; this
-            # function assumes acyclic graphs only
-            assert node is not None
+    # Group by level number
+    nodes_per_level = {}
+    for node, lvl in levels.items():
+        try:
+            nodes_per_level[lvl].append(node)
+        except KeyError:
+            nodes_per_level[lvl] = [node]
 
-            unvisited.remove(node)
-            adjacent = rev_deps[node]
-            unvisited |= util.OrderedSet(
-                n for n in adjacent if n not in visited
-            )
-            visited[r].add(node)
-
-    # Combine all individual sequences into a single one
-    ordered_tests = util.OrderedSet()
-    for tests in visited.values():
-        ordered_tests |= tests
-
-    # Get all partitions and programming environments from test cases
-    partitions = util.OrderedSet()
-    environs = util.OrderedSet()
+    # Index test cases by test name
+    cases_by_name = {}
     for c in graph.keys():
-        partitions.add(c.partition.fullname)
-        environs.add(c.environ.name)
+        try:
+            cases_by_name[c.check.name].append(c)
+        except KeyError:
+            cases_by_name[c.check.name] = [c]
 
-    # Rank test cases; we first need to calculate the base for the rank number
-    base = max(len(partitions), len(environs)) + 1
-    ranks = {}
-    for i, test in enumerate(ordered_tests):
-        for j, part in enumerate(partitions):
-            for k, env in enumerate(environs):
-                ranks[test, part, env] = i*base**2 + j*base + k
+    # Now arrange the test cases based on the topologically sorted tests
+    ret = []
+    for lvl, nodes in nodes_per_level.items():
+        for n in nodes:
+            ret += cases_by_name[n]
 
-    return sorted(graph.keys(),
-                  key=lambda x: ranks[x.check.name,
-                                      x.partition.fullname, x.environ.name])
+    # Assign nodes to the levels that they can be safely cleaned up
+    cleanup_seq = {}
+    for node, deps in rev_deps.items():
+        if deps:
+            lvl = max(levels[n] for n in deps)
+        else:
+            lvl = levels[node]
+
+        try:
+            cleanup_seq[lvl].append(node)
+        except KeyError:
+            cleanup_seq[lvl] = [node]
+
+    return ret, nodes_per_level, cleanup_seq

--- a/unittests/test_policies.py
+++ b/unittests/test_policies.py
@@ -742,7 +742,7 @@ class TestDependencies(unittest.TestCase):
             executors.generate_testcases([t0, t1, t2, t3, t4,
                                           t5, t6, t7, t8])
         )
-        cases, *_ = dependency.toposort(deps)
+        cases = dependency.toposort(deps)
         cases_order = []
         tests = util.OrderedSet()
         visited_tests = set()

--- a/unittests/test_policies.py
+++ b/unittests/test_policies.py
@@ -742,7 +742,7 @@ class TestDependencies(unittest.TestCase):
             executors.generate_testcases([t0, t1, t2, t3, t4,
                                           t5, t6, t7, t8])
         )
-        cases, _, _ = dependency.toposort(deps)
+        cases, *_ = dependency.toposort(deps)
         cases_order = []
         tests = util.OrderedSet()
         visited_tests = set()

--- a/unittests/test_policies.py
+++ b/unittests/test_policies.py
@@ -742,7 +742,7 @@ class TestDependencies(unittest.TestCase):
             executors.generate_testcases([t0, t1, t2, t3, t4,
                                           t5, t6, t7, t8])
         )
-        cases = dependency.toposort(deps)
+        cases, _, _ = dependency.toposort(deps)
         cases_order = []
         tests = util.OrderedSet()
         visited_tests = set()


### PR DESCRIPTION
1. Algorithm's complexity is now O(V+E). ~~The algorithm is doing a DFS traversal of the nodes and assigns each node a level (i.e., in which step it has been discovered). Then the nodes are arranged by increasing level and the test cases of each node (test) are expanded inline. Tests that are in the same level can be executed in any order (or in parallel).~~
The algorithm is simply doing a DFS traversal of the test graph (the original one, not the reversed) and marks a node as visited after all of its outcoming edges are explored. The visited nodes are kept in an ordered set, essentially providing at the end the topologically sorted tests.

2. ~~Additional information that will help execution policies in executing the test cases is now returned. More specifically, a dictionary that arranges the tests per level is returned, as well as a dictionary arranging the nodes by the level that their resources can be safely cleaned up. A test's resources can be safely deleted when the maximum level of its immediate children has been processed.~~

3. Another fixed needed for correct support of pre Python 3.6 dictionaries was to use and ordered dictionary for storing the test case graph. This was needed because we want to keep the order of partitions and environments, in order to keep the final output properly organised.