### PR TITLE
[daint-gpu] Port Gromacs check to Tiger

### DIFF
--- a/cscs-checks/apps/gromacs/gromacs_check.py
+++ b/cscs-checks/apps/gromacs/gromacs_check.py
@@ -51,7 +51,7 @@ class GromacsBaseCheck(rfm.RunOnlyRegressionTest):
 class GromacsGPUCheck(GromacsBaseCheck):
     def __init__(self, scale, variant):
         super().__init__('md.log')
-        self.valid_systems = ['daint:gpu']
+        self.valid_systems = ['daint:gpu', 'tiger:gpu']
         self.descr = 'GROMACS GPU check'
         self.executable_opts = ['mdrun', '-dlb yes', '-ntomp 1', '-npme 0',
                                 '-s herflat.tpr']


### PR DESCRIPTION
```
module load cray-python/3.7.3.2
module use /home/users/vholanda/spack/share/spack/modules/cray-cnl7-ivybridge
mkdir -p /home/users/vholanda/reframe-run
cd reframe-run
../reframe/reframe.py -C ../reframe/config/tiger.py -c ../reframe/cscs-checks/apps/gromacs/gromacs_check.py -n GromacsGPUCheck_small_prod -r

Command line: ../reframe/reframe.py -C ../reframe/config/tiger.py -c ../reframe/cscs-checks/apps/gromacs/gromacs_check.py -n GromacsGPUCheck_small_prod -r
Reframe version: 2.20-dev2
Launched by user: vholanda
Launched on host: tiger
Reframe paths
=============
    Check prefix      : 
    Check search path : '../reframe/cscs-checks/apps/gromacs/gromacs_check.py'
    Stage dir prefix     : /home/users/vholanda/reframe-run/stage/
    Output dir prefix    : /home/users/vholanda/reframe-run/output/
    Perf. logging prefix : /home/users/vholanda/reframe-run/perflogs
[==========] Running 1 check(s)
[==========] Started on Thu Oct 24 15:04:03 2019 

[----------] started processing GromacsGPUCheck_small_prod (GROMACS GPU check)
[ RUN      ] GromacsGPUCheck_small_prod on tiger:gpu using PrgEnv-gnu
[       OK ] GromacsGPUCheck_small_prod on tiger:gpu using PrgEnv-gnu
[----------] finished processing GromacsGPUCheck_small_prod (GROMACS GPU check)

[  PASSED  ] Ran 1 test case(s) from 1 check(s) (0 failure(s))
[==========] Finished on Thu Oct 24 15:09:54 2019 
```