### PR TITLE
[refactor] Make `Sarus` container platform backend a base class

### DIFF
--- a/reframe/core/containers.py
+++ b/reframe/core/containers.py
@@ -99,8 +99,8 @@ class Docker(ContainerPlatform):
             ['cd ' + self.workdir] + self.commands) + "'"
 
 
-class ShifterNG(ContainerPlatform):
-    '''Container platform backend for running containers with ShifterNG.'''
+class Sarus(ContainerPlatform):
+    '''Container platform backend for running containers with Sarus.'''
 
     #: Add an option to the launch command to enable MPI support.
     #:
@@ -111,7 +111,7 @@ class ShifterNG(ContainerPlatform):
     def __init__(self):
         super().__init__()
         self.with_mpi = False
-        self._command = 'shifter'
+        self._command = 'sarus'
 
     def emit_prepare_commands(self):
         return [self._command + ' pull %s' % self.image]
@@ -129,12 +129,12 @@ class ShifterNG(ContainerPlatform):
             ['cd ' + self.workdir] + self.commands) + "'"
 
 
-class Sarus(ShifterNG):
-    '''Container platform backend for running containers with Sarus.'''
+class ShifterNG(Sarus):
+    '''Container platform backend for running containers with ShifterNG.'''
 
     def __init__(self):
         super().__init__()
-        self._command = 'sarus'
+        self._command = 'shifter'
 
 
 class Singularity(ContainerPlatform):

--- a/reframe/core/containers.py
+++ b/reframe/core/containers.py
@@ -100,9 +100,10 @@ class Docker(ContainerPlatform):
 
 
 class Sarus(ContainerPlatform):
-    '''Container platform backend for running containers with Sarus.'''
+    '''Container platform backend for running containers with `Sarus
+    <https://sarus.readthedocs.io>`__.'''
 
-    #: Add an option to the launch command to enable MPI support.
+    #: Enable MPI support when launching the container.
     #:
     #: :type: boolean
     #: :default: :class:`False`
@@ -130,7 +131,8 @@ class Sarus(ContainerPlatform):
 
 
 class ShifterNG(Sarus):
-    '''Container platform backend for running containers with ShifterNG.'''
+    '''Container platform backend for running containers with `ShifterNG
+    <https://user.cscs.ch/tools/containers/>`__.'''
 
     def __init__(self):
         super().__init__()


### PR DESCRIPTION
- This will allow us to easily remove `ShifterNG` backend when it goes out of support and the documentation will not be confusing.
- I also updated the documentation slightly.