### PR TITLE
[bugfix] Remove `type` key from the environment configuration

### DIFF
--- a/config/cscs-ci.py
+++ b/config/cscs-ci.py
@@ -82,34 +82,28 @@ class ReframeSettings:
         'environments': {
             '*': {
                 'PrgEnv-cray': {
-                    'type': 'ProgEnvironment',
                     'modules': ['PrgEnv-cray'],
                 },
 
                 'PrgEnv-gnu': {
-                    'type': 'ProgEnvironment',
                     'modules': ['PrgEnv-gnu'],
                 },
 
                 'PrgEnv-intel': {
-                    'type': 'ProgEnvironment',
                     'modules': ['PrgEnv-intel'],
                 },
 
                 'PrgEnv-pgi': {
-                    'type': 'ProgEnvironment',
                     'modules': ['PrgEnv-pgi'],
                 },
 
                 'builtin': {
-                    'type': 'ProgEnvironment',
                     'cc':  'cc',
                     'cxx': '',
                     'ftn': '',
                 },
 
                 'builtin-gcc': {
-                    'type': 'ProgEnvironment',
                     'cc':  'gcc',
                     'cxx': 'g++',
                     'ftn': 'gfortran',

--- a/config/cscs-pbs.py
+++ b/config/cscs-pbs.py
@@ -65,34 +65,28 @@ class ReframeSettings:
         'environments': {
             '*': {
                 'PrgEnv-cray': {
-                    'type': 'ProgEnvironment',
                     'modules': ['PrgEnv-cray'],
                 },
 
                 'PrgEnv-gnu': {
-                    'type': 'ProgEnvironment',
                     'modules': ['PrgEnv-gnu'],
                 },
 
                 'PrgEnv-intel': {
-                    'type': 'ProgEnvironment',
                     'modules': ['PrgEnv-intel'],
                 },
 
                 'PrgEnv-pgi': {
-                    'type': 'ProgEnvironment',
                     'modules': ['PrgEnv-pgi'],
                 },
 
                 'builtin': {
-                    'type': 'ProgEnvironment',
                     'cc':  'cc',
                     'cxx': '',
                     'ftn': '',
                 },
 
                 'builtin-gcc': {
-                    'type': 'ProgEnvironment',
                     'cc':  'gcc',
                     'cxx': 'g++',
                     'ftn': 'gfortran',

--- a/config/cscs.py
+++ b/config/cscs.py
@@ -299,52 +299,6 @@ class ReframeSettings:
                 }
             },
 
-            'leone': {
-                'descr': 'Leone',
-                'hostnames': ['leone'],
-                'modules_system': 'tmod',
-                'resourcesdir': '/apps/common/UES/reframe/resources',
-                'partitions': {
-                    'login': {
-                        'scheduler': 'local',
-                        'environs': ['PrgEnv-gnu'],
-                        'descr': 'Leone login nodes',
-                        'max_jobs': 1
-                    },
-
-                    'normal': {
-                        'scheduler': 'nativeslurm',
-                        'environs': ['PrgEnv-gnu'],
-                        'descr': ('Leone compute nodes - '
-                                  'default partition'),
-                        'max_jobs': 10
-                    },
-                }
-            },
-
-            'monch': {
-                'descr': 'Monch PASC',
-                'hostnames': ['monch'],
-                'modules_system': 'tmod',
-                'resourcesdir': '/apps/common/UES/reframe/resources',
-                'partitions': {
-                    'login': {
-                        'scheduler': 'local',
-                        'environs': ['PrgEnv-gnu'],
-                        'descr': 'Monch login nodes',
-                        'max_jobs': 1
-                    },
-
-                    'compute': {
-                        'scheduler': 'slurm+mpirun',
-                        'access': ['--partition=compute'],
-                        'environs': ['PrgEnv-gnu'],
-                        'descr': 'Monch compute nodes',
-                        'max_jobs': 10
-                    }
-                }
-            },
-
             'generic': {
                 'descr': 'Generic example system',
                 'partitions': {
@@ -363,7 +317,6 @@ class ReframeSettings:
 
             'ault': {
                 'PrgEnv-gnu': {
-                    'type': 'ProgEnvironment',
                     # defaults were gcc/8.3.0, cuda/10.1, openmpi/4.0.0
                     'modules': ['gcc', 'cuda/10.1', 'openmpi'],
                     'cc':  'mpicc',
@@ -371,13 +324,11 @@ class ReframeSettings:
                     'ftn': 'mpif90',
                 },
                 'builtin': {
-                    'type': 'ProgEnvironment',
                     'cc':  'cc',
                     'cxx': '',
                     'ftn': '',
                 },
                 'builtin-gcc': {
-                    'type': 'ProgEnvironment',
                     'cc':  'gcc',
                     'cxx': 'g++',
                     'ftn': 'gfortran',
@@ -386,7 +337,6 @@ class ReframeSettings:
 
             'kesch': {
                 'PrgEnv-pgi-nompi': {
-                    'type': 'ProgEnvironment',
                     'modules': ['PE/17.06',
                                 'PrgEnv-pgi/18.5'],
                     'cc': 'pgcc',
@@ -394,7 +344,6 @@ class ReframeSettings:
                     'ftn': 'pgf90',
                 },
                 'PrgEnv-pgi': {
-                    'type': 'ProgEnvironment',
                     'modules': [
                         'PE/17.06', 'pgi/18.5-gcc-5.4.0-2.26',
                         'openmpi/4.0.1-pgi-18.5-gcc-5.4.0-2.26-cuda-8.0'
@@ -404,17 +353,14 @@ class ReframeSettings:
                     'ftn': 'mpifort',
                 },
                 'PrgEnv-cray': {
-                    'type': 'ProgEnvironment',
                     'modules': ['PE/17.06',
                                 'PrgEnv-CrayCCE/17.06'],
                 },
                 'PrgEnv-cray-nompi': {
-                    'type': 'ProgEnvironment',
                     'modules': ['PE/17.06',
                                 'PrgEnv-cray'],
                 },
                 'PrgEnv-gnu': {
-                    'type': 'ProgEnvironment',
                     'modules': ['PE/17.06',
                                 'gmvapich2/17.02_cuda_8.0_gdr'],
                     'variables': {
@@ -425,7 +371,6 @@ class ReframeSettings:
                     'ftn': 'mpif90',
                 },
                 'PrgEnv-gnu-nompi': {
-                    'type': 'ProgEnvironment',
                     'modules': ['PE/17.06',
                                 'PrgEnv-gnu'],
                     'cc': 'gcc',
@@ -433,17 +378,14 @@ class ReframeSettings:
                     'ftn': 'gfortran',
                 },
                 'PrgEnv-cray-c2sm': {
-                    'type': 'ProgEnvironment',
                     'modules': ['c2sm-rcm/1.00.00-kesch',
                                 'c2sm/cray-env/base'],
                 },
                 'PrgEnv-cray-c2sm-gpu': {
-                    'type': 'ProgEnvironment',
                     'modules': ['c2sm-rcm/1.00.00-kesch',
                                 'c2sm/cray-env/gpu'],
                 },
                 'PrgEnv-pgi-c2sm': {
-                    'type': 'ProgEnvironment',
                     'modules': ['c2sm-rcm/1.00.00-kesch',
                                 'c2sm/pgi-env/base'],
                     'cc': 'mpicc',
@@ -451,7 +393,6 @@ class ReframeSettings:
                     'ftn': 'mpif90',
                 },
                 'PrgEnv-pgi-c2sm-gpu': {
-                    'type': 'ProgEnvironment',
                     'modules': ['c2sm-rcm/1.00.00-kesch',
                                 'c2sm/pgi-env/gpu'],
                     'cc': 'mpicc',
@@ -459,7 +400,6 @@ class ReframeSettings:
                     'ftn': 'mpif90',
                 },
                 'PrgEnv-gnu-c2sm': {
-                    'type': 'ProgEnvironment',
                     'modules': ['c2sm-rcm/1.00.00-kesch',
                                 'c2sm/gnu-env/base'],
                     'cc': 'mpicc',
@@ -467,7 +407,6 @@ class ReframeSettings:
                     'ftn': 'mpif90',
                 },
                 'PrgEnv-gnu-c2sm-gpu': {
-                    'type': 'ProgEnvironment',
                     'modules': ['c2sm-rcm/1.00.00-kesch',
                                 'c2sm/gnu-env/gpu'],
                     'cc': 'mpicc',
@@ -476,61 +415,34 @@ class ReframeSettings:
                 },
             },
 
-            'leone': {
-                'PrgEnv-gnu': {
-                    'type': 'ProgEnvironment',
-                    'modules': ['PrgEnv-gnu/leone-foss-2016b'],
-                    'cc':  'mpicc',
-                    'cxx': 'mpicxx',
-                    'ftn': 'mpif90',
-                },
-            },
-
-            'monch': {
-                'PrgEnv-gnu': {
-                    'type': 'ProgEnvironment',
-                    'modules': ['PrgEnv-gnu'],
-                    'cc':  'mpicc',
-                    'cxx': 'mpicxx',
-                    'ftn': 'mpif90',
-                }
-            },
-
             '*': {
                 'PrgEnv-cray': {
-                    'type': 'ProgEnvironment',
                     'modules': ['PrgEnv-cray'],
                 },
 
                 'PrgEnv-cray_classic': {
-                    'type': 'ProgEnvironment',
                     'modules': ['PrgEnv-cray', 'cce/9.0.2-classic'],
                 },
 
                 'PrgEnv-gnu': {
-                    'type': 'ProgEnvironment',
                     'modules': ['PrgEnv-gnu'],
                 },
 
                 'PrgEnv-intel': {
-                    'type': 'ProgEnvironment',
                     'modules': ['PrgEnv-intel'],
                 },
 
                 'PrgEnv-pgi': {
-                    'type': 'ProgEnvironment',
                     'modules': ['PrgEnv-pgi'],
                 },
 
                 'builtin': {
-                    'type': 'ProgEnvironment',
                     'cc':  'cc',
                     'cxx': '',
                     'ftn': '',
                 },
 
                 'builtin-gcc': {
-                    'type': 'ProgEnvironment',
                     'cc':  'gcc',
                     'cxx': 'g++',
                     'ftn': 'gfortran',

--- a/docs/configure.rst
+++ b/docs/configure.rst
@@ -73,22 +73,18 @@ The following example shows a minimal configuration for the `Piz Daint <https://
        'environments': {
            '*': {
                'PrgEnv-cray': {
-                   'type': 'ProgEnvironment',
                    'modules': ['PrgEnv-cray'],
                },
 
                'PrgEnv-gnu': {
-                   'type': 'ProgEnvironment',
                    'modules': ['PrgEnv-gnu'],
                },
 
                'PrgEnv-intel': {
-                   'type': 'ProgEnvironment',
                    'modules': ['PrgEnv-intel'],
                },
 
                'PrgEnv-pgi': {
-                   'type': 'ProgEnvironment',
                    'modules': ['PrgEnv-pgi'],
                }
            }
@@ -343,7 +339,6 @@ In the following example, we redefine ``PrgEnv-gnu`` for a system named ``foo``,
 
   'foo': {
       'PrgEnv-gnu': {
-          'type': 'ProgEnvironment',
           'modules': ['PrgEnv-gnu', 'openmpi'],
           'cc':  'mpicc',
           'cxx': 'mpicxx',
@@ -354,26 +349,26 @@ In the following example, we redefine ``PrgEnv-gnu`` for a system named ``foo``,
 An environment is also defined as a set of key/value pairs with the key being its name and the value being a dictionary of its attributes.
 The possible attributes of an environment are the following:
 
-* ``type``: The type of the environment to create. There are two available environment types (note that names are case sensitive):
-
-  * ``'Environment'``: A simple environment.
-  * ``'ProgEnvironment'``: A programming environment.
-
 * ``modules``: A list of modules to be loaded when this environment is used (default ``[]``, valid for all environment types)
 * ``variables``: A set of variables to be set when this environment is used (default ``{}``, valid for all environment types)
-* ``cc``: The C compiler (default ``'cc'``, valid for ``'ProgEnvironment'`` only).
-* ``cxx``: The C++ compiler (default ``'CC'``, valid for ``'ProgEnvironment'`` only).
-* ``ftn``: The Fortran compiler (default ``'ftn'``, valid for ``'ProgEnvironment'`` only).
-* ``cppflags``: The default preprocessor flags (default :class:`None`, valid for ``'ProgEnvironment'`` only).
-* ``cflags``: The default C compiler flags (default :class:`None`, valid for ``'ProgEnvironment'`` only).
-* ``cxxflags``: The default C++ compiler flags (default :class:`None`, valid for ``'ProgEnvironment'`` only).
-* ``fflags``: The default Fortran compiler flags (default :class:`None`, valid for ``'ProgEnvironment'`` only).
-* ``ldflags``: The default linker flags (default :class:`None`, valid for ``'ProgEnvironment'`` only).
+* ``cc``: The C compiler (default: ``'cc'``)
+* ``cxx``: The C++ compiler (default: ``'CC'``)
+* ``ftn``: The Fortran compiler (default: ``'ftn'``)
+* ``cppflags``: The default preprocessor flags (default: :class:`None`)
+* ``cflags``: The default C compiler flags (default: :class:`None`)
+* ``cxxflags``: The default C++ compiler flags (default: :class:`None`)
+* ``fflags``: The default Fortran compiler flags (default: :class:`None`)
+* ``ldflags``: The default linker flags (default: :class:`None`)
 
 .. note::
    All flags for programming environments are now defined as list of strings instead of simple strings.
 
    .. versionchanged:: 2.17
+
+.. note::
+  The ``type`` key is no more required for the environment configuration.
+
+  .. versionchanged:: 2.22
 
 
 System Auto-Detection
@@ -406,7 +401,6 @@ If the system cannot be auto-detected, ReFrame will issue a warning and fall bac
        'environments': {
            '*': {
                'builtin-gcc': {
-                   'type': 'ProgEnvironment',
                    'cc':  'gcc',
                    'cxx': 'g++',
                    'ftn': 'gfortran',

--- a/reframe/core/config.py
+++ b/reframe/core/config.py
@@ -1,4 +1,5 @@
 import collections.abc
+import re
 
 import reframe.core.debug as debug
 import reframe.core.fields as fields
@@ -115,12 +116,7 @@ class SiteConfiguration:
             if not isinstance(config, collections.abc.Mapping):
                 raise TypeError("config for `%s' is not a dictionary" % name)
 
-            try:
-                envtype = m_env.__dict__[config['type']]
-                return envtype(name, **config)
-            except KeyError:
-                raise ConfigError("no type specified for environment `%s'" %
-                                  name) from None
+            return m_env.ProgEnvironment(name, **config)
 
         # Populate the systems directory
         for sys_name, config in sysconfig.items():

--- a/tutorial/config/settings.py
+++ b/tutorial/config/settings.py
@@ -61,21 +61,17 @@ class ReframeSettings:
         'environments': {
             '*': {
                 'PrgEnv-cray': {
-                    'type': 'ProgEnvironment',
                     'modules': ['PrgEnv-cray'],
                 },
                 'PrgEnv-gnu': {
-                    'type': 'ProgEnvironment',
                     'modules': ['PrgEnv-gnu'],
                 },
 
                 'PrgEnv-intel': {
-                    'type': 'ProgEnvironment',
                     'modules': ['PrgEnv-intel'],
                 },
 
                 'PrgEnv-pgi': {
-                    'type': 'ProgEnvironment',
                     'modules': ['PrgEnv-pgi'],
                 }
             }

--- a/unittests/resources/settings.py
+++ b/unittests/resources/settings.py
@@ -78,7 +78,6 @@ class ReframeSettings:
         'environments': {
             'testsys:login': {
                 'PrgEnv-gnu': {
-                    'type': 'ProgEnvironment',
                     'modules': ['PrgEnv-gnu'],
                     'cc': 'gcc',
                     'cxx': 'g++',
@@ -87,31 +86,25 @@ class ReframeSettings:
             },
             '*': {
                 'PrgEnv-gnu': {
-                    'type': 'ProgEnvironment',
                     'modules': ['PrgEnv-gnu'],
                 },
                 'PrgEnv-cray': {
-                    'type': 'ProgEnvironment',
                     'modules': ['PrgEnv-cray'],
                 },
                 'builtin': {
-                    'type': 'ProgEnvironment',
                     'cc':  'cc',
                     'cxx': '',
                     'ftn': '',
                 },
                 'builtin-gcc': {
-                    'type': 'ProgEnvironment',
                     'cc':  'gcc',
                     'cxx': 'g++',
                     'ftn': 'gfortran',
                 },
                 'e0': {
-                    'type': 'ProgEnvironment',
                     'modules': ['m0'],
                 },
                 'e1': {
-                    'type': 'ProgEnvironment',
                     'modules': ['m1'],
                 },
             }

--- a/unittests/test_config.py
+++ b/unittests/test_config.py
@@ -66,6 +66,12 @@ class TestSiteConfigurationFromDict(unittest.TestCase):
         assert (resources_spec == ['#DW jobdw capacity=100GB',
                                    '#DW stage_in source=/foo'])
 
+    def test_load_envconfig_with_unknown_args(self):
+        self.dict_config['environments']['*']['builtin-gcc'] = {
+            'foo': 'bar',
+        }
+        self.site_config.load_from_dict(self.dict_config)
+
     def test_load_failure_empty_dict(self):
         dict_config = {}
         with pytest.raises(ValueError):
@@ -112,28 +118,17 @@ class TestSiteConfigurationFromDict(unittest.TestCase):
         self.dict_config['environments'] = {
             '*': {
                 'PrgEnv-gnu': {
-                    'type': 'ProgEnvironment',
                     'modules': ['PrgEnv-gnu'],
                 }
             }
         }
-        with pytest.raises(ConfigError):
+        with pytest.raises(ConfigError,
+                           match='could not find a definition for'):
             self.site_config.load_from_dict(self.dict_config)
 
     def test_load_failure_envconfig_nodict(self):
         self.dict_config['environments']['*']['PrgEnv-gnu'] = 'foo'
         with pytest.raises(TypeError):
-            self.site_config.load_from_dict(self.dict_config)
-
-    def test_load_failure_envconfig_notype(self):
-        self.dict_config['environments'] = {
-            '*': {
-                'PrgEnv-gnu': {
-                    'modules': ['PrgEnv-gnu'],
-                }
-            }
-        }
-        with pytest.raises(ConfigError):
             self.site_config.load_from_dict(self.dict_config)
 
 


### PR DESCRIPTION
- The user specified environments are always of type `ProgEnvironment`.
- Remove the key from all the configuration files.
- Update unit tests
- Update documentation

I am not issuing now a deprecation warning if `type` is specified, because I am planning a redesign of the configuration infrastructure and more things will be deprecated there.

Fixes #1078.