### PR TITLE
[feat] Add SSH job launcher

### DIFF
--- a/docs/configure.rst
+++ b/docs/configure.rst
@@ -269,6 +269,21 @@ ReFrame supports the following parallel job launchers:
 * ``mpirun``: Programs on the configured partition will be launched using the ``mpirun`` command.
 * ``mpiexec``: Programs on the configured partition will be launched using the ``mpiexec`` command.
 * ``local``: Programs on the configured partition will be launched as-is without using any parallel program launcher.
+* ``ssh``: *[new in 2.20]* Programs on the configured partition will be launched using SSH.
+  This option uses the partition's ``access`` parameter (see `above <#partition-configuration>`__) in order to determine the remote host and any additional options to be passed to the SSH client.
+  The ``ssh`` command will be launched in "batch mode," meaning that password-less access to the remote host must be configured.
+  Here is an example configuration for the ``ssh`` launcher:
+
+  .. code:: python
+
+    'partition_name': {
+        'scheduler': 'local+ssh',
+        'access': ['-l admin', 'remote.host'],
+        'environs': ['builtin'],
+    }
+
+  Note that the environment is not propagated to the remote host, so the ``environs`` variable has no practical meaning except for enabling the testing of this partition.
+
 
 There exist also the following aliases for specific combinations of job schedulers and parallel program launchers:
 

--- a/reframe/core/launchers/registry.py
+++ b/reframe/core/launchers/registry.py
@@ -79,3 +79,4 @@ def getlauncher(name):
 # Import the launchers modules to trigger their registration
 import reframe.core.launchers.local  # noqa: F401, F403
 import reframe.core.launchers.mpi    # noqa: F401, F403
+import reframe.core.launchers.ssh    # noqa: F401, F403

--- a/reframe/core/launchers/ssh.py
+++ b/reframe/core/launchers/ssh.py
@@ -1,0 +1,14 @@
+from reframe.core.launchers import JobLauncher
+from reframe.core.launchers.registry import register_launcher
+
+
+@register_launcher('ssh')
+class SSHLauncher(JobLauncher):
+    def command(self, job):
+        hostname = job.sched_access[-1]
+        ssh_opts = list(job.sched_access[:-1]) + self.options
+        return ['ssh', '-o BatchMode=yes'] + ssh_opts + [hostname]
+
+    def run_command(self, job):
+        # self.options is processed specially above
+        return ' '.join(self.command(job))

--- a/unittests/test_launchers.py
+++ b/unittests/test_launchers.py
@@ -203,3 +203,22 @@ class TestLocalLauncher(_TestLauncher, unittest.TestCase):
     @property
     def expected_minimal_command(self):
         return ''
+
+
+class TestSSHLauncher(_TestLauncher, unittest.TestCase):
+    def setUp(self):
+        super().setUp()
+        self.job._sched_access = ['-l user', '-p 22222', 'host']
+        self.minimal_job._sched_access = ['host']
+
+    @property
+    def launcher(self):
+        return getlauncher('ssh')(['--foo'])
+
+    @property
+    def expected_command(self):
+        return 'ssh -o BatchMode=yes -l user -p 22222 --foo host'
+
+    @property
+    def expected_minimal_command(self):
+        return 'ssh -o BatchMode=yes --foo host'


### PR DESCRIPTION
This PR adds a "parallel" job launcher that uses directly SSH. Here is how to configure:

```python
    'partition_name': {
        'scheduler': 'local+ssh',
        'access': ['-l admin', 'remote.host'],
        'environs': ['builtin'],
    }
```

This launcher will use the partition's `access` parameter in order to set up the SSH connection.
The last argument is always the remote host and it is recommended that it is a separate element in the list, since this will allow you to define additional launcher options in your tests, if needed, without surprises. The environment is *not* propagated; the `environs` option is there only for enabling the testing of this partition. Finally, the `ssh` client will be executed with `BatchMode=yes`, so that password-less access to the remote host must have been set up.

Fixes #880.

@bcfriesen Could you test this feature? 