### PR TITLE
[bugfix] Fix crash of local scheduler with flexible allocation

### DIFF
--- a/reframe/core/schedulers/__init__.py
+++ b/reframe/core/schedulers/__init__.py
@@ -334,3 +334,9 @@ class Job:
             raise JobNotStartedError('cannot poll an unstarted job')
 
         return self.scheduler.finished(self)
+
+
+class Node(abc.ABC):
+    @abc.abstractmethod
+    def is_available(self):
+        '''Return ``True`` if this node is available, ``False`` otherwise.'''

--- a/reframe/core/schedulers/local.py
+++ b/reframe/core/schedulers/local.py
@@ -56,10 +56,10 @@ class LocalJobScheduler(sched.JobScheduler):
         return []
 
     def allnodes(self):
-        return [socket.gethostname()]
+        return [_LocalNode(socket.gethostname())]
 
     def filternodes(self, job, nodes):
-        return [socket.gethostname()]
+        return [_LocalNode(socket.gethostname())]
 
     def _kill_all(self, job):
         '''Send SIGKILL to all the processes of the spawned job.'''
@@ -168,4 +168,12 @@ class LocalJobScheduler(sched.JobScheduler):
         if self._proc.returncode is None:
             return False
 
+        return True
+
+
+class _LocalNode(sched.Node):
+    def __init__(self, name):
+        self._name = name
+
+    def is_available(self):
         return True

--- a/reframe/core/schedulers/slurm.py
+++ b/reframe/core/schedulers/slurm.py
@@ -166,7 +166,7 @@ class SlurmJobScheduler(sched.JobScheduler):
             raise JobError('could not retrieve node information') from e
 
         node_descriptions = completed.stdout.splitlines()
-        return create_nodes(node_descriptions)
+        return _create_nodes(node_descriptions)
 
     def _get_default_partition(self):
         completed = _run_strict('scontrol -a show -o partitions')
@@ -272,13 +272,13 @@ class SlurmJobScheduler(sched.JobScheduler):
 
         completed = _run_strict('scontrol -a show -o %s' % reservation_nodes)
         node_descriptions = completed.stdout.splitlines()
-        return create_nodes(node_descriptions)
+        return _create_nodes(node_descriptions)
 
     def _get_nodes_by_name(self, nodespec):
         completed = os_ext.run_command('scontrol -a show -o node %s' %
                                        nodespec)
         node_descriptions = completed.stdout.splitlines()
-        return create_nodes(node_descriptions)
+        return _create_nodes(node_descriptions)
 
     def _set_nodelist(self, job, nodespec):
         if job.nodelist is not None:
@@ -485,16 +485,16 @@ class SqueueJobScheduler(SlurmJobScheduler):
         self._cancelled = True
 
 
-def create_nodes(descriptions):
+def _create_nodes(descriptions):
     nodes = set()
     for descr in descriptions:
         with suppress(JobError):
-            nodes.add(SlurmNode(descr))
+            nodes.add(_SlurmNode(descr))
 
     return nodes
 
 
-class SlurmNode:
+class _SlurmNode(sched.Node):
     '''Class representing a Slurm node.'''
 
     def __init__(self, node_descr):

--- a/unittests/resources/checks/hellocheck.py
+++ b/unittests/resources/checks/hellocheck.py
@@ -9,6 +9,7 @@ class HelloTest(rfm.RegressionTest):
         self.descr = 'C Hello World test'
 
         # All available systems are supported
+        self.num_tasks = 0
         self.valid_systems = ['*']
         self.valid_prog_environs = ['*']
         self.sourcepath = 'hello.c'

--- a/unittests/resources/checks/hellocheck.py
+++ b/unittests/resources/checks/hellocheck.py
@@ -9,7 +9,6 @@ class HelloTest(rfm.RegressionTest):
         self.descr = 'C Hello World test'
 
         # All available systems are supported
-        self.num_tasks = 0
         self.valid_systems = ['*']
         self.valid_prog_environs = ['*']
         self.sourcepath = 'hello.c'


### PR DESCRIPTION
This introduces a an API for a Node, which the Job talks to for determining
whether the node is available or not. Different backends implement that
differently.

Also made private the `SlurmNode` class and the `create_nodes()` function.

Fixes #1087.