### PR TITLE
[test] Fix nvidia and libsci/mkl resolve tests

### DIFF
--- a/cscs-checks/compile/libsci_resolve.py
+++ b/cscs-checks/compile/libsci_resolve.py
@@ -51,9 +51,8 @@ class NvidiaResolveTest(LibSciResolveBaseTest):
 
         # here lib_name is in the format: libsci_acc_gnu_48_nv35.so or
         #                                 libsci_acc_cray_nv35.so
-        regex = (r'.*\(NEEDED\).*'
-                 r'libsci_acc_(?P<prgenv>[A-Za-z]+)_((?P<cver>[A-Za-z0-9]+)_)?'
-                 r'(?P<version>\S+)(?=(\.a)|(\.so))')
+        regex = (r'.*\(NEEDED\).*libsci_acc_(?P<prgenv>[A-Za-z]+)_'
+                 r'((?P<cver>[A-Za-z0-9]+)_)?(?P<version>\S+)\.so')
         prgenv = self.prgenv_names[self.current_environ.name]
         cver = self.compiler_version.get(self.current_system.name,
                                          self.compiler_version_default)
@@ -89,12 +88,8 @@ class MKLResolveTest(LibSciResolveBaseTest):
         # self.build_system.fflags = ['-Wl,-ydgemm_', '-mkl']
         self.build_system.fflags = ['-mkl']
         self.postbuild_cmd = ['readelf -d %s' % self.executable]
-
-        # interesting enough, on Dora the linking here is static.
-        # So there is REAL need for the end term (?=(.a)|(.so)).
-        # not sure if we need to check against the version here
         regex = (r'.*\(NEEDED\).*libmkl_(?P<prgenv>[A-Za-z]+)_(?P<version>\S+)'
-                 r'(?=(.a)|(.so))')
+                 r'\.so')
         self.sanity_patterns = sn.all([
             sn.assert_eq(
                 sn.extractsingle(regex, self.stdout, 'prgenv'), 'intel'),

--- a/cscs-checks/compile/libsci_resolve.py
+++ b/cscs-checks/compile/libsci_resolve.py
@@ -16,12 +16,11 @@ class LibSciResolveBaseTest(rfm.CompileOnlyRegressionTest):
 
 @rfm.required_version('>=2.14')
 @rfm.parameterized_test(['craype-accel-nvidia35'], ['craype-accel-nvidia60'])
-class Nvidia35ResolveTest(LibSciResolveBaseTest):
+class NvidiaResolveTest(LibSciResolveBaseTest):
     def __init__(self, module_name):
         super().__init__()
         self.descr = 'Module %s resolves libsci_acc' % module_name
         self.build_system = 'SingleSource'
-        self.build_system.fflags = ['-Wl,-ypdgemm_']
 
         self.module_name = module_name
         self.module_version = {
@@ -41,12 +40,19 @@ class Nvidia35ResolveTest(LibSciResolveBaseTest):
             'PrgEnv-gnu':  'gnu'
         }
 
+        # FIXME Flags '-Wl,-ydgemm_' which are passed to the linker do not
+        # produce any output when xalt/2.7.10 is loaded, thus we use readelf
+        # to find the dynamic libraries of the executable
+        # self.build_system.fflags = ['-Wl,-ydgemm_']
+        self.postbuild_cmd = ['readelf -d %s' % self.executable]
+
     def setup(self, partition, environ, **job_opts):
         super().setup(partition, environ, **job_opts)
 
         # here lib_name is in the format: libsci_acc_gnu_48_nv35.so or
         #                                 libsci_acc_cray_nv35.so
-        regex = (r'libsci_acc_(?P<prgenv>[A-Za-z]+)_((?P<cver>[A-Za-z0-9]+)_)?'
+        regex = (r'.*\(NEEDED\).*'
+                 r'libsci_acc_(?P<prgenv>[A-Za-z]+)_((?P<cver>[A-Za-z0-9]+)_)?'
                  r'(?P<version>\S+)(?=(\.a)|(\.so))')
         prgenv = self.prgenv_names[self.current_environ.name]
         cver = self.compiler_version.get(self.current_system.name,
@@ -54,17 +60,17 @@ class Nvidia35ResolveTest(LibSciResolveBaseTest):
         mod_name = self.module_version[self.module_name]
 
         if self.current_environ.name == 'PrgEnv-cray':
-            cver_sanity = sn.assert_found(regex, self.stderr)
+            cver_sanity = sn.assert_found(regex, self.stdout)
         else:
             cver_sanity = sn.assert_eq(
-                sn.extractsingle(regex, self.stderr, 'cver'), cver)
+                sn.extractsingle(regex, self.stdout, 'cver'), cver)
 
         self.sanity_patterns = sn.all([
             sn.assert_eq(
-                sn.extractsingle(regex, self.stderr, 'prgenv'), prgenv),
+                sn.extractsingle(regex, self.stdout, 'prgenv'), prgenv),
             cver_sanity,
             sn.assert_eq(
-                sn.extractsingle(regex, self.stderr, 'version'), mod_name)
+                sn.extractsingle(regex, self.stdout, 'version'), mod_name)
         ])
 
 
@@ -76,18 +82,24 @@ class MKLResolveTest(LibSciResolveBaseTest):
         self.descr = '-mkl Resolves to MKL'
         self.valid_prog_environs = ['PrgEnv-intel']
         self.build_system = 'SingleSource'
-        self.build_system.fflags = ['-Wl,-ydgemm_', '-mkl']
+
+        # FIXME Flags '-Wl,-ydgemm_' which are passed to the linker do not
+        # produce any output when xalt/2.7.10 is loaded, thus we use readelf
+        # to find the dynamic libraries of the executable
+        # self.build_system.fflags = ['-Wl,-ydgemm_', '-mkl']
+        self.build_system.fflags = ['-mkl']
+        self.postbuild_cmd = ['readelf -d %s' % self.executable]
 
         # interesting enough, on Dora the linking here is static.
         # So there is REAL need for the end term (?=(.a)|(.so)).
         # not sure if we need to check against the version here
-        regex = (r'libmkl_(?P<prgenv>[A-Za-z]+)_(?P<version>\S+)'
+        regex = (r'.*\(NEEDED\).*libmkl_(?P<prgenv>[A-Za-z]+)_(?P<version>\S+)'
                  r'(?=(.a)|(.so))')
         self.sanity_patterns = sn.all([
             sn.assert_eq(
-                sn.extractsingle(regex, self.stderr, 'prgenv'), 'intel'),
+                sn.extractsingle(regex, self.stdout, 'prgenv'), 'intel'),
             sn.assert_eq(
-                sn.extractsingle(regex, self.stderr, 'version'), 'lp64')
+                sn.extractsingle(regex, self.stdout, 'version'), 'lp64')
         ])
 
         self.maintainers = ['AJ']


### PR DESCRIPTION
* The flag for tracing the symbol when linking does not produce any
output when xalt 2.7.10 is loaded, thus we used readelf.

Fixes MAINT-210, MAINT-216.