### PR TITLE
[bugfix] Ignore invalid Slurm nodes in flexible task allocation

### DIFF
--- a/unittests/test_schedulers.py
+++ b/unittests/test_schedulers.py
@@ -15,7 +15,7 @@ from reframe.core.exceptions import JobError, JobNotStartedError
 from reframe.core.launchers.local import LocalLauncher
 from reframe.core.launchers.registry import getlauncher
 from reframe.core.schedulers.registry import getscheduler
-from reframe.core.schedulers.slurm import SlurmNode
+from reframe.core.schedulers.slurm import SlurmNode, SlurmJob
 
 
 class _TestJob(abc.ABC):
@@ -497,7 +497,7 @@ class TestPbsJob(_TestJob, unittest.TestCase):
 
 
 class TestSlurmFlexibleNodeAllocation(unittest.TestCase):
-    def create_dummy_node_descr(obj):
+    def create_dummy_nodes(obj):
         node_descriptions = ['NodeName=nid00001 Arch=x86_64 CoresPerSocket=12 '
                              'CPUAlloc=0 CPUErr=0 CPUTot=24 CPULoad=0.00 '
                              'AvailableFeatures=f1,f2 ActiveFeatures=f1,f2 '
@@ -591,10 +591,13 @@ class TestSlurmFlexibleNodeAllocation(unittest.TestCase):
 
                              'Node invalid_node2 not found']
 
-        return node_descriptions
+        return SlurmJob._get_nodes_from_description(node_descriptions)
 
     def create_reservation_nodes(obj, res):
         return {n for n in obj.testjob.get_all_nodes() if n.name != 'nid00001'}
+
+    def create_dummy_nodes_by_name(obj, name):
+        return {n for n in obj.testjob.get_all_nodes() if n.name == name}
 
     def setUp(self):
         self.workdir = tempfile.mkdtemp(dir='unittests')
@@ -607,9 +610,9 @@ class TestSlurmFlexibleNodeAllocation(unittest.TestCase):
             stdout=os.path.join(self.workdir, 'testjob.out'),
             stderr=os.path.join(self.workdir, 'testjob.err')
         )
-        # monkey patch `get_all_node_descriptions` to simulate extraction of
+        # monkey patch `get_all_nodes` to simulate extraction of
         # slurm nodes through the use of `scontrol show`
-        self.testjob.get_all_node_descriptions = self.create_dummy_node_descr
+        self.testjob.get_all_nodes = self.create_dummy_nodes
         # monkey patch `_get_default_partition` to simulate extraction
         # of the default partition
         self.testjob._get_default_partition = lambda: 'pdef'
@@ -736,12 +739,16 @@ class TestSlurmFlexibleNodeAllocation(unittest.TestCase):
     def test_exclude_nodes_cmd(self):
         self.testjob._sched_access = ['--constraint=f1']
         self.testjob._sched_exclude_nodelist = 'nid00001'
+        # monkey patch `_get_nodes_by_name` to simulate extraction of
+        # slurm nodes by name through the use of `scontrol show`
+        self.testjob._get_nodes_by_name = self.create_dummy_nodes_by_name
         self.prepare_job()
         self.assertEqual(self.testjob.num_tasks, 8)
 
     def test_exclude_nodes_opt(self):
         self.testjob._sched_access = ['--constraint=f1']
         self.testjob.options = ['-x nid00001']
+        self.testjob._get_nodes_by_name = self.create_dummy_nodes_by_name
         self.prepare_job()
         self.assertEqual(self.testjob.num_tasks, 8)
 

--- a/unittests/test_schedulers.py
+++ b/unittests/test_schedulers.py
@@ -15,7 +15,7 @@ from reframe.core.exceptions import JobError, JobNotStartedError
 from reframe.core.launchers.local import LocalLauncher
 from reframe.core.launchers.registry import getlauncher
 from reframe.core.schedulers.registry import getscheduler
-from reframe.core.schedulers.slurm import SlurmNode, SlurmJob
+from reframe.core.schedulers.slurm import SlurmNode, create_nodes
 
 
 class _TestJob(abc.ABC):
@@ -591,7 +591,7 @@ class TestSlurmFlexibleNodeAllocation(unittest.TestCase):
 
                              'Node invalid_node2 not found']
 
-        return SlurmJob._get_nodes_from_description(node_descriptions)
+        return create_nodes(node_descriptions)
 
     def create_reservation_nodes(obj, res):
         return {n for n in obj.testjob.get_all_nodes() if n.name != 'nid00001'}


### PR DESCRIPTION
* Separate the retrieval of Slurm node descriptions and
  creation of `SlurmNode` instances when nodes
  in flexible task allocation.

* Make the necessary unittests changes to test for invalid
  node descriptions.

Fixes #1031 