### PR TITLE
[feat] Do not allow chaining of the `-c` option; pass multiple paths as a colon separated list 

### DIFF
--- a/docs/running.rst
+++ b/docs/running.rst
@@ -306,7 +306,7 @@ ReFrame the does not search recursively into directories specified with the ``-c
 
 The ``-c`` option completely overrides the default path.
 Currently, there is no option to prepend or append to the default regression path.
-However, you can build your own check path by specifying multiple times the ``-c`` option.
+However, you can build your own check path by specifying multiple colon separate paths to the ``-c`` option.
 The ``-c``\ option accepts also regular files. This is very useful when you are implementing new regression tests, since it allows you to run only your test:
 
 .. code-block:: bash
@@ -320,6 +320,17 @@ The ``-c``\ option accepts also regular files. This is very useful when you are 
    In this case, any conflicting test will not be loaded and a warning will be issued.
 
    .. versionadded:: 2.12
+
+.. note::
+   Using the command line ``-c`` or ``--checkpath`` multiple times is now deprecated and only the last option is going to be taken into account.
+   Multiple paths should be passed as a colon separated string to the above option:
+
+   .. code-block:: bash
+
+      ./bin/reframe -c /path/to/my/first/test.py:/path/to/my/second/test.py -r
+
+
+   .. versionchanged:: 2.22
 
 
 Filtering of Regression Tests

--- a/docs/running.rst
+++ b/docs/running.rst
@@ -323,7 +323,7 @@ The ``-c``\ option accepts also regular files. This is very useful when you are 
 
 .. warning::
    Using the command line ``-c`` or ``--checkpath`` multiple times is not supported anymore and only the last option will be considered.
-   Multiple paths should be passed as a colon separated string to the above option:
+   Multiple paths should be passed instead as a colon separated list:
 
    .. code-block:: bash
 

--- a/docs/running.rst
+++ b/docs/running.rst
@@ -306,7 +306,7 @@ ReFrame the does not search recursively into directories specified with the ``-c
 
 The ``-c`` option completely overrides the default path.
 Currently, there is no option to prepend or append to the default regression path.
-However, you can build your own check path by specifying multiple colon separate paths to the ``-c`` option.
+However, you can build your own check path by specifying a colon separated list of paths to the ``-c`` option.
 The ``-c``\ option accepts also regular files. This is very useful when you are implementing new regression tests, since it allows you to run only your test:
 
 .. code-block:: bash
@@ -321,16 +321,16 @@ The ``-c``\ option accepts also regular files. This is very useful when you are 
 
    .. versionadded:: 2.12
 
-.. note::
-   Using the command line ``-c`` or ``--checkpath`` multiple times is now deprecated and only the last option is going to be taken into account.
+.. warning::
+   Using the command line ``-c`` or ``--checkpath`` multiple times is not supported anymore and only the last option will be considered.
    Multiple paths should be passed as a colon separated string to the above option:
 
    .. code-block:: bash
 
-      ./bin/reframe -c /path/to/my/first/test.py:/path/to/my/second/test.py -r
+      ./bin/reframe -c /path/to/my/first/test.py:/path/to/my/second/ -r
 
 
-   .. versionchanged:: 2.22
+   .. versionchanged:: 3.0
 
 
 Filtering of Regression Tests

--- a/reframe/frontend/cli.py
+++ b/reframe/frontend/cli.py
@@ -94,7 +94,7 @@ def main():
     # Check discovery options
     locate_options.add_argument(
         '-c', '--checkpath', action='append', metavar='DIR|FILE',
-        help='Search for checks in DIR or FILE')
+        help="Search for checks in DIR or FILE, using `:' for multiple paths")
     locate_options.add_argument(
         '-R', '--recursive', action='store_true',
         help='Load checks recursively')
@@ -410,7 +410,11 @@ def main():
     # Setup the check loader
     if options.checkpath:
         load_path = []
-        for d in options.checkpath:
+        if len(options.checkpath) > 1:
+            printer.warning("using command line option `--checkpath' "
+                            "multiple times is deprecated, please use "
+                            "`:' for multiple paths")
+        for d in options.checkpath[-1].split(':'):
             d = os_ext.expandvars(d)
             if not os.path.exists(d):
                 printer.warning("%s: path `%s' does not exist. Skipping..." %

--- a/reframe/frontend/cli.py
+++ b/reframe/frontend/cli.py
@@ -93,8 +93,9 @@ def main():
 
     # Check discovery options
     locate_options.add_argument(
-        '-c', '--checkpath', action='append', metavar='DIR|FILE',
-        help="Search for checks in DIR or FILE, using `:' for multiple paths")
+        '-c', '--checkpath', action='store', metavar='DIR|FILE',
+        help="Search for checks in DIR or FILE; multiple paths can be "
+             "separated with `:'")
     locate_options.add_argument(
         '-R', '--recursive', action='store_true',
         help='Load checks recursively')
@@ -410,11 +411,7 @@ def main():
     # Setup the check loader
     if options.checkpath:
         load_path = []
-        if len(options.checkpath) > 1:
-            printer.warning("using command line option `--checkpath' "
-                            "multiple times is deprecated, please use "
-                            "`:' for multiple paths")
-        for d in options.checkpath[-1].split(':'):
+        for d in options.checkpath.split(':'):
             d = os_ext.expandvars(d)
             if not os.path.exists(d):
                 printer.warning("%s: path `%s' does not exist. Skipping..." %

--- a/unittests/test_cli.py
+++ b/unittests/test_cli.py
@@ -272,6 +272,15 @@ class TestFrontend(unittest.TestCase):
         returncode, *_ = self._run_reframe()
         self.assertEqual(0, returncode)
 
+    def test_checkpath_colon_separated(self):
+        self.action = 'list'
+        self.checkpath = ['unittests/resources/checks/hellocheck_make.py:'
+                          'unittests/resources/checks/hellocheck.py']
+        returncode, stdout, _ = self._run_reframe()
+        num_checks = re.search(
+            r'Found (\d+) check', stdout, re.MULTILINE).group(1)
+        self.assertEqual(num_checks, '2')
+
     def test_checkpath_recursion(self):
         self.action = 'list'
         self.checkpath = []


### PR DESCRIPTION
* Deprecate using the checkpath command line option multiple times
  and issue a warning.

* Create unittest for colon separated paths.

* Add the change to the documentation.

Fixes #1120.