### PR TITLE
[feat] Improve error message when no action is specified

### DIFF
--- a/reframe/frontend/cli.py
+++ b/reframe/frontend/cli.py
@@ -617,7 +617,8 @@ def main():
                     printer.info(runner.stats.performance_report())
 
         else:
-            printer.info('No action specified. Exiting...')
+            printer.info("No action specified. Please specify '-l' for "
+                         "listing or '-r' for running.")
             printer.info("Try `%s -h' for a list of available actions." %
                          argparser.prog)
             sys.exit(1)

--- a/reframe/frontend/cli.py
+++ b/reframe/frontend/cli.py
@@ -617,10 +617,10 @@ def main():
                     printer.info(runner.stats.performance_report())
 
         else:
-            printer.info("No action specified. Please specify `-l'/`-L' for "
-                         "listing or `-r' for running.")
-            printer.info("Try `%s -h' for a list of available actions." %
-                         argparser.prog)
+            printer.error("No action specified. Please specify `-l'/`-L' for "
+                          "listing or `-r' for running. "
+                          "Try `%s -h' for more options." %
+                          argparser.prog)
             sys.exit(1)
 
         if not success:

--- a/reframe/frontend/cli.py
+++ b/reframe/frontend/cli.py
@@ -617,8 +617,8 @@ def main():
                     printer.info(runner.stats.performance_report())
 
         else:
-            printer.info("No action specified. Please specify '-l' for "
-                         "listing or '-r' for running.")
+            printer.info("No action specified. Please specify `-l'/`-L' for "
+                         "listing or `-r' for running.")
             printer.info("Try `%s -h' for a list of available actions." %
                          argparser.prog)
             sys.exit(1)


### PR DESCRIPTION
There is also the '-L' option for 'listing matched regression checks with a detailed description'. Message could also be `No action specified. Please specify '-l'/'-L' for listing or '-r' for running.` to be more accurate.

Closes #1060.