### PR TITLE
[refactor] Redesign job scheduler backends

### DIFF
--- a/reframe/core/launchers/__init__.py
+++ b/reframe/core/launchers/__init__.py
@@ -26,8 +26,8 @@ class JobLauncher(abc.ABC):
     #: :default: ``[]``
     options = fields.TypedField('options', typ.List[str])
 
-    def __init__(self, options=[]):
-        self.options = list(options)
+    def __init__(self):
+        self.options = []
 
     @abc.abstractmethod
     def command(self, job):
@@ -79,9 +79,10 @@ class LauncherWrapper(JobLauncher):
     '''
 
     def __init__(self, target_launcher, wrapper_command, wrapper_options=[]):
-        super().__init__(target_launcher.options)
+        super().__init__()
+        self.options = target_launcher.options
         self._target_launcher = target_launcher
-        self._wrapper_command = [wrapper_command] + list(wrapper_options)
+        self._wrapper_command = [wrapper_command] + wrapper_options
 
     def command(self, job):
         return self._wrapper_command + self._target_launcher.command(job)

--- a/reframe/core/launchers/local.py
+++ b/reframe/core/launchers/local.py
@@ -5,9 +5,10 @@ from reframe.core.launchers.registry import register_launcher
 
 @register_launcher('local', local=True)
 class LocalLauncher(JobLauncher):
-    def __init__(self, options=[]):
-        # Ignore options passed by users
-        super().__init__([])
-
     def command(self, job):
+        # Reset any options set by the user
+        #
+        # NOTE: This assumes that the `command` is called before accessing
+        # `self.options`.
+        self.options = []
         return []

--- a/reframe/core/pipeline.py
+++ b/reframe/core/pipeline.py
@@ -953,13 +953,13 @@ class RegressionTest(metaclass=RegressionTestMeta):
             scheduler_type = self._current_partition.scheduler
             launcher_type = self._current_partition.launcher
 
-        self._job = scheduler_type(
-            name='rfm_%s_job' % self.name,
-            launcher=launcher_type(),
-            workdir=self._stagedir,
-            sched_access=self._current_partition.access,
-            sched_exclusive_access=self.exclusive_access,
-            **job_opts)
+        self._job = Job.create(scheduler_type(),
+                               launcher_type(),
+                               name='rfm_%s_job' % self.name,
+                               workdir=self._stagedir,
+                               sched_access=self._current_partition.access,
+                               sched_exclusive_access=self.exclusive_access,
+                               **job_opts)
 
         # Get job options from managed resources and prepend them to
         # job_opts. We want any user supplied options to be able to
@@ -1082,11 +1082,10 @@ class RegressionTest(metaclass=RegressionTestMeta):
         environs = [self._current_partition.local_env, self._current_environ,
                     user_environ, self._cdt_environ]
 
-        self._build_job = getscheduler('local')(
-            name='rfm_%s_build' % self.name,
-            launcher=getlauncher('local')(),
-            workdir=self._stagedir)
-
+        self._build_job = Job.create(getscheduler('local')(),
+                                     launcher=getlauncher('local')(),
+                                     name='rfm_%s_build' % self.name,
+                                     workdir=self._stagedir)
         with os_ext.change_dir(self._stagedir):
             try:
                 self._build_job.prepare(build_commands, environs,

--- a/reframe/core/schedulers/__init__.py
+++ b/reframe/core/schedulers/__init__.py
@@ -103,18 +103,9 @@ class Job:
     def __init__(self,
                  name,
                  workdir='.',
-                 num_tasks=1,
-                 num_tasks_per_node=None,
-                 num_tasks_per_core=None,
-                 num_tasks_per_socket=None,
-                 num_cpus_per_task=None,
-                 use_smt=None,
-                 time_limit=None,
                  script_filename=None,
                  stdout=None,
                  stderr=None,
-                 pre_run=[],
-                 post_run=[],
                  sched_flex_alloc_nodes=None,
                  sched_access=[],
                  sched_account=None,
@@ -123,17 +114,17 @@ class Job:
                  sched_nodelist=None,
                  sched_exclude_nodelist=None,
                  sched_exclusive_access=None,
-                 sched_options=[]):
+                 sched_options=None):
 
         # Mutable fields
-        self.num_tasks = num_tasks
-        self.num_tasks_per_node = num_tasks_per_node
-        self.num_tasks_per_core = num_tasks_per_core
-        self.num_tasks_per_socket = num_tasks_per_socket
-        self.num_cpus_per_task = num_cpus_per_task
-        self.use_smt = use_smt
-        self.time_limit = time_limit
-        self.options = sched_options
+        self.num_tasks = 1
+        self.num_tasks_per_node = None
+        self.num_tasks_per_core = None
+        self.num_tasks_per_socket = None
+        self.num_cpus_per_task = None
+        self.use_smt = None
+        self.time_limit = None
+        self.options = sched_options or []
 
         # Live job information; to be filled during job's lifetime by the
         # scheduler
@@ -233,7 +224,7 @@ class Job:
             if guessed_num_tasks < min_num_tasks:
                 raise JobError(
                     'could not satisfy the minimum task requirement: '
-                    'required %s, requested %s' %
+                    'required %s, found %s' %
                     (min_num_tasks, guessed_num_tasks))
 
             self.num_tasks = guessed_num_tasks
@@ -262,7 +253,6 @@ class Job:
 
         # Try to guess the number of tasks now
         available_nodes = self.scheduler.filternodes(self, available_nodes)
-        print(available_nodes)
         if self.sched_flex_alloc_nodes == 'idle':
             available_nodes = {n for n in available_nodes
                                if n.is_available()}

--- a/reframe/core/schedulers/local.py
+++ b/reframe/core/schedulers/local.py
@@ -18,61 +18,64 @@ class _TimeoutExpired(ReframeError):
 
 
 @register_scheduler('local', local=True)
-class LocalJob(sched.Job):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.cancel_grace_period = 2
+class LocalJobScheduler(sched.JobScheduler):
+    def __init__(self):
+        self._cancel_grace_period = 2
         self._wait_poll_secs = 0.1
-        self._proc = None  # Launched process
 
-    def submit(self):
+        # Underlying process
+        self._proc = None
+
+        # Underlying process' stdout/stderr
+        self._f_stdout = None
+        self._f_stderr = None
+
+    def submit(self, job):
         # `chmod +x' first, because we will execute the script locally
-        os.chmod(self._script_filename,
-                 os.stat(self._script_filename).st_mode | stat.S_IEXEC)
+        os.chmod(job.script_filename,
+                 os.stat(job.script_filename).st_mode | stat.S_IEXEC)
 
         # Run from the absolute path
-        self._f_stdout = open(self.stdout, 'w+')
-        self._f_stderr = open(self.stderr, 'w+')
+        self._f_stdout = open(job.stdout, 'w+')
+        self._f_stderr = open(job.stderr, 'w+')
 
         # The new process starts also a new session (session leader), so that
         # we can later kill any other processes that this might spawn by just
         # killing this one.
         self._proc = os_ext.run_command_async(
-            os.path.abspath(self._script_filename),
+            os.path.abspath(job.script_filename),
             stdout=self._f_stdout,
             stderr=self._f_stderr,
             start_new_session=True)
 
         # Update job info
-        self._jobid = self._proc.pid
-        self._nodelist = [socket.gethostname()]
+        job.jobid = self._proc.pid
+        job.nodelist = [socket.gethostname()]
 
-    def emit_preamble(self):
+    def emit_preamble(self, job):
         return []
 
-    def get_all_nodes(self):
-        raise NotImplementedError(
-            'local scheduler does not support listing of available nodes')
+    def allnodes(self):
+        return [socket.gethostname()]
 
-    def filter_nodes(self, nodes, options):
-        raise NotImplementedError(
-            'local scheduler does not support filtering of available nodes')
+    def filternodes(self, job, nodes):
+        return [socket.gethostname()]
 
-    def _kill_all(self):
+    def _kill_all(self, job):
         '''Send SIGKILL to all the processes of the spawned job.'''
         try:
-            os.killpg(self._jobid, signal.SIGKILL)
+            os.killpg(job.jobid, signal.SIGKILL)
         except (ProcessLookupError, PermissionError):
             # The process group may already be dead or assigned to a different
             # group, so ignore this error
-            getlogger().debug(
-                'pid %s already dead or assigned elsewhere' % self._jobid)
+            getlogger().debug('pid %s already dead or assigned elsewhere' %
+                              job.jobid)
 
-    def _term_all(self):
+    def _term_all(self, job):
         '''Send SIGTERM to all the processes of the spawned job.'''
-        os.killpg(self._jobid, signal.SIGTERM)
+        os.killpg(job.jobid, signal.SIGTERM)
 
-    def _wait_all(self, timeout=0):
+    def _wait_all(self, job, timeout=0):
         '''Wait for all the processes of spawned job to finish.
 
         Keyword arguments:
@@ -87,22 +90,22 @@ class LocalJob(sched.Job):
             # Wait for all processes in the process group to finish
             while not timeout or t_wait.total_seconds() < timeout:
                 t_poll = datetime.now()
-                os.killpg(self._jobid, 0)
+                os.killpg(job.jobid, 0)
                 time.sleep(self._wait_poll_secs)
                 t_poll = datetime.now() - t_poll
                 t_wait += t_poll
 
             # Final check
-            os.killpg(self._jobid, 0)
+            os.killpg(job.jobid, 0)
             raise _TimeoutExpired
         except (ProcessLookupError, PermissionError):
             # Ignore also EPERM errors in case this process id is assigned
             # elsewhere and we cannot query its status
-            getlogger().debug(
-                'pid %s already dead or assigned elsewhere' % self._jobid)
+            getlogger().debug('pid %s already dead or assigned elsewhere' %
+                              job.jobid)
             return
 
-    def cancel(self):
+    def cancel(self, job):
         '''Cancel job.
 
         The SIGTERM signal will be sent first to all the processes of this job
@@ -110,15 +113,14 @@ class LocalJob(sched.Job):
 
         This function waits for the spawned process tree to finish.
         '''
-        super().cancel()
-        self._term_all()
+        self._term_all(job)
 
         # Set the time limit to the grace period and let wait() do the final
         # killing
-        self.time_limit = (0, 0, self.cancel_grace_period)
-        self.wait()
+        job.time_limit = (0, 0, self._cancel_grace_period)
+        self.wait(job)
 
-    def wait(self):
+    def wait(self, job):
         '''Wait for the spawned job to finish.
 
         As soon as the parent job process finishes, all of its spawned
@@ -127,43 +129,41 @@ class LocalJob(sched.Job):
         Upon return, the whole process tree of the spawned job process will be
         cleared, unless any of them has called `setsid()`.
         '''
-        super().wait()
-        if self._state is not None:
+        if job.state is not None:
             # Job has been already waited for
             return
 
         # Convert job's time_limit to seconds
-        if self.time_limit is not None:
-            h, m, s = self.time_limit
+        if job.time_limit is not None:
+            h, m, s = job.time_limit
             timeout = h * 3600 + m * 60 + s
         else:
             timeout = 0
 
         try:
-            self._wait_all(timeout)
-            self._exitcode = self._proc.returncode
-            if self._exitcode != 0:
-                self._state = 'FAILURE'
+            self._wait_all(job, timeout)
+            job.exitcode = self._proc.returncode
+            if job.exitcode != 0:
+                job.state = 'FAILURE'
             else:
-                self._state = 'SUCCESS'
+                job.state = 'SUCCESS'
         except (_TimeoutExpired, subprocess.TimeoutExpired):
             getlogger().debug('job timed out')
-            self._state = 'TIMEOUT'
+            job.state = 'TIMEOUT'
         finally:
             # Cleanup all the processes of this job
-            self._kill_all()
-            self._wait_all()
+            self._kill_all(job)
+            self._wait_all(job)
             self._f_stdout.close()
             self._f_stderr.close()
 
-    def finished(self):
+    def finished(self, job):
         '''Check if the spawned process has finished.
 
         This function does not wait the process. It just queries its state. If
         the process has finished, you *must* call wait() to properly cleanup
         after it.
         '''
-        super().finished()
         self._proc.poll()
         if self._proc.returncode is None:
             return False

--- a/reframe/core/schedulers/pbs.py
+++ b/reframe/core/schedulers/pbs.py
@@ -96,14 +96,14 @@ class PbsJobScheduler(sched.JobScheduler):
         # Slurm wrappers.
         cmd = 'qsub -o %s -e %s %s' % (job.stdout, job.stderr,
                                        job.script_filename)
-        completed = _run_strict(cmd, settings().job_submit_timeout)
+        completed = _run_strict(cmd, timeout=settings().job_submit_timeout)
         jobid_match = re.search(r'^(?P<jobid>\S+)', completed.stdout)
         if not jobid_match:
             raise JobError('could not retrieve the job id '
                            'of the submitted job')
 
         jobid, *info = jobid_match.group('jobid').split('.', maxsplit=2)
-        self._jobid = int(jobid)
+        job.jobid = int(jobid)
         if info:
             self._pbs_server = info[0]
 
@@ -119,7 +119,7 @@ class PbsJobScheduler(sched.JobScheduler):
             jobid += '.' + self._pbs_server
 
         getlogger().debug('cancelling job (id=%s)' % jobid)
-        _run_strict('qdel %s' % jobid, settings().job_submit_timeout)
+        _run_strict('qdel %s' % jobid, timeout=settings().job_submit_timeout)
 
     def finished(self, job):
         with os_ext.change_dir(job.workdir):

--- a/reframe/core/schedulers/pbs.py
+++ b/reframe/core/schedulers/pbs.py
@@ -4,6 +4,7 @@
 # - Initial version submitted by Rafael Escovar, ASML
 #
 
+import functools
 import os
 import itertools
 import re
@@ -23,20 +24,22 @@ from reframe.core.schedulers.registry import register_scheduler
 PBS_OUTPUT_WRITEBACK_WAIT = 3
 
 
+_run_strict = functools.partial(os_ext.run_command, check=True)
+
+
 @register_scheduler('pbs')
-class PbsJob(sched.Job):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+class PbsJobScheduler(sched.JobScheduler):
+    def __init__(self):
         self._prefix = '#PBS'
         self._time_finished = None
 
         # Optional part of the job id refering to the PBS server
         self._pbs_server = None
 
-    def _emit_lselect_option(self):
-        num_tasks_per_node = self.num_tasks_per_node or 1
-        num_cpus_per_task = self.num_cpus_per_task or 1
-        num_nodes = self.num_tasks // num_tasks_per_node
+    def _emit_lselect_option(self, job):
+        num_tasks_per_node = job.num_tasks_per_node or 1
+        num_cpus_per_task = job.num_cpus_per_task or 1
+        num_nodes = job.num_tasks // num_tasks_per_node
         num_cpus_per_node = num_tasks_per_node * num_cpus_per_task
         select_opt = '-l select=%s:mpiprocs=%s:ncpus=%s' % (num_nodes,
                                                             num_tasks_per_node,
@@ -45,7 +48,7 @@ class PbsJob(sched.Job):
         # Options starting with `-` are emitted in separate lines
         rem_opts = []
         verb_opts = []
-        for opt in (*self.sched_access, *self.options):
+        for opt in (*job.sched_access, *job.options):
             if opt.startswith('-'):
                 rem_opts.append(opt)
             elif opt.startswith('#'):
@@ -60,47 +63,40 @@ class PbsJob(sched.Job):
     def _format_option(self, option):
         return self._prefix + ' ' + option
 
-    def _run_command(self, cmd, timeout=None):
-        '''Run command cmd and re-raise any exception as a JobError.'''
-        try:
-            return os_ext.run_command(cmd, check=True, timeout=timeout)
-        except SpawnedProcessError as e:
-            raise JobError(jobid=self._jobid) from e
-
-    def emit_preamble(self):
+    def emit_preamble(self, job):
         preamble = [
-            self._format_option('-N "%s"' % self.name),
-            self._format_option('-o %s' % self.stdout),
-            self._format_option('-e %s' % self.stderr),
+            self._format_option('-N "%s"' % job.name),
+            self._format_option('-o %s' % job.stdout),
+            self._format_option('-e %s' % job.stderr),
         ]
 
-        if self.time_limit is not None:
+        if job.time_limit is not None:
             preamble.append(
-                self._format_option('-l walltime=%d:%d:%d' % self.time_limit))
+                self._format_option('-l walltime=%d:%d:%d' % job.time_limit))
 
-        if self.sched_partition:
+        if job.sched_partition:
             preamble.append(
-                self._format_option('-q %s' % self.sched_partition))
+                self._format_option('-q %s' % job.sched_partition))
 
-        preamble += self._emit_lselect_option()
+        preamble += self._emit_lselect_option(job)
 
         # PBS starts the job in the home directory by default
-        preamble.append('cd %s' % self.workdir)
+        preamble.append('cd %s' % job.workdir)
         return preamble
 
-    def get_all_nodes(self):
+    def allnodes(self):
         raise NotImplementedError('pbs backend does not support node listing')
 
-    def filter_nodes(self, nodes, options):
+    def filternodes(self, job, nodes):
         raise NotImplementedError('pbs backend does not support '
                                   'node filtering')
 
-    def submit(self):
+    def submit(self, job):
         # `-o` and `-e` options are only recognized in command line by the PBS
         # Slurm wrappers.
-        cmd = 'qsub -o %s -e %s %s' % (self.stdout, self.stderr,
-                                       self.script_filename)
-        completed = self._run_command(cmd, settings().job_submit_timeout)
+        cmd = 'qsub -o %s -e %s %s' % (job.stdout, job.stderr,
+                                       job.script_filename)
+        completed = _run_strict(cmd, settings().job_submit_timeout)
         jobid_match = re.search(r'^(?P<jobid>\S+)', completed.stdout)
         if not jobid_match:
             raise JobError('could not retrieve the job id '
@@ -111,27 +107,23 @@ class PbsJob(sched.Job):
         if info:
             self._pbs_server = info[0]
 
-    def wait(self):
-        super().wait()
+    def wait(self, job):
         intervals = itertools.cycle(settings().job_poll_intervals)
-        while not self.finished():
+        while not self.finished(job):
             time.sleep(next(intervals))
 
-    def cancel(self):
-        super().cancel()
-
+    def cancel(self, job):
         # Recreate the full job id
-        jobid = str(self._jobid)
+        jobid = str(job.jobid)
         if self._pbs_server:
             jobid += '.' + self._pbs_server
 
         getlogger().debug('cancelling job (id=%s)' % jobid)
-        self._run_command('qdel %s' % jobid, settings().job_submit_timeout)
+        _run_strict('qdel %s' % jobid, settings().job_submit_timeout)
 
-    def finished(self):
-        super().finished()
-        with os_ext.change_dir(self.workdir):
-            done = os.path.exists(self.stdout) and os.path.exists(self.stderr)
+    def finished(self, job):
+        with os_ext.change_dir(job.workdir):
+            done = os.path.exists(job.stdout) and os.path.exists(job.stderr)
 
         if done:
             t_now = datetime.now()

--- a/unittests/test_launchers.py
+++ b/unittests/test_launchers.py
@@ -36,13 +36,6 @@ class _TestLauncher(abc.ABC):
         self.job = Job.create(FakeJobScheduler(),
                               self.launcher,
                               name='fake_job',
-                              num_tasks=4,
-                              num_tasks_per_node=2,
-                              num_tasks_per_core=1,
-                              num_tasks_per_socket=1,
-                              num_cpus_per_task=2,
-                              use_smt=True,
-                              time_limit=(0, 10, 0),
                               script_filename='fake_script',
                               stdout='fake_stdout',
                               stderr='fake_stderr',
@@ -53,13 +46,19 @@ class _TestLauncher(abc.ABC):
                               sched_exclude_nodelist='fake_exclude_nodelist',
                               sched_exclusive_access='fake_exclude_access',
                               sched_options=['--fake'])
+        self.job.num_tasks = 4
+        self.job.num_tasks_per_node = 2
+        self.job.num_tasks_per_core = 1
+        self.job.num_tasks_per_socket = 1
+        self.job.num_cpus_per_task = 2
+        self.job.use_smt = True
+        self.job.time_limit = (0, 10, 0)
         self.job.options += ['--gres=gpu:4', '#DW jobdw anything']
         self.job.launcher.options = ['--foo']
         self.minimal_job = Job.create(FakeJobScheduler(),
                                       self.launcher,
                                       name='fake_job')
         self.minimal_job.launcher.options = ['--foo']
-        print(self.job.launcher)
 
     @property
     @abc.abstractmethod
@@ -91,9 +90,7 @@ class _TestLauncher(abc.ABC):
 class TestSrunLauncher(_TestLauncher, unittest.TestCase):
     @property
     def launcher(self):
-        ret = getlauncher('srun')()
-        print('ret =', ret)
-        return ret
+        return getlauncher('srun')()
 
     @property
     def expected_command(self):

--- a/unittests/test_launchers.py
+++ b/unittests/test_launchers.py
@@ -3,29 +3,29 @@ import unittest
 
 import reframe.core.launchers as launchers
 from reframe.core.launchers.registry import getlauncher
-from reframe.core.schedulers import Job
+from reframe.core.schedulers import Job, JobScheduler
 
 
-class FakeJob(Job):
-    def emit_preamble(self):
+class FakeJobScheduler(JobScheduler):
+    def emit_preamble(self, job):
         pass
 
-    def submit(self):
+    def submit(self, job):
         pass
 
-    def wait(self):
+    def wait(self, job):
         pass
 
-    def cancel(self):
+    def cancel(self, job):
         pass
 
-    def finished(self):
+    def finished(self, job):
         pass
 
-    def get_all_nodes(self):
+    def allnodes(self):
         pass
 
-    def filter_nodes(self, nodes):
+    def filternodes(self, job, nodes):
         pass
 
 
@@ -33,27 +33,33 @@ class _TestLauncher(abc.ABC):
     '''Base class for launcher tests.'''
 
     def setUp(self):
-        self.job = FakeJob(name='fake_job',
-                           launcher=self.launcher,
-                           num_tasks=4,
-                           num_tasks_per_node=2,
-                           num_tasks_per_core=1,
-                           num_tasks_per_socket=1,
-                           num_cpus_per_task=2,
-                           use_smt=True,
-                           time_limit=(0, 10, 0),
-                           script_filename='fake_script',
-                           stdout='fake_stdout',
-                           stderr='fake_stderr',
-                           sched_account='fake_account',
-                           sched_partition='fake_partition',
-                           sched_reservation='fake_reservation',
-                           sched_nodelist="mynode",
-                           sched_exclude_nodelist='fake_exclude_nodelist',
-                           sched_exclusive_access='fake_exclude_access',
-                           sched_options=['--fake'])
+        self.job = Job.create(FakeJobScheduler(),
+                              self.launcher,
+                              name='fake_job',
+                              num_tasks=4,
+                              num_tasks_per_node=2,
+                              num_tasks_per_core=1,
+                              num_tasks_per_socket=1,
+                              num_cpus_per_task=2,
+                              use_smt=True,
+                              time_limit=(0, 10, 0),
+                              script_filename='fake_script',
+                              stdout='fake_stdout',
+                              stderr='fake_stderr',
+                              sched_account='fake_account',
+                              sched_partition='fake_partition',
+                              sched_reservation='fake_reservation',
+                              sched_nodelist="mynode",
+                              sched_exclude_nodelist='fake_exclude_nodelist',
+                              sched_exclusive_access='fake_exclude_access',
+                              sched_options=['--fake'])
         self.job.options += ['--gres=gpu:4', '#DW jobdw anything']
-        self.minimal_job = FakeJob(name='fake_job', launcher=self.launcher)
+        self.job.launcher.options = ['--foo']
+        self.minimal_job = Job.create(FakeJobScheduler(),
+                                      self.launcher,
+                                      name='fake_job')
+        self.minimal_job.launcher.options = ['--foo']
+        print(self.job.launcher)
 
     @property
     @abc.abstractmethod
@@ -70,19 +76,24 @@ class _TestLauncher(abc.ABC):
     def expected_minimal_command(self):
         '''The command expected to be emitted by the launcher.'''
 
+    def run_command(self, job):
+        return self.job.launcher.run_command(job)
+
     def test_run_command(self):
-        emitted_command = self.launcher.run_command(self.job)
+        emitted_command = self.run_command(self.job)
         self.assertEqual(self.expected_command, emitted_command)
 
     def test_run_minimal_command(self):
-        emitted_command = self.launcher.run_command(self.minimal_job)
+        emitted_command = self.run_command(self.minimal_job)
         self.assertEqual(self.expected_minimal_command, emitted_command)
 
 
 class TestSrunLauncher(_TestLauncher, unittest.TestCase):
     @property
     def launcher(self):
-        return getlauncher('srun')(options=['--foo'])
+        ret = getlauncher('srun')()
+        print('ret =', ret)
+        return ret
 
     @property
     def expected_command(self):
@@ -97,7 +108,7 @@ class TestSrunallocLauncher(_TestLauncher, unittest.TestCase):
 
     @property
     def launcher(self):
-        return getlauncher('srunalloc')(options=['--foo'])
+        return getlauncher('srunalloc')()
 
     @property
     def expected_command(self):
@@ -135,7 +146,7 @@ class TestSrunallocLauncher(_TestLauncher, unittest.TestCase):
 class TestAlpsLauncher(_TestLauncher, unittest.TestCase):
     @property
     def launcher(self):
-        return getlauncher('alps')(options=['--foo'])
+        return getlauncher('alps')()
 
     @property
     def expected_command(self):
@@ -149,7 +160,7 @@ class TestAlpsLauncher(_TestLauncher, unittest.TestCase):
 class TestMpirunLauncher(_TestLauncher, unittest.TestCase):
     @property
     def launcher(self):
-        return getlauncher('mpirun')(options=['--foo'])
+        return getlauncher('mpirun')()
 
     @property
     def expected_command(self):
@@ -163,7 +174,7 @@ class TestMpirunLauncher(_TestLauncher, unittest.TestCase):
 class TestMpiexecLauncher(_TestLauncher, unittest.TestCase):
     @property
     def launcher(self):
-        return getlauncher('mpiexec')(options=['--foo'])
+        return getlauncher('mpiexec')()
 
     @property
     def expected_command(self):
@@ -178,8 +189,7 @@ class TestLauncherWrapperAlps(_TestLauncher, unittest.TestCase):
     @property
     def launcher(self):
         return launchers.LauncherWrapper(
-            getlauncher('alps')(options=['--foo']),
-            'ddt', ['--offline']
+            getlauncher('alps')(), 'ddt', ['--offline']
         )
 
     @property
@@ -194,7 +204,7 @@ class TestLauncherWrapperAlps(_TestLauncher, unittest.TestCase):
 class TestLocalLauncher(_TestLauncher, unittest.TestCase):
     @property
     def launcher(self):
-        return getlauncher('local')(['--foo'])
+        return getlauncher('local')()
 
     @property
     def expected_command(self):
@@ -213,7 +223,7 @@ class TestSSHLauncher(_TestLauncher, unittest.TestCase):
 
     @property
     def launcher(self):
-        return getlauncher('ssh')(['--foo'])
+        return getlauncher('ssh')()
 
     @property
     def expected_command(self):

--- a/unittests/test_schedulers.py
+++ b/unittests/test_schedulers.py
@@ -27,7 +27,8 @@ class _TestJob(abc.ABC):
             name='testjob',
             workdir=self.workdir,
             script_filename=os_ext.mkstemp_path(
-                dir=self.workdir, suffix='.sh'),
+                dir=self.workdir, suffix='.sh'
+            ),
             stdout=os_ext.mkstemp_path(dir=self.workdir, suffix='.out'),
             stderr=os_ext.mkstemp_path(dir=self.workdir, suffix='.err'),
         )
@@ -82,7 +83,7 @@ class _TestJob(abc.ABC):
             msg = msg or "scheduler '%s' not configured" % self.sched_name
             self.skipTest(msg)
 
-        self.testjob.options += partition.access
+        self.testjob._sched_access = partition.access
 
     def assertScriptSanity(self, script_file):
         '''Assert the sanity of the produced script file.'''


### PR DESCRIPTION
Scheduler logic is now separated from the job information. The `Job` class still offers the same API to its clients, but it delegates all the scheduler-specific work to a scheduler backend. The advantage of this design is that we can easily and cleanly support custom configurations for the backend schedulers. All scheduler backends inherit from the `JobScheduler` base abstract class. This class is intentionally left without any implementation, because it needs to serve as a pure interface, which the scheduler backends must implement. The key difference of this interface compared to the current one is that these function take the user job as an argument instead referring to it through `self`.

I fixed also a minor bug in the local launcher, that actually didn't ignore `options`, if these were set after its creation (now this is also the only way to set the launcher options, which is how it is used in practice).

I have also enabled flexible allocation for the local scheduler, since it's trivial. It's always the current host. :-)

@ZQyou these changes will most probably break your PBS local scheduler adaptations, but the changes should be straightforward to adapt.

Fixes #74. 

- ~~I still need to check if the documentation shows up correctly.~~
- ~~I still need to fix the unit tests in CSCS CI.~~