### PR TITLE
[test] Remove workaround for NetCDF C++ test with PGI

### DIFF
--- a/cscs-checks/libraries/io/netcdf_compile_run.py
+++ b/cscs-checks/libraries/io/netcdf_compile_run.py
@@ -66,9 +66,5 @@ class NetCDFTest(rfm.RegressionTest):
                 self.build_system.ldflags = ['-B' + self.linkage]
         else:
             self.build_system.ldflags = ['-%s' % self.linkage]
-            if environ.name == 'PrgEnv-pgi' and self.lang == 'cpp':
-                # FIXME: Workaround to fix compilation for PrgEnv-pgi
-                # Cray Case: #243751
-                self.build_system.cppflags = ['-D_GLIBCXX_USE_CXX11_ABI=0']
 
         super().setup(partition, environ, **job_opts)


### PR DESCRIPTION
The problem is now fixed and this flag is not needed. It actually makes the test fail.

Will fix MAINT-174