### PR TITLE
[feat] Lazy evaluation of job-related attributes and environments

### DIFF
--- a/reframe/core/environments.py
+++ b/reframe/core/environments.py
@@ -13,7 +13,6 @@ class Environment:
 
     It is simply a collection of modules to be loaded and environment variables
     to be set when this environment is loaded by the framework.
-    Users may not create or modify directly environments.
     '''
     name = fields.TypedField('name', typ.Str[r'(\w|-)+'])
     modules = fields.TypedField('modules', typ.List[str])
@@ -23,11 +22,6 @@ class Environment:
         self._name = name
         self._modules = list(modules)
         self._variables = collections.OrderedDict(variables)
-        self._loaded = False
-        self._saved_variables = {}
-        self._conflicted = []
-        self._preloaded = set()
-        self._module_ops = []
 
     @property
     def name(self):
@@ -63,100 +57,6 @@ class Environment:
                 all(os.environ.get(k, None) == os_ext.expandvars(v)
                     for k, v in self._variables.items()))
 
-    def load(self):
-        # conflicted module list must be filled at the time of load
-        rt = runtime()
-        for m in self._modules:
-            if rt.modules_system.is_module_loaded(m):
-                self._preloaded.add(m)
-
-            conflicted = rt.modules_system.load_module(m, force=True)
-            for c in conflicted:
-                self._module_ops.append(('u', c))
-
-            self._module_ops.append(('l', m))
-            self._conflicted += conflicted
-
-        for k, v in self._variables.items():
-            if k in os.environ:
-                self._saved_variables[k] = os.environ[k]
-
-            os.environ[k] = os_ext.expandvars(v)
-
-        self._loaded = True
-
-    def unload(self):
-        if not self._loaded:
-            return
-
-        for k, v in self._variables.items():
-            if k in self._saved_variables:
-                os.environ[k] = self._saved_variables[k]
-            elif k in os.environ:
-                del os.environ[k]
-
-        # Unload modules in reverse order
-        for m in reversed(self._modules):
-            if m not in self._preloaded:
-                runtime().modules_system.unload_module(m)
-
-        # Reload the conflicted packages, previously removed
-        for m in self._conflicted:
-            runtime().modules_system.load_module(m)
-
-        self._loaded = False
-
-    def emit_load_commands(self):
-        rt = runtime()
-        emit_fn = {
-            'l': rt.modules_system.emit_load_commands,
-            'u': rt.modules_system.emit_unload_commands
-        }
-        module_ops = self._module_ops or [('l', m) for m in self._modules]
-
-        # Emit module commands
-        ret = []
-        for op, m in module_ops:
-            ret += emit_fn[op](m)
-
-        # Emit variable set commands
-        for k, v in self._variables.items():
-            ret.append('export %s=%s' % (k, v))
-
-        return ret
-
-    def emit_unload_commands(self):
-        rt = runtime()
-
-        # Invert the logic of module operations, since we are unloading the
-        # environment
-        emit_fn = {
-            'l': rt.modules_system.emit_unload_commands,
-            'u': rt.modules_system.emit_load_commands
-        }
-
-        ret = []
-        for var in self._variables.keys():
-            ret.append('unset %s' % var)
-
-        if self._module_ops:
-            module_ops = reversed(self._module_ops)
-        else:
-            module_ops = (('l', m) for m in reversed(self._modules))
-
-        for op, m in module_ops:
-            ret += emit_fn[op](m)
-
-        return ret
-
-    def __eq__(self, other):
-        if not isinstance(other, type(self)):
-            return NotImplemented
-
-        return (self._name == other._name and
-                set(self._modules) == set(other._modules) and
-                self._variables == other._variables)
-
     def details(self):
         '''Return a detailed description of this environment.'''
         variables = '\n'.join(' '*8 + '- %s=%s' % (k, v)
@@ -168,6 +68,14 @@ class Environment:
         ]
         return '\n'.join(lines)
 
+    def __eq__(self, other):
+        if not isinstance(other, type(self)):
+            return NotImplemented
+
+        return (self._name == other._name and
+                set(self._modules) == set(other._modules) and
+                self._variables == other._variables)
+
     def __str__(self):
         return self.name
 
@@ -177,44 +85,51 @@ class Environment:
                           self.modules, self.variables)
 
 
-def swap_environments(src, dst):
-    src.unload()
-    dst.load()
-
-
-class EnvironmentSnapshot(Environment):
+class _EnvironmentSnapshot(Environment):
     def __init__(self, name='env_snapshot'):
-        self._name = name
-        self._modules = runtime().modules_system.loaded_modules()
-        self._variables = dict(os.environ)
-        self._conflicted = []
+        super().__init__(name,
+                         runtime().modules_system.loaded_modules(),
+                         os.environ.items())
 
-    def load(self):
+    def restore(self):
+        '''Restore this environment snapshot.'''
         os.environ.clear()
         os.environ.update(self._variables)
-        self._loaded = True
-
-    @property
-    def is_loaded(self):
-        raise NotImplementedError('is_loaded is not a valid property '
-                                  'of an environment snapshot')
-
-    def unload(self):
-        raise NotImplementedError('cannot unload an environment snapshot')
 
 
-class save_environment:
-    '''A context manager for saving and restoring the current environment.'''
+def snapshot():
+    '''Create an environment snapshot'''
+    return _EnvironmentSnapshot()
 
-    def __init__(self):
-        self.environ_save = EnvironmentSnapshot()
 
-    def __enter__(self):
-        return self.environ_save
+def load(*environs):
+    '''Load environments in the current Python context.
 
-    def __exit__(self, exc_type, exc_value, traceback):
-        # Restore the environment and propagate any exception thrown
-        self.environ_save.load()
+    Returns a tuple containing a snapshot of the environment at entry to this
+    function and a list of shell commands required to load ``environs``.
+    '''
+    env_snapshot = snapshot()
+    commands = []
+    rt = runtime()
+    for env in environs:
+        for m in env.modules:
+            conflicted = rt.modules_system.load_module(m, force=True)
+            for c in conflicted:
+                commands += rt.modules_system.emit_unload_commands(c)
+
+            commands += rt.modules_system.emit_load_commands(m)
+
+        for k, v in env.variables.items():
+            os.environ[k] = os_ext.expandvars(v)
+            commands.append('export %s=%s' % (k, v))
+
+    return env_snapshot, commands
+
+
+def emit_load_commands(*environs):
+    env_snapshot, commands = load(*environs)
+    env_snapshot.restore()
+    return commands
 
 
 class ProgEnvironment(Environment):

--- a/reframe/core/environments.py
+++ b/reframe/core/environments.py
@@ -72,9 +72,9 @@ class Environment:
         if not isinstance(other, type(self)):
             return NotImplemented
 
-        return (self._name == other._name and
-                set(self._modules) == set(other._modules) and
-                self._variables == other._variables)
+        return (self.name == other.name and
+                set(self.modules) == set(other.modules) and
+                self.variables == other.variables)
 
     def __str__(self):
         return self.name
@@ -95,6 +95,18 @@ class _EnvironmentSnapshot(Environment):
         '''Restore this environment snapshot.'''
         os.environ.clear()
         os.environ.update(self._variables)
+
+    def __eq__(self, other):
+        if not isinstance(other, Environment):
+            return NotImplemented
+
+        # Order of variables is not important when comparing snapshots
+        for k, v in self.variables.items():
+            if other.variables[k] != v:
+                return False
+
+        return (self.name == other.name and
+                set(self.modules) == set(other.modules))
 
 
 def snapshot():

--- a/reframe/core/pipeline.py
+++ b/reframe/core/pipeline.py
@@ -935,13 +935,6 @@ class RegressionTest(metaclass=RegressionTestMeta):
             name='rfm_%s_job' % self.name,
             launcher=launcher_type(),
             workdir=self._stagedir,
-            num_tasks=self.num_tasks,
-            num_tasks_per_node=self.num_tasks_per_node,
-            num_tasks_per_core=self.num_tasks_per_core,
-            num_tasks_per_socket=self.num_tasks_per_socket,
-            num_cpus_per_task=self.num_cpus_per_task,
-            use_smt=self.use_multithreading,
-            time_limit=self.time_limit,
             sched_access=self._current_partition.access,
             sched_exclusive_access=self.exclusive_access,
             **job_opts)
@@ -1102,6 +1095,13 @@ class RegressionTest(metaclass=RegressionTestMeta):
         if not self.current_system or not self._current_partition:
             raise PipelineError('no system or system partition is set')
 
+        self.job.num_tasks = self.num_tasks
+        self.job.num_tasks_per_node = self.num_tasks_per_node
+        self.job.num_tasks_per_core = self.num_tasks_per_core
+        self.job.num_cpus_per_task = self.num_cpus_per_task
+        self.job.use_smt = self.use_multithreading
+        self.job.time_limit = self.time_limit
+
         exec_cmd = [self.job.launcher.run_command(self.job),
                     self.executable, *self.executable_opts]
         commands = [*self.pre_run, ' '.join(exec_cmd), *self.post_run]
@@ -1119,6 +1119,10 @@ class RegressionTest(metaclass=RegressionTestMeta):
         msg = ('spawned job (%s=%s)' %
                ('pid' if self.is_local() else 'jobid', self._job.jobid))
         self.logger.debug(msg)
+
+        # Update num_tasks if test is flexible
+        if self.job.sched_flex_alloc_tasks:
+            self.num_tasks = self.job.num_tasks
 
     def poll(self):
         '''Poll the test's state.

--- a/reframe/core/pipeline.py
+++ b/reframe/core/pipeline.py
@@ -13,6 +13,7 @@ import itertools
 import os
 import shutil
 
+import reframe.core.environments as env
 import reframe.core.fields as fields
 import reframe.core.logging as logging
 import reframe.core.runtime as rt
@@ -21,7 +22,6 @@ import reframe.utility.os_ext as os_ext
 import reframe.utility.typecheck as typ
 from reframe.core.buildsystems import BuildSystemField
 from reframe.core.deferrable import deferrable, _DeferredExpression, evaluate
-from reframe.core.environments import Environment, EnvironmentSnapshot
 from reframe.core.exceptions import (BuildError, DependencyError,
                                      PipelineError, SanityError,
                                      PerformanceError)
@@ -567,11 +567,10 @@ class RegressionTest(metaclass=RegressionTestMeta):
     _current_partition = fields.TypedField('_current_partition',
                                            SystemPartition, type(None))
     _current_environ = fields.TypedField('_current_environ',
-                                         Environment, type(None))
-    _user_environ = fields.TypedField('_user_environ', Environment, type(None))
+                                         env.Environment, type(None))
+    _cdt_environ = fields.TypedField('_cdt_environ', env.Environment)
     _job = fields.TypedField('_job', Job, type(None))
     _build_job = fields.TypedField('_build_job', Job, type(None))
-    _cdt_environ = fields.TypedField('_cdt_environ', Environment)
 
     def __new__(cls, *args, **kwargs):
         obj = super().__new__(cls)
@@ -650,7 +649,6 @@ class RegressionTest(metaclass=RegressionTestMeta):
         # Runtime information of the test
         self._current_partition = None
         self._current_environ = None
-        self._user_environ = None
 
         # Associated job
         self._job = None
@@ -677,7 +675,7 @@ class RegressionTest(metaclass=RegressionTestMeta):
         self._case = None
 
         if rt.runtime().non_default_craype:
-            self._cdt_environ = Environment(
+            self._cdt_environ = env.Environment(
                 name='__rfm_cdt_environ',
                 variables={
                     'LD_LIBRARY_PATH': '$CRAY_LD_LIBRARY_PATH:$LD_LIBRARY_PATH'
@@ -685,7 +683,7 @@ class RegressionTest(metaclass=RegressionTestMeta):
             )
         else:
             # Just an empty environment
-            self._cdt_environ = Environment('__rfm_cdt_environ')
+            self._cdt_environ = env.Environment('__rfm_cdt_environ')
 
     # Export read-only views to interesting fields
     @property
@@ -870,30 +868,6 @@ class RegressionTest(metaclass=RegressionTestMeta):
 
         return self.local or self._current_partition.scheduler.is_local
 
-    def _setup_environ(self, environ):
-        '''Setup the current environment and load it.'''
-
-        self._current_environ = environ
-
-        # Set up user environment
-        self._user_environ = Environment(type(self).__name__, self.modules,
-                                         self.variables.items())
-
-        # Temporarily load the test's environment to record the actual module
-        # load/unload sequence
-        environ_save = EnvironmentSnapshot()
-        # First load the local environment of the partition
-        self.logger.debug('loading environment for the current partition')
-        self._current_partition.local_env.load()
-
-        self.logger.debug("loading current programming environment")
-        self._current_environ.load()
-
-        self.logger.debug("loading user's environment")
-        self._user_environ.load()
-        self._cdt_environ.load()
-        environ_save.load()
-
     def _setup_paths(self):
         '''Setup the check's dynamic paths.'''
         self.logger.debug('setting up paths')
@@ -965,7 +939,7 @@ class RegressionTest(metaclass=RegressionTestMeta):
         :raises reframe.core.exceptions.ReframeError: In case of errors.
         '''
         self._current_partition = partition
-        self._setup_environ(environ)
+        self._current_environ = environ
         self._setup_paths()
         self._setup_job(**job_opts)
         if self.perf_patterns is not None:
@@ -1055,8 +1029,10 @@ class RegressionTest(metaclass=RegressionTestMeta):
             *self.build_system.emit_build_commands(self._current_environ),
             *self.postbuild_cmd
         ]
+        user_environ = env.Environment(type(self).__name__,
+                                       self.modules, self.variables.items())
         environs = [self._current_partition.local_env, self._current_environ,
-                    self._user_environ, self._cdt_environ]
+                    user_environ, self._cdt_environ]
 
         self._build_job = getscheduler('local')(
             name='rfm_%s_build' % self.name,
@@ -1105,8 +1081,10 @@ class RegressionTest(metaclass=RegressionTestMeta):
         exec_cmd = [self.job.launcher.run_command(self.job),
                     self.executable, *self.executable_opts]
         commands = [*self.pre_run, ' '.join(exec_cmd), *self.post_run]
+        user_environ = env.Environment(type(self).__name__,
+                                       self.modules, self.variables.items())
         environs = [self._current_partition.local_env, self._current_environ,
-                    self._user_environ, self._cdt_environ]
+                    user_environ, self._cdt_environ]
 
         with os_ext.change_dir(self._stagedir):
             try:
@@ -1273,13 +1251,11 @@ class RegressionTest(metaclass=RegressionTestMeta):
                 shutil.copytree(f, os.path.join(self.outputdir, f_orig))
 
     @_run_hooks()
-    def cleanup(self, remove_files=False, unload_env=True):
+    def cleanup(self, remove_files=False):
         '''The cleanup phase of the regression test pipeline.
 
         :arg remove_files: If :class:`True`, the stage directory associated
             with this test will be removed.
-        :arg unload_env: If :class:`True`, the environment that was used to run
-            this test will be unloaded.
         '''
         aliased = os.path.samefile(self._stagedir, self._outputdir)
         if aliased:
@@ -1292,14 +1268,8 @@ class RegressionTest(metaclass=RegressionTestMeta):
             self.logger.debug('removing stage directory')
             os_ext.rmtree(self._stagedir)
 
-        if unload_env:
-            self.logger.debug("unloading test's environment")
-            self._cdt_environ.unload()
-            self._user_environ.unload()
-            self._current_environ.unload()
-            self._current_partition.local_env.unload()
-
     # Dependency API
+
     def user_deps(self):
         return util.SequenceView(self._userdeps)
 
@@ -1401,7 +1371,7 @@ class CompileOnlyRegressionTest(RegressionTest):
         '''
         # No need to setup the job for compile-only checks
         self._current_partition = partition
-        self._setup_environ(environ)
+        self._current_environ = environ
         self._setup_paths()
 
     @property

--- a/reframe/core/schedulers/__init__.py
+++ b/reframe/core/schedulers/__init__.py
@@ -21,6 +21,18 @@ class Job(abc.ABC):
        Users may not create jobs directly.
     '''
 
+    num_tasks = fields.TypedField('num_tasks', int)
+    num_tasks_per_node = fields.TypedField('num_tasks_per_node',
+                                           int,  type(None))
+    num_tasks_per_core = fields.TypedField('num_tasks_per_core',
+                                           int,  type(None))
+    num_tasks_per_socket = fields.TypedField('num_tasks_per_socket',
+                                             int,  type(None))
+    num_cpus_per_tasks = fields.TypedField('num_cpus_per_task',
+                                           int,  type(None))
+    use_smt = fields.TypedField('use_smt', bool,  type(None))
+    time_limit = fields.TimerField('time_limit', type(None))
+
     #: Options to be passed to the backend job scheduler.
     #:
     #: :type: :class:`List[str]`
@@ -65,21 +77,21 @@ class Job(abc.ABC):
                  sched_options=[]):
 
         # Mutable fields
+        self.num_tasks = num_tasks
+        self.num_tasks_per_node = num_tasks_per_node
+        self.num_tasks_per_core = num_tasks_per_core
+        self.num_tasks_per_socket = num_tasks_per_socket
+        self.num_cpus_per_task = num_cpus_per_task
+        self.use_smt = use_smt
+        self.time_limit = time_limit
         self.options = list(sched_options)
         self.launcher = launcher
 
         self._name = name
         self._workdir = workdir
-        self._num_tasks = num_tasks
-        self._num_tasks_per_node = num_tasks_per_node
-        self._num_tasks_per_core = num_tasks_per_core
-        self._num_tasks_per_socket = num_tasks_per_socket
-        self._num_cpus_per_task = num_cpus_per_task
-        self._use_smt = use_smt
         self._script_filename = script_filename or '%s.sh' % name
         self._stdout = stdout or '%s.out' % name
         self._stderr = stderr or '%s.err' % name
-        self._time_limit = time_limit
         self._nodelist = None
 
         # Backend scheduler related information
@@ -123,18 +135,6 @@ class Job(abc.ABC):
         return self._workdir
 
     @property
-    def num_tasks(self):
-        '''The number of tasks assigned to this job.
-
-        This attribute is useful in a flexible regression test for determining
-        the actual number of tasks that ReFrame assigned to the test.
-
-        For more information on flexible task allocation, please refer to the
-        `tutorial <advanced.html#flexible-regression-tests>`__.
-        '''
-        return self._num_tasks
-
-    @property
     def script_filename(self):
         return self._script_filename
 
@@ -145,30 +145,6 @@ class Job(abc.ABC):
     @property
     def stderr(self):
         return self._stderr
-
-    @property
-    def time_limit(self):
-        return self._time_limit
-
-    @property
-    def num_cpus_per_task(self):
-        return self._num_cpus_per_task
-
-    @property
-    def num_tasks_per_core(self):
-        return self._num_tasks_per_core
-
-    @property
-    def num_tasks_per_node(self):
-        return self._num_tasks_per_node
-
-    @property
-    def num_tasks_per_socket(self):
-        return self._num_tasks_per_socket
-
-    @property
-    def use_smt(self):
-        return self._use_smt
 
     @property
     def sched_flex_alloc_tasks(self):
@@ -222,9 +198,9 @@ class Job(abc.ABC):
                                'required %s, found %s' %
                                (nodes_required, nodes_found))
 
-            self._num_tasks = guessed_num_tasks
+            self.num_tasks = guessed_num_tasks
             getlogger().debug('flex_alloc_tasks: setting num_tasks to %s' %
-                              self._num_tasks)
+                              self.num_tasks)
 
         with shell.generate_script(self.script_filename,
                                    **gen_opts) as builder:

--- a/reframe/core/schedulers/__init__.py
+++ b/reframe/core/schedulers/__init__.py
@@ -5,6 +5,7 @@
 import abc
 
 import reframe.core.debug as debug
+import reframe.core.environments as env
 import reframe.core.fields as fields
 import reframe.core.shell as shell
 import reframe.utility.typecheck as typ
@@ -205,9 +206,7 @@ class Job(abc.ABC):
         with shell.generate_script(self.script_filename,
                                    **gen_opts) as builder:
             builder.write_prolog(self.emit_preamble())
-            for e in environs:
-                builder.write(e.emit_load_commands())
-
+            builder.write(env.emit_load_commands(*environs))
             for c in commands:
                 builder.write_body(c)
 

--- a/reframe/core/schedulers/local.py
+++ b/reframe/core/schedulers/local.py
@@ -115,7 +115,7 @@ class LocalJob(sched.Job):
 
         # Set the time limit to the grace period and let wait() do the final
         # killing
-        self._time_limit = (0, 0, self.cancel_grace_period)
+        self.time_limit = (0, 0, self.cancel_grace_period)
         self.wait()
 
     def wait(self):

--- a/reframe/core/schedulers/pbs.py
+++ b/reframe/core/schedulers/pbs.py
@@ -34,9 +34,9 @@ class PbsJob(sched.Job):
         self._pbs_server = None
 
     def _emit_lselect_option(self):
-        num_tasks_per_node = self._num_tasks_per_node or 1
-        num_cpus_per_task = self._num_cpus_per_task or 1
-        num_nodes = self._num_tasks // num_tasks_per_node
+        num_tasks_per_node = self.num_tasks_per_node or 1
+        num_cpus_per_task = self.num_cpus_per_task or 1
+        num_nodes = self.num_tasks // num_tasks_per_node
         num_cpus_per_node = num_tasks_per_node * num_cpus_per_task
         select_opt = '-l select=%s:mpiprocs=%s:ncpus=%s' % (num_nodes,
                                                             num_tasks_per_node,

--- a/reframe/frontend/cli.py
+++ b/reframe/frontend/cli.py
@@ -7,6 +7,7 @@ import traceback
 
 import reframe
 import reframe.core.config as config
+import reframe.core.environments as env
 import reframe.core.logging as logging
 import reframe.core.runtime as runtime
 import reframe.frontend.argparse as argparse
@@ -380,15 +381,15 @@ def main():
     if options.show_config_env:
         envname = options.show_config_env
         for p in rt.system.partitions:
-            env = p.environment(envname)
-            if env:
+            environ = p.environment(envname)
+            if environ:
                 break
 
-        if env is None:
+        if environ is None:
             printer.error('no such environment: ' + envname)
             sys.exit(1)
 
-        printer.info(env.details())
+        printer.info(environ.details())
         sys.exit(0)
 
     if hasattr(settings, 'perf_logging_config'):
@@ -516,7 +517,7 @@ def main():
 
         # Load the environment for the current system
         try:
-            rt.system.preload_environ.load()
+            env.load(rt.system.preload_environ)
         except EnvironError as e:
             printer.error("failed to load current system's environment; "
                           "please check your configuration")

--- a/reframe/frontend/executors/__init__.py
+++ b/reframe/frontend/executors/__init__.py
@@ -4,9 +4,9 @@ import sys
 import weakref
 
 import reframe.core.debug as debug
+import reframe.core.environments as env
 import reframe.core.logging as logging
 import reframe.core.runtime as runtime
-from reframe.core.environments import EnvironmentSnapshot
 from reframe.core.exceptions import (AbortTaskError, JobNotStartedError,
                                      ReframeFatalError, TaskExit)
 from reframe.frontend.printer import PrettyPrinter
@@ -153,7 +153,7 @@ class RegressionTask:
 
     def setup(self, *args, **kwargs):
         self._safe_call(self.check.setup, *args, **kwargs)
-        self._environ = EnvironmentSnapshot()
+        self._environ = env.snapshot()
 
     def compile(self):
         self._safe_call(self.check.compile)
@@ -193,7 +193,7 @@ class RegressionTask:
         self._notify_listeners('on_task_failure')
 
     def resume(self):
-        self._environ.load()
+        self._environ.restore()
 
     def abort(self, cause=None):
         logging.getlogger().debug('aborting: %s' % self.check.info())
@@ -241,7 +241,7 @@ class Runner:
         self._stats = TestStats()
         self._policy.stats = self._stats
         self._policy.printer = self._printer
-        self._environ_snapshot = EnvironmentSnapshot()
+        self._environ_snapshot = env.snapshot()
 
     def __repr__(self):
         return debug.repr(self)
@@ -274,7 +274,7 @@ class Runner:
                 (len(testcases), num_checks, num_failures), just='center'
             )
             self._printer.timestamp('Finished on', 'short double line')
-            self._environ_snapshot.load()
+            self._environ_snapshot.restore()
 
     def _retry_failed(self, cases):
         rt = runtime.runtime()
@@ -309,7 +309,7 @@ class Runner:
                 print_separator(t.check, 'started processing')
                 last_check = t.check
 
-            self._environ_snapshot.load()
+            self._environ_snapshot.restore()
             self._policy.runcase(t)
 
         # Close the last visual box

--- a/reframe/frontend/executors/policies.py
+++ b/reframe/frontend/executors/policies.py
@@ -45,7 +45,7 @@ class SerialExecutionPolicy(ExecutionPolicy):
             if not self.skip_performance_check:
                 task.performance()
 
-            task.cleanup(not self.keep_stage_files, False)
+            task.cleanup(not self.keep_stage_files)
 
         except TaskExit:
             return
@@ -222,7 +222,7 @@ class AsynchronousExecutionPolicy(ExecutionPolicy, TaskEventListener):
         if not self.skip_performance_check:
             task.performance()
 
-        task.cleanup(not self.keep_stage_files, False)
+        task.cleanup(not self.keep_stage_files)
 
     def _failall(self, cause):
         '''Mark all tests as failures'''

--- a/reframe/utility/__init__.py
+++ b/reframe/utility/__init__.py
@@ -472,10 +472,16 @@ class SequenceView(collections.abc.Sequence):
         return NotImplemented
 
     def __eq__(self, other):
-        if not isinstance(other, collections.abc.Sequence):
-            return NotImplemented
+        if isinstance(other, SequenceView):
+            return self.__container == other.__container
 
         return self.__container == other
+
+    def __repr__(self):
+        return '%s(%r)' % (type(self).__name__, self.__container)
+
+    def __str__(self):
+        return str(self.__container)
 
 
 class MappingView(collections.abc.Mapping):
@@ -511,8 +517,17 @@ class MappingView(collections.abc.Mapping):
     def __len__(self, *args, **kwargs):
         return self.__mapping.__len__(*args, **kwargs)
 
-    def __eq__(self, *args, **kwargs):
-        return self.__mapping.__eq__(*args, **kwargs)
+    def __eq__(self, other):
+        if isinstance(other, MappingView):
+            return self.__mapping == other.__mapping
+
+        return self.__mapping.__eq__(other)
 
     def __ne__(self, *args, **kwargs):
         return self.__mapping.__ne__(*args, **kwargs)
+
+    def __repr__(self):
+        return '%s(%r)' % (type(self).__name__, self.__mapping)
+
+    def __str__(self):
+        return str(self.__mapping)

--- a/unittests/test_cli.py
+++ b/unittests/test_cli.py
@@ -10,16 +10,16 @@ from contextlib import redirect_stdout, redirect_stderr
 from io import StringIO
 
 import reframe.core.config as config
+import reframe.core.environments as env
 import reframe.core.runtime as rt
 import reframe.utility.os_ext as os_ext
 import unittests.fixtures as fixtures
-from reframe.core.environments import EnvironmentSnapshot
 
 
 def run_command_inline(argv, funct, *args, **kwargs):
     # Save current execution context
     argv_save = sys.argv
-    environ_save = EnvironmentSnapshot()
+    environ_save = env.snapshot()
     sys.argv = argv
     exitcode = None
 
@@ -35,7 +35,7 @@ def run_command_inline(argv, funct, *args, **kwargs):
                 exitcode = e.code
             finally:
                 # Restore execution context
-                environ_save.load()
+                environ_save.restore()
                 sys.argv = argv_save
 
     return (exitcode,

--- a/unittests/test_environments.py
+++ b/unittests/test_environments.py
@@ -114,6 +114,7 @@ class TestEnvironment(unittest.TestCase):
         env1 = env.Environment('env1', modules=['foo', 'bar'])
         env2 = env.Environment('env1', modules=['bar', 'foo'])
         assert env1 == env2
+        assert env2 == env1
 
     def test_not_equal(self):
         env1 = env.Environment('env1', modules=['foo', 'bar'])
@@ -122,7 +123,7 @@ class TestEnvironment(unittest.TestCase):
 
         # Variables are ordered, because they might depend on each other
         env1 = env.Environment('env1', variables=[('a', 1), ('b', 2)])
-        env1 = env.Environment('env1', variables=[('b', 2), ('a', 1)])
+        env2 = env.Environment('env1', variables=[('b', 2), ('a', 1)])
         assert env1 != env2
 
     @fixtures.switch_to_user_runtime

--- a/unittests/test_environments.py
+++ b/unittests/test_environments.py
@@ -1,7 +1,8 @@
 import os
+import pytest
 import unittest
 
-import reframe.core.environments as renv
+import reframe.core.environments as env
 import reframe.utility.os_ext as os_ext
 import unittests.fixtures as fixtures
 from reframe.core.runtime import runtime
@@ -11,11 +12,11 @@ from reframe.core.exceptions import EnvironError
 class TestEnvironment(unittest.TestCase):
     def assertModulesLoaded(self, modules):
         for m in modules:
-            self.assertTrue(self.modules_system.is_module_loaded(m))
+            assert self.modules_system.is_module_loaded(m)
 
     def assertModulesNotLoaded(self, modules):
         for m in modules:
-            self.assertFalse(self.modules_system.is_module_loaded(m))
+            assert not self.modules_system.is_module_loaded(m)
 
     def setup_modules_system(self):
         if not fixtures.has_sane_modules_system():
@@ -34,197 +35,164 @@ class TestEnvironment(unittest.TestCase):
         self.modules_system = None
         os.environ['_var0'] = 'val0'
         os.environ['_var1'] = 'val1'
-        self.environ_save = renv.EnvironmentSnapshot()
-        self.environ = renv.Environment(name='TestEnv1',
-                                        modules=['testmod_foo'],
-                                        variables=[('_var0', 'val1'),
-                                                   ('_var2', '$_var0'),
-                                                   ('_var3', '${_var1}')])
-        self.environ_other = renv.Environment(name='TestEnv2',
-                                              modules=['testmod_boo'],
-                                              variables={'_var4': 'val4'})
+        self.environ_save = env.snapshot()
+        self.environ = env.Environment(name='TestEnv1',
+                                       modules=['testmod_foo'],
+                                       variables=[('_var0', 'val1'),
+                                                  ('_var2', '$_var0'),
+                                                  ('_var3', '${_var1}')])
+        self.environ_other = env.Environment(name='TestEnv2',
+                                             modules=['testmod_boo'],
+                                             variables={'_var4': 'val4'})
 
     def tearDown(self):
         if self.modules_system is not None:
             self.modules_system.searchpath_remove(fixtures.TEST_MODULES)
 
-        self.environ_save.load()
+        self.environ_save.restore()
 
     def test_setup(self):
         if fixtures.has_sane_modules_system():
-            self.assertEqual(len(self.environ.modules), 1)
-            self.assertIn('testmod_foo', self.environ.modules)
+            assert len(self.environ.modules) == 1
+            assert 'testmod_foo' in self.environ.modules
 
-        self.assertEqual(len(self.environ.variables.keys()), 3)
-        self.assertEqual(self.environ.variables['_var0'], 'val1')
+        assert len(self.environ.variables.keys()) == 3
+        assert self.environ.variables['_var0'] == 'val1'
 
         # No variable expansion, if environment is not loaded
-        self.assertEqual(self.environ.variables['_var2'], '$_var0')
-        self.assertEqual(self.environ.variables['_var3'], '${_var1}')
+        self.environ.variables['_var2'] == '$_var0'
+        self.environ.variables['_var3'] == '${_var1}'
 
     def test_environ_snapshot(self):
-        self.assertRaises(NotImplementedError, self.environ_save.unload)
-        self.environ.load()
-        self.environ_other.load()
-        self.environ_save.load()
-        self.assertEqual(self.environ_save, renv.EnvironmentSnapshot())
-        self.assertFalse(self.environ.is_loaded)
-        self.assertFalse(self.environ_other.is_loaded)
-        with self.assertRaises(NotImplementedError):
-            _ = self.environ_save.is_loaded
-
-    def test_environ_snapshot_context_mgr(self):
-        with renv.save_environment() as env:
-            self.assertIsInstance(env, renv.EnvironmentSnapshot)
-            del os.environ['_var0']
-            os.environ['_var1'] = 'valX'
-            os.environ['_var2'] = 'var3'
-
-        self.assertEqual('val0', os.environ['_var0'])
-        self.assertEqual('val1', os.environ['_var1'])
-        self.assertNotIn('_var2', os.environ)
+        env.load(self.environ, self.environ_other)
+        self.environ_save.restore()
+        assert self.environ_save == env.snapshot()
+        assert not self.environ.is_loaded
+        assert not self.environ_other.is_loaded
 
     def test_load_restore(self):
-        self.environ.load()
-        self.assertEqual(os.environ['_var0'], 'val1')
-        self.assertEqual(os.environ['_var1'], 'val1')
-        self.assertEqual(os.environ['_var2'], 'val1')
-        self.assertEqual(os.environ['_var3'], 'val1')
+        snapshot, _ = env.load(self.environ)
+        os.environ['_var0'] == 'val1'
+        os.environ['_var1'] == 'val1'
+        os.environ['_var2'] == 'val1'
+        os.environ['_var3'] == 'val1'
         if fixtures.has_sane_modules_system():
             self.assertModulesLoaded(self.environ.modules)
 
-        self.assertTrue(self.environ.is_loaded)
-        self.environ.unload()
-        self.assertEqual(self.environ_save, renv.EnvironmentSnapshot())
-        self.assertEqual(os.environ['_var0'], 'val0')
+        assert self.environ.is_loaded
+        snapshot.restore()
+        self.environ_save == env.snapshot()
+        os.environ['_var0'], 'val0'
         if fixtures.has_sane_modules_system():
-            self.assertFalse(
-                self.modules_system.is_module_loaded('testmod_foo'))
+            assert not self.modules_system.is_module_loaded('testmod_foo')
 
-        self.assertFalse(self.environ.is_loaded)
+        assert not self.environ.is_loaded
 
     @fixtures.switch_to_user_runtime
     def test_load_already_present(self):
         self.setup_modules_system()
         self.modules_system.load_module('testmod_boo')
-        self.environ.load()
-        self.environ.unload()
-        self.assertTrue(self.modules_system.is_module_loaded('testmod_boo'))
+        snapshot, _ = env.load(self.environ)
+        snapshot.restore()
+        assert self.modules_system.is_module_loaded('testmod_boo')
 
     def test_load_non_overlapping(self):
-        e0 = renv.Environment(name='e0', variables=[('a', '1'), ('b', '2')])
-        e1 = renv.Environment(name='e1', variables=[('c', '3'), ('d', '4')])
-        e0.load()
-        e1.load()
-        self.assertTrue(e0.is_loaded)
-        self.assertTrue(e1.is_loaded)
+        e0 = env.Environment(name='e0', variables=[('a', '1'), ('b', '2')])
+        e1 = env.Environment(name='e1', variables=[('c', '3'), ('d', '4')])
+        env.load(e0, e1)
+        assert e0.is_loaded
+        assert e1.is_loaded
 
     def test_load_overlapping(self):
-        e0 = renv.Environment(name='e0', variables=[('a', '1'), ('b', '2')])
-        e1 = renv.Environment(name='e1', variables=[('b', '3'), ('c', '4')])
-        e0.load()
-        e1.load()
-        self.assertFalse(e0.is_loaded)
-        self.assertTrue(e1.is_loaded)
+        e0 = env.Environment(name='e0', variables=[('a', '1'), ('b', '2')])
+        e1 = env.Environment(name='e1', variables=[('b', '3'), ('c', '4')])
+        env.load(e0, e1)
+        assert not e0.is_loaded
+        assert e1.is_loaded
 
     def test_equal(self):
-        env1 = renv.Environment('env1', modules=['foo', 'bar'])
-        env2 = renv.Environment('env1', modules=['bar', 'foo'])
-        self.assertEqual(env1, env2)
+        env1 = env.Environment('env1', modules=['foo', 'bar'])
+        env2 = env.Environment('env1', modules=['bar', 'foo'])
+        assert env1 == env2
 
     def test_not_equal(self):
-        env1 = renv.Environment('env1', modules=['foo', 'bar'])
-        env2 = renv.Environment('env2', modules=['foo', 'bar'])
-        self.assertNotEqual(env1, env2)
+        env1 = env.Environment('env1', modules=['foo', 'bar'])
+        env2 = env.Environment('env2', modules=['foo', 'bar'])
+        assert env1 != env2
 
         # Variables are ordered, because they might depend on each other
-        env1 = renv.Environment('env1', variables=[('a', 1), ('b', 2)])
-        env1 = renv.Environment('env1', variables=[('b', 2), ('a', 1)])
-        self.assertNotEqual(env1, env2)
+        env1 = env.Environment('env1', variables=[('a', 1), ('b', 2)])
+        env1 = env.Environment('env1', variables=[('b', 2), ('a', 1)])
+        assert env1 != env2
 
     @fixtures.switch_to_user_runtime
     def test_conflicting_environments(self):
         self.setup_modules_system()
-        envfoo = renv.Environment(name='envfoo',
-                                  modules=['testmod_foo', 'testmod_boo'])
-        envbar = renv.Environment(name='envbar', modules=['testmod_bar'])
-        envfoo.load()
-        envbar.load()
+        envfoo = env.Environment(name='envfoo',
+                                 modules=['testmod_foo', 'testmod_boo'])
+        envbar = env.Environment(name='envbar', modules=['testmod_bar'])
+        env.load(envfoo, envbar)
         for m in envbar.modules:
-            self.assertTrue(self.modules_system.is_module_loaded(m))
+            assert self.modules_system.is_module_loaded(m)
 
         for m in envfoo.modules:
-            self.assertFalse(self.modules_system.is_module_loaded(m))
+            assert not self.modules_system.is_module_loaded(m)
 
     @fixtures.switch_to_user_runtime
     def test_conflict_environ_after_module_load(self):
         self.setup_modules_system()
         self.modules_system.load_module('testmod_foo')
-        envfoo = renv.Environment(name='envfoo', modules=['testmod_foo'])
-        envfoo.load()
-        envfoo.unload()
-        self.assertTrue(self.modules_system.is_module_loaded('testmod_foo'))
+        envfoo = env.Environment(name='envfoo', modules=['testmod_foo'])
+        snapshot, _ = env.load(envfoo)
+        snapshot.restore()
+        assert self.modules_system.is_module_loaded('testmod_foo')
 
     @fixtures.switch_to_user_runtime
     def test_conflict_environ_after_module_force_load(self):
         self.setup_modules_system()
         self.modules_system.load_module('testmod_foo')
-        envbar = renv.Environment(name='envbar', modules=['testmod_bar'])
-        envbar.load()
-        envbar.unload()
-        self.assertTrue(self.modules_system.is_module_loaded('testmod_foo'))
-
-    def test_swap(self):
-        from reframe.core.environments import swap_environments
-
-        self.environ.load()
-        swap_environments(self.environ, self.environ_other)
-        self.assertFalse(self.environ.is_loaded)
-        self.assertTrue(self.environ_other.is_loaded)
+        envbar = env.Environment(name='envbar', modules=['testmod_bar'])
+        snapshot, _ = env.load(envbar)
+        snapshot.restore()
+        assert self.modules_system.is_module_loaded('testmod_foo')
 
     def test_immutability(self):
         # Check emit_load_commands()
-        commands = self.environ.emit_load_commands()
-        self.assertIsNot(commands, self.environ.emit_load_commands())
-        self.assertEqual(commands, self.environ.emit_load_commands())
+        _, commands = env.load(self.environ)
 
         # Try to modify the returned list of commands
         commands.append('foo')
-        self.assertNotIn('foo', self.environ.emit_load_commands())
+        assert 'foo' not in env.load(self.environ)[1]
 
         # Test ProgEnvironment
-        prgenv = renv.ProgEnvironment('foo_prgenv')
-        self.assertIsInstance(prgenv, renv.Environment)
-        with self.assertRaises(AttributeError):
+        prgenv = env.ProgEnvironment('foo_prgenv')
+        assert isinstance(prgenv, env.Environment)
+        with pytest.raises(AttributeError):
             prgenv.cc = 'gcc'
 
-        with self.assertRaises(AttributeError):
+        with pytest.raises(AttributeError):
             prgenv.cxx = 'g++'
 
-        with self.assertRaises(AttributeError):
+        with pytest.raises(AttributeError):
             prgenv.ftn = 'gfortran'
 
-        with self.assertRaises(AttributeError):
+        with pytest.raises(AttributeError):
             prgenv.nvcc = 'clang'
 
-        with self.assertRaises(AttributeError):
+        with pytest.raises(AttributeError):
             prgenv.cppflags = ['-DFOO']
 
-        with self.assertRaises(AttributeError):
+        with pytest.raises(AttributeError):
             prgenv.cflags = ['-O1']
 
-        with self.assertRaises(AttributeError):
+        with pytest.raises(AttributeError):
             prgenv.cxxflags = ['-O1']
 
-        with self.assertRaises(AttributeError):
+        with pytest.raises(AttributeError):
             prgenv.fflags = ['-O1']
 
-        with self.assertRaises(AttributeError):
+        with pytest.raises(AttributeError):
             prgenv.ldflags = ['-lm']
-
-    def test_immutability_after_load(self):
-        self.environ.load()
-        self.test_immutability()
 
     @fixtures.switch_to_user_runtime
     def test_emit_load_commands(self):
@@ -236,7 +204,7 @@ class TestEnvironment(unittest.TestCase):
             'export _var2=$_var0',
             'export _var3=${_var1}',
         ]
-        self.assertEqual(expected_commands, self.environ.emit_load_commands())
+        assert expected_commands == env.emit_load_commands(self.environ)
 
     @fixtures.switch_to_user_runtime
     def test_emit_load_commands_with_confict(self):
@@ -244,12 +212,6 @@ class TestEnvironment(unittest.TestCase):
 
         # Load a conflicting module
         self.modules_system.load_module('testmod_bar')
-
-        # When the environment is not loaded, the conflicting module does not
-        # make a difference
-        self.test_emit_load_commands()
-
-        self.environ.load()
         rt = runtime()
         expected_commands = [
             rt.modules_system.emit_unload_commands('testmod_bar')[0],
@@ -258,40 +220,4 @@ class TestEnvironment(unittest.TestCase):
             'export _var2=$_var0',
             'export _var3=${_var1}',
         ]
-        self.assertEqual(expected_commands, self.environ.emit_load_commands())
-
-    @fixtures.switch_to_user_runtime
-    def test_emit_unload_commands(self):
-        self.setup_modules_system()
-        rt = runtime()
-        expected_commands = [
-            'unset _var0',
-            'unset _var2',
-            'unset _var3',
-            rt.modules_system.emit_unload_commands('testmod_foo')[0],
-        ]
-        self.assertEqual(expected_commands,
-                         self.environ.emit_unload_commands())
-
-    @fixtures.switch_to_user_runtime
-    def test_emit_unload_commands_with_confict(self):
-        self.setup_modules_system()
-
-        # Load a conflicting module
-        self.modules_system.load_module('testmod_bar')
-
-        # When the environment is not loaded, the conflicting module does not
-        # make a difference
-        self.test_emit_unload_commands()
-
-        self.environ.load()
-        rt = runtime()
-        load_cmd = rt.modules_system.emit_load_commands
-        unload_cmd = rt.modules_system.emit_unload_commands
-        expected_commands = ['unset _var0',
-                             'unset _var2',
-                             'unset _var3']
-        expected_commands += unload_cmd('testmod_foo')
-        expected_commands += load_cmd('testmod_bar')
-        self.assertEqual(expected_commands,
-                         self.environ.emit_unload_commands())
+        assert expected_commands == env.emit_load_commands(self.environ)

--- a/unittests/test_modules.py
+++ b/unittests/test_modules.py
@@ -3,8 +3,8 @@ import os
 import unittest
 from tempfile import NamedTemporaryFile
 
+import reframe.core.environments as env
 import reframe.core.modules as modules
-from reframe.core.environments import EnvironmentSnapshot
 from reframe.core.exceptions import ConfigError, EnvironError
 from reframe.core.runtime import runtime
 from unittests.fixtures import TEST_MODULES
@@ -12,11 +12,11 @@ from unittests.fixtures import TEST_MODULES
 
 class _TestModulesSystem(abc.ABC):
     def setUp(self):
-        self.environ_save = EnvironmentSnapshot()
+        self.environ_save = env.snapshot()
         self.modules_system.searchpath_add(TEST_MODULES)
 
     def tearDown(self):
-        self.environ_save.load()
+        self.environ_save.restore()
 
     def test_searchpath(self):
         self.assertIn(TEST_MODULES, self.modules_system.searchpath)

--- a/unittests/test_pipeline.py
+++ b/unittests/test_pipeline.py
@@ -85,9 +85,6 @@ class TestRegressionTest(unittest.TestCase):
         for k in test.variables.keys():
             self.assertNotIn(k, os.environ)
 
-        # Manually unload the environment
-        self.prgenv.unload()
-
     def _run_test(self, test, compile_only=False):
         _run(test, self.partition, self.prgenv)
         self.assertFalse(os.path.exists(test.stagedir))

--- a/unittests/test_schedulers.py
+++ b/unittests/test_schedulers.py
@@ -81,22 +81,22 @@ class _TestJob(abc.ABC):
 
     def setup_job(self):
         # Mock up a job submission
-        self.testjob._time_limit = (0, 5, 0)
-        self.testjob._num_tasks = 16
-        self.testjob._num_tasks_per_node = 2
-        self.testjob._num_tasks_per_core = 1
-        self.testjob._num_tasks_per_socket = 1
-        self.testjob._num_cpus_per_task = 18
-        self.testjob._use_smt = True
+        self.testjob.time_limit = (0, 5, 0)
+        self.testjob.num_tasks = 16
+        self.testjob.num_tasks_per_node = 2
+        self.testjob.num_tasks_per_core = 1
+        self.testjob.num_tasks_per_socket = 1
+        self.testjob.num_cpus_per_task = 18
+        self.testjob.use_smt = True
+        self.testjob.options = ['--gres=gpu:4',
+                                '#DW jobdw capacity=100GB',
+                                '#DW stage_in source=/foo']
         self.testjob._sched_nodelist = 'nid000[00-17]'
         self.testjob._sched_exclude_nodelist = 'nid00016'
         self.testjob._sched_partition = 'foo'
         self.testjob._sched_reservation = 'bar'
         self.testjob._sched_account = 'spam'
         self.testjob._sched_exclusive_access = True
-        self.testjob.options = ['--gres=gpu:4',
-                                '#DW jobdw capacity=100GB',
-                                '#DW stage_in source=/foo']
 
     def test_prepare(self):
         self.testjob.prepare(self.commands, self.environs)
@@ -115,7 +115,7 @@ class _TestJob(abc.ABC):
     def test_submit_timelimit(self, check_elapsed_time=True):
         self.setup_user()
         self.parallel_cmd = 'sleep 10'
-        self.testjob._time_limit = (0, 0, 2)
+        self.testjob.time_limit = (0, 0, 2)
         self.testjob.prepare(self.commands, self.environs)
         t_job = datetime.now()
         self.testjob.submit()
@@ -171,7 +171,7 @@ class _TestJob(abc.ABC):
             self.assertNotEqual(l, '')
 
     def test_guess_num_tasks(self):
-        self.testjob._num_tasks = 0
+        self.testjob.num_tasks = 0
         with self.assertRaises(NotImplementedError):
             self.testjob.guess_num_tasks()
 
@@ -224,7 +224,7 @@ class TestLocalJob(_TestJob, unittest.TestCase):
         self.parallel_cmd = 'sleep 5 &'
         self.pre_run = ['trap -- "" TERM']
         self.post_run = ['echo $!', 'wait']
-        self.testjob._time_limit = (0, 1, 0)
+        self.testjob.time_limit = (0, 1, 0)
         self.testjob.cancel_grace_period = 2
 
         self.testjob.prepare(self.commands, self.environs)
@@ -347,21 +347,21 @@ class TestSlurmJob(_TestJob, unittest.TestCase):
 
     def test_prepare_no_smt(self):
         self.setup_job()
-        self.testjob._use_smt = None
+        self.testjob.use_smt = None
         super().test_prepare()
         with open(self.testjob.script_filename) as fp:
             self.assertIsNone(re.search(r'--hint', fp.read()))
 
     def test_prepare_with_smt(self):
         self.setup_job()
-        self.testjob._use_smt = True
+        self.testjob.use_smt = True
         super().test_prepare()
         with open(self.testjob.script_filename) as fp:
             self.assertIsNotNone(re.search(r'--hint=multithread', fp.read()))
 
     def test_prepare_without_smt(self):
         self.setup_job()
-        self.testjob._use_smt = False
+        self.testjob.use_smt = False
         super().test_prepare()
         with open(self.testjob.script_filename) as fp:
             self.assertIsNotNone(re.search(r'--hint=nomultithread', fp.read()))
@@ -382,7 +382,7 @@ class TestSlurmJob(_TestJob, unittest.TestCase):
         self.assertEqual(self.testjob.state, 'CANCELLED')
 
     def test_guess_num_tasks(self):
-        self.testjob._num_tasks = 0
+        self.testjob.num_tasks = 0
         self.testjob._sched_flex_alloc_tasks = 'all'
         # monkey patch `get_all_nodes()` to simulate extraction of
         # slurm nodes through the use of `scontrol show`
@@ -466,7 +466,7 @@ class TestPbsJob(_TestJob, unittest.TestCase):
 
     def test_prepare_no_cpus(self):
         self.setup_job()
-        self.testjob._num_cpus_per_task = None
+        self.testjob.num_cpus_per_task = None
         self.testjob.options += ['mem=100GB', 'cpu_type=haswell']
         super().test_prepare()
         num_nodes = self.testjob.num_tasks // self.testjob.num_tasks_per_node
@@ -614,8 +614,8 @@ class TestSlurmFlexibleNodeAllocation(unittest.TestCase):
         # of the default partition
         self.testjob._get_default_partition = lambda: 'pdef'
         self.testjob._sched_flex_alloc_tasks = 'all'
-        self.testjob._num_tasks_per_node = 4
-        self.testjob._num_tasks = 0
+        self.testjob.num_tasks_per_node = 4
+        self.testjob.num_tasks = 0
 
     def tearDown(self):
         os_ext.rmtree(self.workdir)
@@ -748,26 +748,26 @@ class TestSlurmFlexibleNodeAllocation(unittest.TestCase):
         self.assertEqual(self.testjob.num_tasks, 8)
 
     def test_no_num_tasks_per_node(self):
-        self.testjob._num_tasks_per_node = None
+        self.testjob.num_tasks_per_node = None
         self.testjob.options = ['-C f1,f2', '--partition=p1,p2']
         self.prepare_job()
         self.assertEqual(self.testjob.num_tasks, 1)
 
     def test_not_enough_idle_nodes(self):
         self.testjob._sched_flex_alloc_tasks = 'idle'
-        self.testjob._num_tasks = -12
+        self.testjob.num_tasks = -12
         with self.assertRaises(JobError):
             self.prepare_job()
 
     def test_not_enough_nodes_constraint_partition(self):
         self.testjob.options = ['-C f1,f2', '--partition=p1,p2']
-        self.testjob._num_tasks = -8
+        self.testjob.num_tasks = -8
         with self.assertRaises(JobError):
             self.prepare_job()
 
     def test_enough_nodes_constraint_partition(self):
         self.testjob.options = ['-C f1,f2', '--partition=p1,p2']
-        self.testjob._num_tasks = -4
+        self.testjob.num_tasks = -4
         self.prepare_job()
         self.assertEqual(self.testjob.num_tasks, 4)
 

--- a/unittests/test_utility.py
+++ b/unittests/test_utility.py
@@ -767,10 +767,12 @@ class TestReadOnlyViews(unittest.TestCase):
         self.assertEqual(1, l[0])
         self.assertEqual(3, len(l))
         self.assertIn(2, l)
-        self.assertEqual(list(l), [1, 2, 2])
+        self.assertEqual(l, [1, 2, 2])
+        self.assertEqual(l, util.SequenceView([1, 2, 2]))
         self.assertEqual(list(reversed(l)), [2, 2, 1])
         self.assertEqual(1, l.index(2))
         self.assertEqual(2, l.count(2))
+        self.assertEqual(str(l), str([1, 2, 2]))
 
         # Assert immutability
         m = l + [3, 4]
@@ -832,6 +834,8 @@ class TestReadOnlyViews(unittest.TestCase):
         self.assertEqual(2, d.get('b'))
         self.assertEqual(3, d.get('c', 3))
         self.assertEqual({'a': 1, 'b': 2}, d)
+        self.assertEqual(d, util.MappingView({'b': 2, 'a': 1}))
+        self.assertEqual(str(d), str({'a': 1, 'b': 2}))
         self.assertNotEqual({'a': 1, 'b': 2, 'c': 3}, d)
 
         # Assert immutability


### PR DESCRIPTION
This PR introduces two major enhancements.

## Lazy evaluation of the job-related attributes

The job associated with the test is only minimally created inside `setup()`. Any attributes related to its run configuration (e.g., `num_tasks`, `num_tasks_per_node` etc.) are set when preparing the job script and just before launching the test. This change required that these attributes become writeable in `Job`'s interface.

This enhancement allows you to set the `num_tasks` of a test based on the current partition or the environment in a cleaner way anytime after setup. For example:

```python
@rfm.run_before('run')
def set_num_tasks(self):
    if self.current_partition.fullname == 'foo:part':
        self.num_tasks = 8
    else:
        self.num_tasks = 4
```

In case of flexible tests, the test's `num_tasks` attribute is set to the actual number of tasks assigned to it, after the test has been launched. This eliminates the need of defining a separate sanity function to retrieve the number of tasks:

```python
# old way, but still valid

def __init__(self):
    self.sanity_patterns = sn.assert_eq(sn.count(sth), self.num_tasks_assigned)

@sn.sanity_function
@property 
def num_tasks_assigned(self):
    return self.job.num_tasks    # or now simply self.num_tasks

# new way

@rfm.run_before('sanity')
def set_sanity(self):
    self.sanity_patterns = sn.assert_eq(sn.count(sth), self.num_tasks)
```

## Re-evaluate the test's environment whenever needed

The mechanism of loading environments has changed completely. `Environment` objects are now really immutable: they are just placeholders for modules and environment variables. They don't carry any state. Responsible for loading environments is the `load(*environs)` free function. This function returns a tuple consisting of an environment snapshot just before loading `environs` and the commands needed to load the environments. There is no explicit mechanism for unloading an environment as in the past. Instead, an environment or a set of environments are implicitly unloaded by restoring the environment snapshot returned by the `load()` function.

There is also the `emit_load_commands(*environs)` function, which essentially loads `environs`, restores the original environment and returns the required load commands. In  the past this was accomplished by the `_setup_environ()` method of `RegressionTest` and the internal state of the `Environment`. Now, every time `emit_load_commands(*environs)` is called, all the environments will be loaded and the command sequence will be recorded. In addition to that, we construct a new user environment (from `self.modules` and `self.variables`) before the build and run phase of the pipeline. This allows a user to define different compilation and running environments. An example follows:

```python
@rfm.run_before('run')
def set_num_threads(self):
    self.variables = {'OMP_NUM_THREADS': '16'}
```

This will define `OMP_NUM_THREADS` only inside the generated job script and not in the build phase.

Due to this feature, this PR fixes #58. 