### PR TITLE
[bugfix] Fix incomplete printout of the performance report in case of test failures

### DIFF
--- a/reframe/frontend/statistics.py
+++ b/reframe/frontend/statistics.py
@@ -115,22 +115,23 @@ class TestStats:
         report_start = line_width * '='
         report_title = 'PERFORMANCE REPORT'
         report_end = line_width * '_'
-        report = []
+        report_body = []
         previous_name = ''
         previous_part = ''
         for t in self.tasks():
             if t.check.perfvalues.keys():
                 if t.check.name != previous_name:
-                    report.append(line_width * '-')
-                    report.append('%s' % t.check.name)
+                    report_body.append(line_width * '-')
+                    report_body.append('%s' % t.check.name)
                     previous_name = t.check.name
 
                 if t.check.current_partition.fullname != previous_part:
-                    report.append('- %s' % t.check.current_partition.fullname)
+                    report_body.append(
+                        '- %s' % t.check.current_partition.fullname)
                     previous_part = t.check.current_partition.fullname
 
-                report.append('   - %s' % t.check.current_environ)
-                report.append('      * num_tasks: %s' % t.check.num_tasks)
+                report_body.append('   - %s' % t.check.current_environ)
+                report_body.append('      * num_tasks: %s' % t.check.num_tasks)
 
             for key, ref in t.check.perfvalues.items():
                 var = key.split(':')[-1]
@@ -140,9 +141,10 @@ class TestStats:
                 except IndexError:
                     unit = '(no unit specified)'
 
-                report.append('      * %s: %s %s' % (var, val, unit))
+                report_body.append('      * %s: %s %s' % (var, val, unit))
 
         if report:
-            return '\n'.join([report_start, report_title, *report, report_end])
+            return '\n'.join([report_start, report_title, *report_body,
+                              report_end])
 
         return ''

--- a/reframe/frontend/statistics.py
+++ b/reframe/frontend/statistics.py
@@ -143,7 +143,7 @@ class TestStats:
 
                 report_body.append('      * %s: %s %s' % (var, val, unit))
 
-        if report:
+        if report_body:
             return '\n'.join([report_start, report_title, *report_body,
                               report_end])
 

--- a/reframe/frontend/statistics.py
+++ b/reframe/frontend/statistics.py
@@ -112,8 +112,10 @@ class TestStats:
 
     def performance_report(self):
         line_width = 78
-        report = [line_width * '=']
-        report.append('PERFORMANCE REPORT')
+        report_start = line_width * '='
+        report_title = 'PERFORMANCE REPORT'
+        report_end = line_width * '_'
+        report = []
         previous_name = ''
         previous_part = ''
         for t in self.tasks():
@@ -128,8 +130,7 @@ class TestStats:
                     previous_part = t.check.current_partition.fullname
 
                 report.append('   - %s' % t.check.current_environ)
-
-            report.append('      * num_tasks: %s' % t.check.num_tasks)
+                report.append('      * num_tasks: %s' % t.check.num_tasks)
 
             for key, ref in t.check.perfvalues.items():
                 var = key.split(':')[-1]
@@ -141,5 +142,7 @@ class TestStats:
 
                 report.append('      * %s: %s %s' % (var, val, unit))
 
-        report.append(line_width * '-')
-        return '\n'.join(report)
+        if report:
+            return '\n'.join([report_start, report_title, *report, report_end])
+
+        return ''


### PR DESCRIPTION
* Do not print the performance report table if no performance report
values are present.

* Put printing of num_tasks in the correct if block.

Fixes #1081 