### PR TITLE
[bugfix] Change command line option --flex-alloc-tasks to --flex-alloc-nodes

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -446,8 +446,8 @@ Here is how the new deferred attribute is defined:
   :dedent: 4
 
 
-The behavior of the flexible task allocation is controlled by the ``--flex-alloc-tasks`` command line option.
-See the corresponding `section <running.html#controlling-the-flexible-task-allocation>`__ for more information.
+The behavior of the flexible task allocation is controlled by the ``--flex-alloc-nodes`` command line option.
+See the corresponding `section <running.html#controlling-the-flexible-node-allocation>`__ for more information.
 
 
 Testing containerized applications

--- a/docs/running.rst
+++ b/docs/running.rst
@@ -1242,7 +1242,7 @@ This option accepts three values:
   1. ``idle``: (default) In this case, ReFrame will set the number of tasks to the number of idle nodes of the current logical partition multiplied by the :attr:`num_tasks_per_node <reframe.core.pipeline.RegressionTest.num_tasks_per_node>` attribute of the particular test.
   2. ``all``: In this case, ReFrame will set the number of tasks to the number of all the nodes of the current logical partition multiplied by the :attr:`num_tasks_per_node <reframe.core.pipeline.RegressionTest.num_tasks_per_node>` attribute of the particular test.
 
-  3. Any positive integer: In this case, ReFrame will set the number of tasks to the given value.
+  3. Any positive integer which is a multiple of :attr:`num_tasks_per_node <reframe.core.pipeline.RegressionTest.num_tasks_per_node>`: In this case, ReFrame will set the number of tasks to the given value.
 
 The flexible allocation of number of tasks takes into account any additional logical constraint imposed by the command line options affecting the job allocation, such as ``--partition``, ``--reservation``, ``--nodelist``, ``--exclude-nodes`` and ``--job-option`` (if the scheduler option passed to the latter imposes a restriction).
 Notice that ReFrame will issue an error if the resulting number of nodes is zero.

--- a/docs/running.rst
+++ b/docs/running.rst
@@ -509,7 +509,8 @@ They are summarized below:
   In this example, Slurm's policy is that later definitions of options override previous ones.
   So, in this case, way you would override the standard output for all the submitted jobs!
 
-* ``--flex-alloc-tasks {all|idle|NUM}``: Automatically determine the number of tasks allocated for each test.
+* ``--flex-alloc-tasks {all|idle|NUM}``: (Deprecated) Automatically determine the number of tasks allocated for each test.
+* ``--flex-alloc-nodes {all|idle|NUM}``: Automatically determine the number of nodes allocated for each test.
 * ``--force-local``: Force the local execution of the selected tests.
   No jobs will be submitted.
 * ``--skip-sanity-check``: Skip sanity checking phase.
@@ -1237,7 +1238,9 @@ Controlling the Flexible Node Allocation
 .. note::
    .. versionchanged:: 2.21
       Flexible task allocation is now based on number of nodes.
-      The corresponding command line option is now ``--flex-alloc-nodes`` instead of ``--flex-alloc-tasks``.
+
+.. warning::
+      The command line option ``--flex-alloc-tasks`` is now deprecated, you should use ``--flex-alloc-nodes`` instead.
 
 
 ReFrame can automatically set the number of tasks of a particular test, if its :attr:`num_tasks <reframe.core.pipeline.RegressionTest.num_tasks>` attribute is set to a value ``<=0``.

--- a/docs/running.rst
+++ b/docs/running.rst
@@ -509,7 +509,7 @@ They are summarized below:
   In this example, Slurm's policy is that later definitions of options override previous ones.
   So, in this case, way you would override the standard output for all the submitted jobs!
 
-* ``--flex-alloc-tasks {all|idle|NUM}``: (Deprecated) Automatically determine the number of tasks allocated for each test.
+* ``--flex-alloc-tasks {all|idle|NUM}``: (Deprecated) Please use ``--flex-alloc-nodes`` instead.
 * ``--flex-alloc-nodes {all|idle|NUM}``: Automatically determine the number of nodes allocated for each test.
 * ``--force-local``: Force the local execution of the selected tests.
   No jobs will be submitted.

--- a/docs/running.rst
+++ b/docs/running.rst
@@ -1229,33 +1229,39 @@ In the following example, ReFrame will load both ``module-1`` and ``module-2`` w
 
   --map-module 'module-1: module-1 module-2'
 
-Controlling the Flexible Task Allocation
+Controlling the Flexible Node Allocation
 ----------------------------------------
 
 .. versionadded:: 2.15
 
+.. note::
+   .. versionchanged:: 2.21
+      Flexible task allocation is now based on number of nodes.
+      The corresponding command line option is now ``--flex-alloc-nodes`` instead of ``--flex-alloc-tasks``.
+
+
 ReFrame can automatically set the number of tasks of a particular test, if its :attr:`num_tasks <reframe.core.pipeline.RegressionTest.num_tasks>` attribute is set to a value ``<=0``.
 By default, ReFrame will spawn such a test on all the idle nodes of the current system partition.
-This behavior can be adjusted using the ``--flex-alloc-tasks`` command line option.
+This behavior can be adjusted using the ``--flex-alloc-nodes`` command line option.
 This option accepts three values:
 
   1. ``idle``: (default) In this case, ReFrame will set the number of tasks to the number of idle nodes of the current logical partition multiplied by the :attr:`num_tasks_per_node <reframe.core.pipeline.RegressionTest.num_tasks_per_node>` attribute of the particular test.
   2. ``all``: In this case, ReFrame will set the number of tasks to the number of all the nodes of the current logical partition multiplied by the :attr:`num_tasks_per_node <reframe.core.pipeline.RegressionTest.num_tasks_per_node>` attribute of the particular test.
 
-  3. Any positive integer which is a multiple of :attr:`num_tasks_per_node <reframe.core.pipeline.RegressionTest.num_tasks_per_node>`: In this case, ReFrame will set the number of tasks to the given value.
+  3. Any positive integer: In this case, ReFrame will set the number of tasks to the given value multiplied by the :attr:`num_tasks_per_node <reframe.core.pipeline.RegressionTest.num_tasks_per_node>` attribute of the particular test.
 
-The flexible allocation of number of tasks takes into account any additional logical constraint imposed by the command line options affecting the job allocation, such as ``--partition``, ``--reservation``, ``--nodelist``, ``--exclude-nodes`` and ``--job-option`` (if the scheduler option passed to the latter imposes a restriction).
+The flexible allocation of number of nodes takes into account any additional logical constraint imposed by the command line options affecting the job allocation, such as ``--partition``, ``--reservation``, ``--nodelist``, ``--exclude-nodes`` and ``--job-option`` (if the scheduler option passed to the latter imposes a restriction).
 Notice that ReFrame will issue an error if the resulting number of nodes is zero.
 
 For example, using the following options would run a flexible test on all the nodes of reservation ``foo`` except the nodes ``n0[1-5]``:
 
 .. code-block:: bash
 
-  --flex-alloc-tasks=all --reservation=foo --exclude-nodes=n0[1-5]
+  --flex-alloc-nodes=all --reservation=foo --exclude-nodes=n0[1-5]
 
 
 .. note::
-   Flexible task allocation is supported only for the Slurm scheduler backend.
+   Flexible node allocation is supported only for the Slurm scheduler backend.
 
 .. warning::
    Test cases resulting from flexible ReFrame tests may not be run using the asynchronous execution policy, because the nodes satisfying the required criteria will be allocated for the first test case, causing all subsequent ones to fail.

--- a/reframe/__init__.py
+++ b/reframe/__init__.py
@@ -2,7 +2,7 @@ import os
 import sys
 
 
-VERSION = '2.21-dev0'
+VERSION = '2.21-dev1'
 INSTALL_PREFIX = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 MIN_PYTHON_VERSION = (3, 5, 0)
 

--- a/reframe/core/pipeline.py
+++ b/reframe/core/pipeline.py
@@ -342,7 +342,7 @@ class RegressionTest(metaclass=RegressionTestMeta):
     #:
     #: If the number of tasks is set to a number ``<=0``, ReFrame will try
     #: to flexibly allocate the number of tasks, based on the command line
-    #: option ``--flex-alloc-tasks``.
+    #: option ``--flex-alloc-nodes``.
     #: A negative number is used to indicate the minimum number of tasks
     #: required for the test.
     #: In this case the minimum number of tasks is the absolute value of
@@ -356,13 +356,15 @@ class RegressionTest(metaclass=RegressionTestMeta):
     #: .. note::
     #:     .. versionchanged:: 2.15
     #:        Added support for flexible allocation of the number of tasks
-    #:        according to the ``--flex-alloc-tasks`` command line option
+    #:        according to the ``--flex-alloc-`` command line option
     #:        (see `Flexible task allocation
-    #:        <running.html#flexible-task-allocation>`__)
+    #:        <running.html#flexible-node-allocation>`__)
     #:        if the number of tasks is set to ``0``.
     #:     .. versionchanged:: 2.16
     #:        Negative ``num_tasks`` is allowed for specifying the minimum
     #:        number of required tasks by the test.
+    #:     .. versionchanged:: 2.21
+    #:        Flexible task allocation is now node based.
     num_tasks = fields.TypedField('num_tasks', int)
 
     #: Number of tasks per node required by this test.
@@ -1174,7 +1176,7 @@ class RegressionTest(metaclass=RegressionTestMeta):
         self.logger.debug(msg)
 
         # Update num_tasks if test is flexible
-        if self.job.sched_flex_alloc_tasks:
+        if self.job.sched_flex_alloc_nodes:
             self.num_tasks = self.job.num_tasks
 
     def poll(self):

--- a/reframe/core/pipeline.py
+++ b/reframe/core/pipeline.py
@@ -356,15 +356,18 @@ class RegressionTest(metaclass=RegressionTestMeta):
     #: .. note::
     #:     .. versionchanged:: 2.15
     #:        Added support for flexible allocation of the number of tasks
-    #:        according to the ``--flex-alloc-`` command line option
-    #:        (see `Flexible task allocation
+    #:        according to the ``--flex-alloc-tasks`` command line option
+    #:        (see `Flexible node allocation
     #:        <running.html#flexible-node-allocation>`__)
     #:        if the number of tasks is set to ``0``.
     #:     .. versionchanged:: 2.16
     #:        Negative ``num_tasks`` is allowed for specifying the minimum
     #:        number of required tasks by the test.
     #:     .. versionchanged:: 2.21
-    #:        Flexible task allocation is now node based.
+    #:        Flexible node allocation is now controlled by the
+    #:        ``--flex-alloc-nodes`` command line option
+    #:        (see `Flexible node allocation
+    #:        <running.html#flexible-node-allocation>`__)
     num_tasks = fields.TypedField('num_tasks', int)
 
     #: Number of tasks per node required by this test.

--- a/reframe/core/schedulers/__init__.py
+++ b/reframe/core/schedulers/__init__.py
@@ -67,7 +67,7 @@ class Job(abc.ABC):
                  stderr=None,
                  pre_run=[],
                  post_run=[],
-                 sched_flex_alloc_tasks=None,
+                 sched_flex_alloc_nodes=None,
                  sched_access=[],
                  sched_account=None,
                  sched_partition=None,
@@ -96,7 +96,7 @@ class Job(abc.ABC):
         self._nodelist = None
 
         # Backend scheduler related information
-        self._sched_flex_alloc_tasks = sched_flex_alloc_tasks
+        self._sched_flex_alloc_nodes = sched_flex_alloc_nodes
         self._sched_access = sched_access
         self._sched_nodelist = sched_nodelist
         self._sched_exclude_nodelist = sched_exclude_nodelist
@@ -148,8 +148,8 @@ class Job(abc.ABC):
         return self._stderr
 
     @property
-    def sched_flex_alloc_tasks(self):
-        return self._sched_flex_alloc_tasks
+    def sched_flex_alloc_nodes(self):
+        return self._sched_flex_alloc_nodes
 
     @property
     def sched_access(self):
@@ -189,7 +189,7 @@ class Job(abc.ABC):
             try:
                 guessed_num_tasks = self.guess_num_tasks()
             except NotImplementedError as e:
-                raise JobError('flexible task allocation is not supported by '
+                raise JobError('flexible node allocation is not supported by '
                                'this backend') from e
 
             if guessed_num_tasks < min_num_tasks:
@@ -199,7 +199,7 @@ class Job(abc.ABC):
                     (min_num_tasks, guessed_num_tasks))
 
             self.num_tasks = guessed_num_tasks
-            getlogger().debug('flex_alloc_tasks: setting num_tasks to %s' %
+            getlogger().debug('flex_alloc_nodes: setting num_tasks to %s' %
                               self.num_tasks)
 
         with shell.generate_script(self.script_filename,
@@ -215,35 +215,29 @@ class Job(abc.ABC):
 
     def guess_num_tasks(self):
         num_tasks_per_node = self.num_tasks_per_node or 1
-        if isinstance(self.sched_flex_alloc_tasks, int):
-            if self.sched_flex_alloc_tasks <= 0:
-                raise JobError('invalid number of flex_alloc_tasks: %s' %
-                               self.sched_flex_alloc_tasks)
-            elif self.sched_flex_alloc_tasks % num_tasks_per_node != 0:
-                raise JobError(
-                    'invalid number of flex_alloc_tasks: %s, it must be a '
-                    'multiple of num_tasks_per_node: %s' %
-                    (self.sched_flex_alloc_tasks, num_tasks_per_node))
+        if isinstance(self.sched_flex_alloc_nodes, int):
+            if self.sched_flex_alloc_nodes <= 0:
+                raise JobError('invalid number of flex_alloc_nodes: %s' %
+                               self.sched_flex_alloc_nodes)
 
-            return self.sched_flex_alloc_tasks
+            return self.sched_flex_alloc_nodes * num_tasks_per_node
 
         available_nodes = self.get_all_nodes()
-        getlogger().debug('flex_alloc_tasks: total available nodes %s ' %
+        getlogger().debug('flex_alloc_nodes: total available nodes %s ' %
                           len(available_nodes))
 
         # Try to guess the number of tasks now
-        available_nodes = self.filter_nodes(available_nodes,
-                                            self.sched_access + self.options)
+        available_nodes = self.filter_nodes(
+            available_nodes, self.sched_access + self.options)
 
-        if self.sched_flex_alloc_tasks == 'idle':
+        if self.sched_flex_alloc_nodes == 'idle':
             available_nodes = {n for n in available_nodes
                                if n.is_available()}
             getlogger().debug(
-                'flex_alloc_tasks: selecting idle nodes: '
+                'flex_alloc_nodes: selecting idle nodes: '
                 'available nodes now: %s' % len(available_nodes))
 
-        num_tasks = len(available_nodes) * num_tasks_per_node
-        return num_tasks
+        return len(available_nodes) * num_tasks_per_node
 
     @abc.abstractmethod
     def get_all_nodes(self):
@@ -290,7 +284,7 @@ class Job(abc.ABC):
         This attribute might be useful in a flexible regression test for
         determining the actual nodes that were assigned to the test.
 
-        For more information on flexible task allocation, please refer to the
+        For more information on flexible node allocation, please refer to the
         corresponding `section <advanced.html#flexible-regression-tests>`__ of
         the tutorial.
 

--- a/reframe/core/schedulers/slurm.py
+++ b/reframe/core/schedulers/slurm.py
@@ -216,7 +216,7 @@ class SlurmJob(sched.Job):
             reservation = reservation.strip()
             nodes &= self._get_reservation_nodes(reservation)
             getlogger().debug(
-                'flex_alloc_tasks: filtering nodes by reservation %s: '
+                'flex_alloc_nodes: filtering nodes by reservation %s: '
                 'available nodes now: %s' % (reservation, len(nodes)))
 
         if partitions:
@@ -224,33 +224,33 @@ class SlurmJob(sched.Job):
         else:
             default_partition = self._get_default_partition()
             partitions = {default_partition} if default_partition else set()
-            getlogger().debug('flex_alloc_tasks: default partition: %s' %
+            getlogger().debug('flex_alloc_nodes: default partition: %s' %
                               default_partition)
 
         nodes = {n for n in nodes if n.partitions >= partitions}
         getlogger().debug(
-            'flex_alloc_tasks: filtering nodes by partition(s) %s: '
+            'flex_alloc_nodes: filtering nodes by partition(s) %s: '
             'available nodes now: %s' % (partitions, len(nodes)))
 
         if constraints:
             constraints = set(constraints.strip().split(','))
             nodes = {n for n in nodes if n.active_features >= constraints}
             getlogger().debug(
-                'flex_alloc_tasks: filtering nodes by constraint(s) %s: '
+                'flex_alloc_nodes: filtering nodes by constraint(s) %s: '
                 'available nodes now: %s' % (constraints, len(nodes)))
 
         if nodelist:
             nodelist = nodelist.strip()
             nodes &= self._get_nodes_by_name(nodelist)
             getlogger().debug(
-                'flex_alloc_tasks: filtering nodes by nodelist: %s '
+                'flex_alloc_nodes: filtering nodes by nodelist: %s '
                 'available nodes now: %s' % (nodelist, len(nodes)))
 
         if exclude_nodes:
             exclude_nodes = exclude_nodes.strip()
             nodes -= self._get_nodes_by_name(exclude_nodes)
             getlogger().debug(
-                'flex_alloc_tasks: excluding node(s): %s '
+                'flex_alloc_nodes: excluding node(s): %s '
                 'available nodes now: %s' % (exclude_nodes, len(nodes)))
 
         return nodes

--- a/reframe/frontend/cli.py
+++ b/reframe/frontend/cli.py
@@ -183,6 +183,10 @@ def main():
         help='Specify the maximum number of times a failed regression test '
              'may be retried (default: 0)')
     run_options.add_argument(
+        '--flex-alloc-tasks', action='store',
+        dest='flex_alloc_tasks', metavar='{all|idle|NUM}',
+        help='Deprecated, please use --flex-alloc-nodes instead')
+    run_options.add_argument(
         '--flex-alloc-nodes', action='store',
         dest='flex_alloc_nodes', metavar='{all|idle|NUM}', default='idle',
         help="Strategy for flexible node allocation (default: 'idle').")
@@ -562,6 +566,12 @@ def main():
             exec_policy.skip_sanity_check = options.skip_sanity_check
             exec_policy.skip_performance_check = options.skip_performance_check
             exec_policy.keep_stage_files = options.keep_stage_files
+
+            if options.flex_alloc_tasks:
+                printer.warning('--flex-alloc-tasks is deprecated, you should '
+                                'use --flex-alloc-nodes instead: Exiting...')
+                sys.exit(1)
+
             try:
                 errmsg = "invalid option for --flex-alloc-nodes: '{0}'"
                 sched_flex_alloc_nodes = int(options.flex_alloc_nodes)

--- a/reframe/frontend/cli.py
+++ b/reframe/frontend/cli.py
@@ -184,11 +184,11 @@ def main():
              'may be retried (default: 0)')
     run_options.add_argument(
         '--flex-alloc-tasks', action='store',
-        dest='flex_alloc_tasks', metavar='{all|idle|NUM}',
+        dest='flex_alloc_tasks', metavar='{all|idle|NUM}', default=None,
         help='Deprecated, please use --flex-alloc-nodes instead')
     run_options.add_argument(
         '--flex-alloc-nodes', action='store',
-        dest='flex_alloc_nodes', metavar='{all|idle|NUM}', default='idle',
+        dest='flex_alloc_nodes', metavar='{all|idle|NUM}', default=None,
         help="Strategy for flexible node allocation (default: 'idle').")
 
     env_options.add_argument(
@@ -538,6 +538,15 @@ def main():
                                 "Skipping..." % m)
                 printer.debug(str(e))
 
+        if options.flex_alloc_tasks:
+            printer.warning('--flex-alloc-tasks is deprecated, you should '
+                            'use --flex-alloc-nodes instead: Passing the '
+                            'given option to --flex-alloc-nodes')
+            options.flex_alloc_nodes = (options.flex_alloc_nodes or
+                                        options.flex_alloc_tasks)
+
+        options.flex_alloc_nodes = options.flex_alloc_nodes or 'idle'
+
         # Act on checks
 
         success = True
@@ -566,11 +575,6 @@ def main():
             exec_policy.skip_sanity_check = options.skip_sanity_check
             exec_policy.skip_performance_check = options.skip_performance_check
             exec_policy.keep_stage_files = options.keep_stage_files
-
-            if options.flex_alloc_tasks:
-                printer.warning('--flex-alloc-tasks is deprecated, you should '
-                                'use --flex-alloc-nodes instead: Exiting...')
-                sys.exit(1)
 
             try:
                 errmsg = "invalid option for --flex-alloc-nodes: '{0}'"

--- a/reframe/frontend/cli.py
+++ b/reframe/frontend/cli.py
@@ -183,9 +183,9 @@ def main():
         help='Specify the maximum number of times a failed regression test '
              'may be retried (default: 0)')
     run_options.add_argument(
-        '--flex-alloc-tasks', action='store',
-        dest='flex_alloc_tasks', metavar='{all|idle|NUM}', default='idle',
-        help="Strategy for flexible task allocation (default: 'idle').")
+        '--flex-alloc-nodes', action='store',
+        dest='flex_alloc_nodes', metavar='{all|idle|NUM}', default='idle',
+        help="Strategy for flexible node allocation (default: 'idle').")
 
     env_options.add_argument(
         '-M', '--map-module', action='append', metavar='MAPPING',
@@ -563,19 +563,19 @@ def main():
             exec_policy.skip_performance_check = options.skip_performance_check
             exec_policy.keep_stage_files = options.keep_stage_files
             try:
-                errmsg = "invalid option for --flex-alloc-tasks: '{0}'"
-                sched_flex_alloc_tasks = int(options.flex_alloc_tasks)
-                if sched_flex_alloc_tasks <= 0:
-                    raise ConfigError(errmsg.format(options.flex_alloc_tasks))
+                errmsg = "invalid option for --flex-alloc-nodes: '{0}'"
+                sched_flex_alloc_nodes = int(options.flex_alloc_nodes)
+                if sched_flex_alloc_nodes <= 0:
+                    raise ConfigError(errmsg.format(options.flex_alloc_nodes))
             except ValueError:
-                if not options.flex_alloc_tasks.lower() in {'idle', 'all'}:
+                if not options.flex_alloc_nodes.casefold() in {'idle', 'all'}:
                     raise ConfigError(
-                        errmsg.format(options.flex_alloc_tasks)) from None
+                        errmsg.format(options.flex_alloc_nodes)) from None
 
-                sched_flex_alloc_tasks = options.flex_alloc_tasks
+                sched_flex_alloc_nodes = options.flex_alloc_nodes
 
-            exec_policy.sched_flex_alloc_tasks = sched_flex_alloc_tasks
-            exec_policy.flex_alloc_tasks = options.flex_alloc_tasks
+            exec_policy.sched_flex_alloc_nodes = sched_flex_alloc_nodes
+            exec_policy.flex_alloc_nodes = options.flex_alloc_nodes
             exec_policy.sched_account = options.account
             exec_policy.sched_partition = options.partition
             exec_policy.sched_reservation = options.reservation

--- a/reframe/frontend/cli.py
+++ b/reframe/frontend/cli.py
@@ -185,7 +185,7 @@ def main():
     run_options.add_argument(
         '--flex-alloc-tasks', action='store',
         dest='flex_alloc_tasks', metavar='{all|idle|NUM}', default=None,
-        help='Deprecated, please use --flex-alloc-nodes instead')
+        help='*deprecated*, please use --flex-alloc-nodes instead')
     run_options.add_argument(
         '--flex-alloc-nodes', action='store',
         dest='flex_alloc_nodes', metavar='{all|idle|NUM}', default=None,
@@ -539,16 +539,15 @@ def main():
                 printer.debug(str(e))
 
         if options.flex_alloc_tasks:
-            printer.warning('--flex-alloc-tasks is deprecated, you should '
-                            'use --flex-alloc-nodes instead: Passing the '
-                            'given option to --flex-alloc-nodes')
+            printer.warning("`--flex-alloc-tasks' is deprecated and "
+                            "will be removed in the future; "
+                            "you should use --flex-alloc-nodes instead")
             options.flex_alloc_nodes = (options.flex_alloc_nodes or
                                         options.flex_alloc_tasks)
 
         options.flex_alloc_nodes = options.flex_alloc_nodes or 'idle'
 
         # Act on checks
-
         success = True
         if options.list:
             # List matched checks

--- a/reframe/frontend/executors/__init__.py
+++ b/reframe/frontend/executors/__init__.py
@@ -369,7 +369,7 @@ class ExecutionPolicy(abc.ABC):
         self.strict_check = False
 
         # Scheduler options
-        self.sched_flex_alloc_tasks = None
+        self.sched_flex_alloc_nodes = None
         self.sched_account = None
         self.sched_partition = None
         self.sched_reservation = None

--- a/reframe/frontend/executors/policies.py
+++ b/reframe/frontend/executors/policies.py
@@ -38,7 +38,7 @@ class SerialExecutionPolicy(ExecutionPolicy, TaskEventListener):
                 raise TaskDependencyError('dependencies failed')
 
             task.setup(partition, environ,
-                       sched_flex_alloc_tasks=self.sched_flex_alloc_tasks,
+                       sched_flex_alloc_nodes=self.sched_flex_alloc_nodes,
                        sched_account=self.sched_account,
                        sched_partition=self.sched_partition,
                        sched_reservation=self.sched_reservation,
@@ -243,7 +243,7 @@ class AsynchronousExecutionPolicy(ExecutionPolicy, TaskEventListener):
                 return
 
             task.setup(partition, environ,
-                       sched_flex_alloc_tasks=self.sched_flex_alloc_tasks,
+                       sched_flex_alloc_nodes=self.sched_flex_alloc_nodes,
                        sched_account=self.sched_account,
                        sched_partition=self.sched_partition,
                        sched_reservation=self.sched_reservation,
@@ -303,7 +303,7 @@ class AsynchronousExecutionPolicy(ExecutionPolicy, TaskEventListener):
             elif self.deps_succeeded(task):
                 task.setup(task.testcase.partition,
                            task.testcase.environ,
-                           sched_flex_alloc_tasks=self.sched_flex_alloc_tasks,
+                           sched_flex_alloc_nodes=self.sched_flex_alloc_nodes,
                            sched_account=self.sched_account,
                            sched_partition=self.sched_partition,
                            sched_reservation=self.sched_reservation,

--- a/unittests/test_schedulers.py
+++ b/unittests/test_schedulers.py
@@ -632,6 +632,12 @@ class TestSlurmFlexibleNodeAllocation(unittest.TestCase):
         with self.assertRaises(JobError):
             self.prepare_job()
 
+    def test_non_mult_flex_alloc_tasks(self):
+        self.testjob._sched_flex_alloc_tasks = 7
+        self.testjob._sched_access = ['--constraint=f1']
+        with self.assertRaises(JobError):
+            self.prepare_job()
+
     def test_negative_flex_alloc_tasks(self):
         self.testjob._sched_flex_alloc_tasks = -4
         self.testjob._sched_access = ['--constraint=f1']

--- a/unittests/test_schedulers.py
+++ b/unittests/test_schedulers.py
@@ -383,7 +383,7 @@ class TestSlurmJob(_TestJob, unittest.TestCase):
 
     def test_guess_num_tasks(self):
         self.testjob.num_tasks = 0
-        self.testjob._sched_flex_alloc_tasks = 'all'
+        self.testjob._sched_flex_alloc_nodes = 'all'
         # monkey patch `get_all_nodes()` to simulate extraction of
         # slurm nodes through the use of `scontrol show`
         self.testjob.get_all_nodes = lambda: set()
@@ -613,45 +613,39 @@ class TestSlurmFlexibleNodeAllocation(unittest.TestCase):
         # monkey patch `_get_default_partition` to simulate extraction
         # of the default partition
         self.testjob._get_default_partition = lambda: 'pdef'
-        self.testjob._sched_flex_alloc_tasks = 'all'
+        self.testjob._sched_flex_alloc_nodes = 'all'
         self.testjob.num_tasks_per_node = 4
         self.testjob.num_tasks = 0
 
     def tearDown(self):
         os_ext.rmtree(self.workdir)
 
-    def test_positive_flex_alloc_tasks(self):
-        self.testjob._sched_flex_alloc_tasks = 48
+    def test_positive_flex_alloc_nodes(self):
+        self.testjob._sched_flex_alloc_nodes = 12
         self.testjob._sched_access = ['--constraint=f1']
         self.prepare_job()
         self.assertEqual(self.testjob.num_tasks, 48)
 
-    def test_zero_flex_alloc_tasks(self):
-        self.testjob._sched_flex_alloc_tasks = 0
+    def test_zero_flex_alloc_nodes(self):
+        self.testjob._sched_flex_alloc_nodes = 0
         self.testjob._sched_access = ['--constraint=f1']
         with self.assertRaises(JobError):
             self.prepare_job()
 
-    def test_non_mult_flex_alloc_tasks(self):
-        self.testjob._sched_flex_alloc_tasks = 7
-        self.testjob._sched_access = ['--constraint=f1']
-        with self.assertRaises(JobError):
-            self.prepare_job()
-
-    def test_negative_flex_alloc_tasks(self):
-        self.testjob._sched_flex_alloc_tasks = -4
+    def test_negative_flex_alloc_nodes(self):
+        self.testjob._sched_flex_alloc_nodes = -1
         self.testjob._sched_access = ['--constraint=f1']
         with self.assertRaises(JobError):
             self.prepare_job()
 
     def test_sched_access_idle(self):
-        self.testjob._sched_flex_alloc_tasks = 'idle'
+        self.testjob._sched_flex_alloc_nodes = 'idle'
         self.testjob._sched_access = ['--constraint=f1']
         self.prepare_job()
         self.assertEqual(self.testjob.num_tasks, 8)
 
     def test_sched_access_constraint_partition(self):
-        self.testjob._sched_flex_alloc_tasks = 'all'
+        self.testjob._sched_flex_alloc_nodes = 'all'
         self.testjob._sched_access = ['--constraint=f1', '--partition=p2']
         self.prepare_job()
         self.assertEqual(self.testjob.num_tasks, 4)
@@ -662,18 +656,18 @@ class TestSlurmFlexibleNodeAllocation(unittest.TestCase):
         self.assertEqual(self.testjob.num_tasks, 16)
 
     def test_default_partition_all(self):
-        self.testjob._sched_flex_alloc_tasks = 'all'
+        self.testjob._sched_flex_alloc_nodes = 'all'
         self.prepare_job()
         self.assertEqual(self.testjob.num_tasks, 16)
 
     def test_constraint_idle(self):
-        self.testjob._sched_flex_alloc_tasks = 'idle'
+        self.testjob._sched_flex_alloc_nodes = 'idle'
         self.testjob.options = ['--constraint=f1']
         self.prepare_job()
         self.assertEqual(self.testjob.num_tasks, 8)
 
     def test_partition_idle(self):
-        self.testjob._sched_flex_alloc_tasks = 'idle'
+        self.testjob._sched_flex_alloc_nodes = 'idle'
         self.testjob._sched_partition = 'p2'
         with self.assertRaises(JobError):
             self.prepare_job()
@@ -760,7 +754,7 @@ class TestSlurmFlexibleNodeAllocation(unittest.TestCase):
         self.assertEqual(self.testjob.num_tasks, 1)
 
     def test_not_enough_idle_nodes(self):
-        self.testjob._sched_flex_alloc_tasks = 'idle'
+        self.testjob._sched_flex_alloc_nodes = 'idle'
         self.testjob.num_tasks = -12
         with self.assertRaises(JobError):
             self.prepare_job()


### PR DESCRIPTION
* Change the command line option `--flex-alloc-tasks` to `--flex-alloc-nodes` and make it work based on node numbers.

* Change classes and unittests.

* Update documentation.

Fixes #1037 