### PR TITLE
[test] Update reference values of G2G [1] check

### DIFF
--- a/cscs-checks/mch/g2g_meteoswiss_check.py
+++ b/cscs-checks/mch/g2g_meteoswiss_check.py
@@ -45,6 +45,6 @@ class G2GMeteoswissTest(rfm.RegressionTest):
                                      self.stdout, 'time', float)
         }
         self.reference = {
-            'kesch:cn': {'time': (3.00, None, 0.2)}
+            'kesch:cn': {'time': (3.461, None, 0.2)}
         }
         self.variables = {'G2G': str(g2g)}


### PR DESCRIPTION
Update reference value of G2G using the average of last 14 timings in `/project/g110/reframe/perflogs/kesch/cn/G2GMeteoswissTest_1.log`, as discussed in CSCS RT #36752.
See http://jenkins-mch.cscs.ch/view/ReFrame/job/reframe-kesch-production-daily.