### PR TITLE
[feat] Add syntax for running functions after dependency resolution

### DIFF
--- a/reframe/core/pipeline.py
+++ b/reframe/core/pipeline.py
@@ -1297,7 +1297,15 @@ class RegressionTest(metaclass=RegressionTestMeta):
 
         self._userdeps.append((target, how, subdeps))
 
-    def getdep(self, target, environ):
+    def getdep(self, target, environ=None):
+        if self.current_environ is None:
+            raise DependencyError(
+                'cannot resolve dependencies before the setup phase'
+            )
+
+        if environ is None:
+            environ = self.current_environ.name
+
         if self._case is None or self._case() is None:
             raise DependencyError('no test case is associated with this test')
 

--- a/unittests/test_pipeline.py
+++ b/unittests/test_pipeline.py
@@ -481,7 +481,7 @@ class TestHooks(unittest.TestCase):
         _run(test, self.partition, self.prgenv)
         assert test.var == 3
 
-    def test_required_deps(self):
+    def test_require_deps(self):
         import unittests.resources.checks.hellocheck as mod
         import reframe.frontend.dependency as dependency
         import reframe.frontend.executors as executors

--- a/unittests/test_pipeline.py
+++ b/unittests/test_pipeline.py
@@ -481,6 +481,49 @@ class TestHooks(unittest.TestCase):
         _run(test, self.partition, self.prgenv)
         assert test.var == 3
 
+    def test_required_deps(self):
+        import unittests.resources.checks.hellocheck as mod
+        import reframe.frontend.dependency as dependency
+        import reframe.frontend.executors as executors
+
+        class T0(mod.HelloTest):
+            def __init__(self):
+                super().__init__()
+                self._prefix = 'unittests/resources/checks'
+                self.name = type(self).__name__
+                self.executable = os.path.join('.', self.name)
+                self.x = 1
+
+        class T1(mod.HelloTest):
+            def __init__(self):
+                super().__init__()
+                self._prefix = 'unittests/resources/checks'
+                self.name = type(self).__name__
+                self.executable = os.path.join('.', self.name)
+                self.depends_on('T0')
+
+            @rfm.require_deps
+            def sety(self, T0):
+                self.y = T0().x + 1
+
+            @rfm.run_before('run')
+            @rfm.require_deps
+            def setz(self, T0):
+                self.z = T0().x + 2
+
+        cases = executors.generate_testcases([T0(), T1()])
+        deps = dependency.build_deps(cases)
+        for c in dependency.toposort(deps):
+            _run(*c)
+
+        for c in cases:
+            t = c.check
+            if t.name == 'T0':
+                assert t.x == 1
+            elif t.name == 'T1':
+                assert t.y == 2
+                assert t.z == 3
+
 
 class TestSyntax(unittest.TestCase):
     def test_regression_test(self):

--- a/unittests/test_policies.py
+++ b/unittests/test_policies.py
@@ -12,6 +12,7 @@ import reframe.frontend.executors as executors
 import reframe.frontend.executors.policies as policies
 import reframe.utility as util
 import reframe.utility.os_ext as os_ext
+from reframe.core.environments import Environment
 from reframe.core.exceptions import DependencyError, JobNotStartedError
 from reframe.frontend.loader import RegressionCheckLoader
 import unittests.fixtures as fixtures
@@ -530,6 +531,14 @@ class TestDependencies(unittest.TestCase):
         # Pick a check to test getdep()
         check_e0 = find_case('Test1_exact', 'e0', cases).check
         check_e1 = find_case('Test1_exact', 'e1', cases).check
+
+        with pytest.raises(DependencyError):
+            check_e0.getdep('Test0')
+
+        # Set the current environment
+        check_e0._current_environ = Environment('e0')
+        check_e1._current_environ = Environment('e1')
+
         assert check_e0.getdep('Test0', 'e0').name == 'Test0'
         assert check_e0.getdep('Test0', 'e1').name == 'Test0'
         assert check_e1.getdep('Test0', 'e1').name == 'Test0'


### PR DESCRIPTION
This PR provides a mechanism around the low-level `getdep()` function that is used to access information on the dependencies of a test. The syntax follows the paradigm of the `@run_before` and `@run_after` decorators  as introduced in #920. The following shows a more concrete example:

```python
import reframe as rfm


@rfm.simple_test
class T0(rfm.RegressionTest):
    def __init__(self):
        ...
        self.x = 1

@rfm.simple_test
class T1(rfm.RegressionTest):
    def __init__(self):
        ...
        self.depends_on('T0')

     @rfm.require_deps
     def sety(self, T0):
        self.y = T0().x + 1
```

The `@require_deps` will bind all arguments of the decorated function to the corresponding test dependencies by name. In the above example, the `T0` argument will be bound to the `T0` test, so that its information can be retrieved when the function is executed. More precisely, each argument of the function (except `self`) is bound to `functools.partial(self.getdep, arg_name)`. This allows to access a specific a test case of the target dependency as in the example below:

```python
     @rfm.require_deps
     def sety(self, T0):
        self.y = T0('PrgEnv-gnu').x + 1
```

When no environment is passed to the bound argument, the `self.current_environ` is assumed.

All functions that require dependencies to be executed after dependency resolution will be executed first after the `setup` phase and before any other function that is set to run after `setup` using the `@run_after('setup')` decorator. You may also attach a function that requires dependencies to a different pipeline stage using as usual the `@run_before` or `@run_after` decorators as follows:

```python
     @rfm.run_before('compile')
     @rfm.require_deps
     def sety(self, T0):
        self.y = T0().x + 1
```

The only requirement is that the `@require_deps` decorator is the innermost one. Of course, you can attach a function that requires dependencies to run before the `setup()` method, in which a runtime error will be generated.

Fixes UES-540.