### PR TITLE
[bugfix] Fix dependency bug in async policy

### DIFF
--- a/reframe/frontend/executors/policies.py
+++ b/reframe/frontend/executors/policies.py
@@ -168,7 +168,9 @@ class AsynchronousExecutionPolicy(ExecutionPolicy, TaskEventListener):
         self.task_listeners.append(self)
 
     def _remove_from_running(self, task):
-        getlogger().debug('removing task from running: %s' % task.check.info())
+        getlogger().debug(
+            'removing task from running list: %s' % task.check.info()
+        )
         try:
             self._running_tasks.remove(task)
         except ValueError:
@@ -179,7 +181,9 @@ class AsynchronousExecutionPolicy(ExecutionPolicy, TaskEventListener):
             self._running_tasks_counts[partname] -= 1
 
     def _remove_from_waiting(self, task):
-        getlogger().debug('removing task from waiting: %s' % task.check.info())
+        getlogger().debug(
+            'removing task from waiting list: %s' % task.check.info()
+        )
         try:
             self._waiting_tasks.remove(task)
         except ValueError:

--- a/reframe/frontend/executors/policies.py
+++ b/reframe/frontend/executors/policies.py
@@ -314,14 +314,14 @@ class AsynchronousExecutionPolicy(ExecutionPolicy, TaskEventListener):
                     task.fail((type(exc), exc, None))
                 elif self.deps_succeeded(task):
                     task.setup(task.testcase.partition,
-                            task.testcase.environ,
-                            sched_flex_alloc_nodes=self.sched_flex_alloc_nodes,
-                            sched_account=self.sched_account,
-                            sched_partition=self.sched_partition,
-                            sched_reservation=self.sched_reservation,
-                            sched_nodelist=self.sched_nodelist,
-                            sched_exclude_nodelist=self.sched_exclude_nodelist,
-                            sched_options=self.sched_options)
+                               task.testcase.environ,
+                               sched_flex_alloc_nodes=self.sched_flex_alloc_nodes,
+                               sched_account=self.sched_account,
+                               sched_partition=self.sched_partition,
+                               sched_reservation=self.sched_reservation,
+                               sched_nodelist=self.sched_nodelist,
+                               sched_exclude_nodelist=self.sched_exclude_nodelist,
+                               sched_options=self.sched_options)
                 else:
                     still_waiting.append(task)
             except TaskExit:

--- a/reframe/frontend/executors/policies.py
+++ b/reframe/frontend/executors/policies.py
@@ -168,7 +168,7 @@ class AsynchronousExecutionPolicy(ExecutionPolicy, TaskEventListener):
         self.task_listeners.append(self)
 
     def _remove_from_running(self, task):
-        getlogger().debug('removing task: %s' % task.check.info())
+        getlogger().debug('removing task from running: %s' % task.check.info())
         try:
             self._running_tasks.remove(task)
         except ValueError:
@@ -177,6 +177,14 @@ class AsynchronousExecutionPolicy(ExecutionPolicy, TaskEventListener):
         else:
             partname = task.check.current_partition.fullname
             self._running_tasks_counts[partname] -= 1
+
+    def _remove_from_waiting(self, task):
+        getlogger().debug('removing task from waiting: %s' % task.check.info())
+        try:
+            self._waiting_tasks.remove(task)
+        except ValueError:
+            getlogger().debug('not in waiting tasks')
+            pass
 
     def deps_failed(self, task):
         return any(self._task_index[c].failed for c in task.testcase.deps)
@@ -195,6 +203,7 @@ class AsynchronousExecutionPolicy(ExecutionPolicy, TaskEventListener):
 
     def on_task_failure(self, task):
         self._remove_from_running(task)
+        self._remove_from_waiting(task)
         self.printer.status('FAIL', task.check.info(), just='right')
 
     def on_task_success(self, task):
@@ -295,22 +304,28 @@ class AsynchronousExecutionPolicy(ExecutionPolicy, TaskEventListener):
 
     def _setup_all(self):
         still_waiting = []
-        for task in self._waiting_tasks:
-            if self.deps_failed(task):
-                exc = TaskDependencyError('dependencies failed')
-                task.fail((type(exc), exc, None))
-            elif self.deps_succeeded(task):
-                task.setup(task.testcase.partition,
-                           task.testcase.environ,
-                           sched_flex_alloc_nodes=self.sched_flex_alloc_nodes,
-                           sched_account=self.sched_account,
-                           sched_partition=self.sched_partition,
-                           sched_reservation=self.sched_reservation,
-                           sched_nodelist=self.sched_nodelist,
-                           sched_exclude_nodelist=self.sched_exclude_nodelist,
-                           sched_options=self.sched_options)
-            else:
-                still_waiting.append(task)
+        # It needs to loop over a copy of _waiting_tasks because a testcase
+        # could fail on setup and be removed from the list _waiting_tasks.
+        # This would not be not safe and could have unxpected consequences.
+        for task in self._waiting_tasks[:]:
+            try:
+                if self.deps_failed(task):
+                    exc = TaskDependencyError('dependencies failed')
+                    task.fail((type(exc), exc, None))
+                elif self.deps_succeeded(task):
+                    task.setup(task.testcase.partition,
+                            task.testcase.environ,
+                            sched_flex_alloc_nodes=self.sched_flex_alloc_nodes,
+                            sched_account=self.sched_account,
+                            sched_partition=self.sched_partition,
+                            sched_reservation=self.sched_reservation,
+                            sched_nodelist=self.sched_nodelist,
+                            sched_exclude_nodelist=self.sched_exclude_nodelist,
+                            sched_options=self.sched_options)
+                else:
+                    still_waiting.append(task)
+            except TaskExit:
+                pass
 
         self._waiting_tasks[:] = still_waiting
 

--- a/unittests/resources/checks_unlisted/deps_complex.py
+++ b/unittests/resources/checks_unlisted/deps_complex.py
@@ -166,16 +166,14 @@ class T8(BaseTest):
 
     @rfm.run_after('setup')
     def fail(self):
-        '''Make this test fail on purpose'''
-
+        # Make this test fail on purpose
         raise Exception
 
 
 @rfm.simple_test
 class T9(BaseTest):
-    '''This tests fails because of T8. It is added to make sure that
-    all tests are accounted for in the summary.
-    '''
+    # This tests fails because of T8. It is added to make sure that
+    # all tests are accounted for in the summary.
 
     def __init__(self):
         super().__init__()

--- a/unittests/resources/checks_unlisted/deps_complex.py
+++ b/unittests/resources/checks_unlisted/deps_complex.py
@@ -164,16 +164,19 @@ class T8(BaseTest):
         with open(os.path.join(T1().stagedir, 'out.txt')) as fp:
             self._count += int(fp.read())
 
-    # Make this test fail on purpose
     @rfm.run_after('setup')
     def fail(self):
+        '''Make this test fail on purpose'''
+
         raise Exception
 
 
-# This tests fails because of T8. It is added to make sure that
-# all tests are accounted for in the summary.
 @rfm.simple_test
 class T9(BaseTest):
+    '''This tests fails because of T8. It is added to make sure that
+    all tests are accounted for in the summary.
+    '''
+
     def __init__(self):
         super().__init__()
         self.depends_on('T8')

--- a/unittests/resources/checks_unlisted/deps_complex.py
+++ b/unittests/resources/checks_unlisted/deps_complex.py
@@ -11,7 +11,7 @@ import reframe.utility.sanity as sn
 #       |
 #   +-->t4<--+
 #   |        |
-#   t5<------t1
+#   t5<------t1<--t8<--t9
 #   ^        ^
 #   |        |
 #   +---t6---+
@@ -149,4 +149,37 @@ class T7(BaseTest):
     @rfm.require_deps
     def prepend_output(self, T2):
         with open(os.path.join(T2().stagedir, 'out.txt')) as fp:
+            self._count += int(fp.read())
+
+
+@rfm.simple_test
+class T8(BaseTest):
+    def __init__(self):
+        super().__init__()
+        self.depends_on('T1')
+        self.sanity_patterns = sn.assert_eq(self.count, 22)
+
+    @rfm.require_deps
+    def prepend_output(self, T1):
+        with open(os.path.join(T1().stagedir, 'out.txt')) as fp:
+            self._count += int(fp.read())
+
+    # Make this test fail on purpose
+    @rfm.run_after('setup')
+    def fail(self):
+        raise Exception
+
+
+# This tests fails because of T8. It is added to make sure that
+# all tests are accounted for in the summary.
+@rfm.simple_test
+class T9(BaseTest):
+    def __init__(self):
+        super().__init__()
+        self.depends_on('T8')
+        self.sanity_patterns = sn.assert_eq(self.count, 31)
+
+    @rfm.require_deps
+    def prepend_output(self, T8):
+        with open(os.path.join(T8().stagedir, 'out.txt')) as fp:
             self._count += int(fp.read())

--- a/unittests/test_policies.py
+++ b/unittests/test_policies.py
@@ -225,9 +225,9 @@ class TestSerialExecutionPolicy(unittest.TestCase):
         self.checks = self.loader.load_all()
         self.runall(self.checks, sort=True)
 
+        self.assertRunall()
         stats = self.runner.stats
         assert stats.num_cases(0) == 10
-        self.assertRunall()
         assert len(stats.failures()) == 4
         for tf in stats.failures():
             check = tf.testcase.check

--- a/unittests/test_policies.py
+++ b/unittests/test_policies.py
@@ -58,6 +58,11 @@ class TestSerialExecutionPolicy(unittest.TestCase):
 
         self.runner.runall(cases)
 
+    def assertRunall(self):
+        # Make sure that all cases finished or failed
+        for t in self.runner.stats.tasks():
+            assert t.succeeded or t.failed
+
     def _num_failures_stage(self, stage):
         stats = self.runner.stats
         return len([t for t in stats.failures() if t.failed_stage == stage])
@@ -77,6 +82,7 @@ class TestSerialExecutionPolicy(unittest.TestCase):
 
         stats = self.runner.stats
         self.assertEqual(7, stats.num_cases())
+        self.assertRunall()
         self.assertEqual(4, len(stats.failures()))
         self.assertEqual(2, self._num_failures_stage('setup'))
         self.assertEqual(1, self._num_failures_stage('sanity'))
@@ -87,6 +93,7 @@ class TestSerialExecutionPolicy(unittest.TestCase):
 
         stats = self.runner.stats
         self.assertEqual(8, stats.num_cases())
+        self.assertRunall()
         self.assertEqual(4, len(stats.failures()))
         self.assertEqual(2, self._num_failures_stage('setup'))
         self.assertEqual(1, self._num_failures_stage('sanity'))
@@ -97,6 +104,7 @@ class TestSerialExecutionPolicy(unittest.TestCase):
 
         stats = self.runner.stats
         self.assertEqual(8, stats.num_cases())
+        self.assertRunall()
         self.assertEqual(4, len(stats.failures()))
         self.assertEqual(2, self._num_failures_stage('setup'))
         self.assertEqual(1, self._num_failures_stage('sanity'))
@@ -108,6 +116,7 @@ class TestSerialExecutionPolicy(unittest.TestCase):
 
         stats = self.runner.stats
         self.assertEqual(7, stats.num_cases())
+        self.assertRunall()
         self.assertEqual(3, len(stats.failures()))
         self.assertEqual(2, self._num_failures_stage('setup'))
         self.assertEqual(0, self._num_failures_stage('sanity'))
@@ -119,6 +128,7 @@ class TestSerialExecutionPolicy(unittest.TestCase):
 
         stats = self.runner.stats
         self.assertEqual(7, stats.num_cases())
+        self.assertRunall()
         self.assertEqual(3, len(stats.failures()))
         self.assertEqual(2, self._num_failures_stage('setup'))
         self.assertEqual(1, self._num_failures_stage('sanity'))
@@ -130,6 +140,7 @@ class TestSerialExecutionPolicy(unittest.TestCase):
 
         stats = self.runner.stats
         self.assertEqual(7, stats.num_cases())
+        self.assertRunall()
         self.assertEqual(5, len(stats.failures()))
         self.assertEqual(2, self._num_failures_stage('setup'))
         self.assertEqual(1, self._num_failures_stage('sanity'))
@@ -138,6 +149,7 @@ class TestSerialExecutionPolicy(unittest.TestCase):
     def test_force_local_execution(self):
         self.runner.policy.force_local = True
         self.runall([HelloTest()])
+        self.assertRunall()
         stats = self.runner.stats
         for t in stats.tasks():
             self.assertTrue(t.check.local)
@@ -165,6 +177,7 @@ class TestSerialExecutionPolicy(unittest.TestCase):
 
         # Ensure that the test was retried #max_retries times and failed.
         self.assertEqual(2, self.runner.stats.num_cases())
+        self.assertRunall()
         self.assertEqual(max_retries, rt.runtime().current_run)
         self.assertEqual(2, len(self.runner.stats.failures()))
 
@@ -179,6 +192,7 @@ class TestSerialExecutionPolicy(unittest.TestCase):
 
         # Ensure that the test passed without retries.
         self.assertEqual(1, self.runner.stats.num_cases())
+        self.assertRunall()
         self.assertEqual(0, rt.runtime().current_run)
         self.assertEqual(0, len(self.runner.stats.failures()))
 
@@ -196,6 +210,7 @@ class TestSerialExecutionPolicy(unittest.TestCase):
 
         # Ensure that the test passed after retries in run #run_to_pass.
         self.assertEqual(1, self.runner.stats.num_cases())
+        self.assertRunall()
         self.assertEqual(1, len(self.runner.stats.failures(run=0)))
         self.assertEqual(run_to_pass, rt.runtime().current_run)
         self.assertEqual(0, len(self.runner.stats.failures()))
@@ -211,12 +226,13 @@ class TestSerialExecutionPolicy(unittest.TestCase):
         self.runall(self.checks, sort=True)
 
         stats = self.runner.stats
-        assert stats.num_cases(0) == 8
-        assert len(stats.failures()) == 2
+        assert stats.num_cases(0) == 10
+        self.assertRunall()
+        assert len(stats.failures()) == 4
         for tf in stats.failures():
             check = tf.testcase.check
-            exc_type, exc_value, _ = tf.exc_info
-            if check.name == 'T7':
+            _, exc_value, _ = tf.exc_info
+            if check.name == 'T7' or check.name == 'T9':
                 assert isinstance(exc_value, TaskDependencyError)
 
         # Check that cleanup is executed properly for successful tests as well
@@ -309,6 +325,7 @@ class TestAsynchronousExecutionPolicy(TestSerialExecutionPolicy):
 
         # Ensure that all tests were run and without failures.
         self.assertEqual(len(checks), self.runner.stats.num_cases())
+        self.assertRunall()
         self.assertEqual(0, len(self.runner.stats.failures()))
 
         # Ensure that maximum concurrency was reached as fast as possible
@@ -334,6 +351,7 @@ class TestAsynchronousExecutionPolicy(TestSerialExecutionPolicy):
 
         # Ensure that all tests were run and without failures.
         self.assertEqual(len(checks), self.runner.stats.num_cases())
+        self.assertRunall()
         self.assertEqual(0, len(self.runner.stats.failures()))
 
         # Ensure that maximum concurrency was reached as fast as possible
@@ -372,6 +390,7 @@ class TestAsynchronousExecutionPolicy(TestSerialExecutionPolicy):
 
         # Ensure that all tests were run and without failures.
         self.assertEqual(len(checks), self.runner.stats.num_cases())
+        self.assertRunall()
         self.assertEqual(0, len(self.runner.stats.failures()))
 
         # Ensure that a single task was running all the time
@@ -391,6 +410,7 @@ class TestAsynchronousExecutionPolicy(TestSerialExecutionPolicy):
         self.assertRaises(KeyboardInterrupt, self.runall, checks)
 
         self.assertEqual(4, self.runner.stats.num_cases())
+        self.assertRunall()
         self.assertEqual(4, len(self.runner.stats.failures()))
         self.assert_all_dead()
 
@@ -427,6 +447,7 @@ class TestAsynchronousExecutionPolicy(TestSerialExecutionPolicy):
         self.runall(checks)
         stats = self.runner.stats
         self.assertEqual(num_tasks, stats.num_cases())
+        self.assertRunall()
         self.assertEqual(num_tasks, len(stats.failures()))
 
     def test_poll_fails_busy_loop(self):
@@ -437,6 +458,7 @@ class TestAsynchronousExecutionPolicy(TestSerialExecutionPolicy):
         self.runall(checks)
         stats = self.runner.stats
         self.assertEqual(num_tasks, stats.num_cases())
+        self.assertRunall()
         self.assertEqual(num_tasks, len(stats.failures()))
 
 


### PR DESCRIPTION
Async policy enters infinite loop when executing dependencies that fail before/after the setup phase.

I also made the dependency unittests more strict so that they check that all cases either were successful or failed. Checking the `num_cases` of `stats` is not enough to make sure a testcase was accounted for in the final summary.

Fixes #1082 .
