### PR TITLE
[feat] Replace `reframe_module` configuration option with command line option

### DIFF
--- a/config/cscs-ci.py
+++ b/config/cscs-ci.py
@@ -4,7 +4,6 @@
 
 
 class ReframeSettings:
-    reframe_module = 'reframe'
     job_poll_intervals = [1, 2, 3]
     job_submit_timeout = 60
     checks_path = ['checks/']

--- a/config/cscs-pbs.py
+++ b/config/cscs-pbs.py
@@ -4,7 +4,6 @@
 
 
 class ReframeSettings:
-    reframe_module = 'reframe'
     job_poll_intervals = [1, 2, 3]
     job_submit_timeout = 60
     checks_path = ['checks/']

--- a/config/cscs.py
+++ b/config/cscs.py
@@ -4,7 +4,6 @@
 
 
 class ReframeSettings:
-    reframe_module = 'reframe'
     job_poll_intervals = [1, 2, 3]
     job_submit_timeout = 60
     checks_path = ['checks/']

--- a/config/cscs.py
+++ b/config/cscs.py
@@ -481,6 +481,7 @@ class ReframeSettings:
         'modes': {
             '*': {
                 'maintenance': [
+                    '--unload-module=reframe',
                     '--exec-policy=async',
                     '--strict',
                     '--output=$APPS/UES/$USER/regression/maintenance',
@@ -492,6 +493,7 @@ class ReframeSettings:
                     '--timestamp=%F_%H-%M-%S'
                 ],
                 'production': [
+                    '--unload-module=reframe',
                     '--exec-policy=async',
                     '--strict',
                     '--output=$APPS/UES/$USER/regression/production',

--- a/reframe/settings.py
+++ b/reframe/settings.py
@@ -4,7 +4,6 @@
 
 
 class ReframeSettings:
-    reframe_module = None
     job_poll_intervals = [1, 2, 3]
     job_submit_timeout = 60
     checks_path = ['checks/']

--- a/tutorial/config/settings.py
+++ b/tutorial/config/settings.py
@@ -4,7 +4,6 @@
 
 
 class ReframeSettings:
-    reframe_module = 'reframe'
     job_poll_intervals = [1, 2, 3]
     job_submit_timeout = 60
     checks_path = ['checks/']

--- a/unittests/modules/testmod_bar
+++ b/unittests/modules/testmod_bar
@@ -3,7 +3,7 @@ proc ModulesHelp { } {
     Helper module for PyRegression unit tests
 }
 
-module-whatis { Helper module for PyRegression unit tests }
+module-whatis { Helper module for ReFrame unit tests }
 
 conflict testmod_bar
 conflict testmod_foo

--- a/unittests/modules/testmod_boo
+++ b/unittests/modules/testmod_boo
@@ -3,7 +3,7 @@ proc ModulesHelp { } {
     Helper module for PyRegression unit tests
 }
 
-module-whatis { Helper module for PyRegression unit tests }
+module-whatis { Helper module for ReFrame unit tests }
 
 conflict testmod_boo
 conflict testmod_bar

--- a/unittests/modules/testmod_foo
+++ b/unittests/modules/testmod_foo
@@ -3,7 +3,7 @@ proc ModulesHelp { } {
     Helper module for PyRegression unit tests
 }
 
-module-whatis { Helper module for PyRegression unit tests }
+module-whatis { Helper module for ReFrame unit tests }
 
 conflict testmod_foo
 conflict testmod_bar

--- a/unittests/resources/settings.py
+++ b/unittests/resources/settings.py
@@ -4,7 +4,6 @@
 
 
 class ReframeSettings:
-    reframe_module = None
     job_poll_intervals = [1, 2, 3]
     job_submit_timeout = 60
     checks_path = ['checks/']

--- a/unittests/test_cli.py
+++ b/unittests/test_cli.py
@@ -430,3 +430,4 @@ class TestFrontend(unittest.TestCase):
         assert 'Traceback' not in stdout
         assert 'Traceback' not in stderr
         assert returncode == 0
+        ms.unload_module('testmod_foo')


### PR DESCRIPTION
- The `reframe_module` configuration option is now ignored; a warning message is issued.
- It is replaced by the `-u|--unload-module MOD` option.

Fixes #821. 