### PR TITLE
[test] Update reference for AutomaticArrays test on Dom

### DIFF
--- a/cscs-checks/mch/automatic_arrays_acc.py
+++ b/cscs-checks/mch/automatic_arrays_acc.py
@@ -40,7 +40,7 @@ class AutomaticArraysCheck(rfm.RegressionTest):
             },
             'PrgEnv-pgi': {
                 'daint:gpu': {'time': (6.4E-05, None, 0.15)},
-                'dom:gpu': {'time': (6.3E-05, None, 0.15)},
+                'dom:gpu': {'time': (7.5e-05, None, 0.15)},
                 'kesch:cn': {'time': (1.4E-04, None, 0.15)},
             }
         }


### PR DESCRIPTION
Given the new results after the CLE 7 upgrade, the performance needs to be adapted: see https://jira.cscs.ch/browse/MAINT-108