### PR TITLE
[feat] Evaluate `extra_resources` just before job submission

### DIFF
--- a/reframe/core/pipeline.py
+++ b/reframe/core/pipeline.py
@@ -621,12 +621,6 @@ class RegressionTest(metaclass=RegressionTestMeta):
     #:
     #:    A new more powerful syntax was introduced
     #:    that allows also custom job script directive prefixes.
-    #:
-    #: .. note::
-    #:    .. versionchanged:: 2.22
-    #:
-    #:    The attr:`extra_resources` is now used during the generation of
-    #:    allowing its definition after the :func:`setup` phase.
     extra_resources = fields.TypedField('extra_resources',
                                         typ.Dict[str, typ.Dict[str, object]])
 
@@ -1189,7 +1183,6 @@ class RegressionTest(metaclass=RegressionTestMeta):
                 self._current_partition.get_resource(r, **v))
 
         self._job.options = resources_opts + self._job.options
-
         with os_ext.change_dir(self._stagedir):
             try:
                 self._job.prepare(commands, environs)

--- a/reframe/core/pipeline.py
+++ b/reframe/core/pipeline.py
@@ -622,6 +622,11 @@ class RegressionTest(metaclass=RegressionTestMeta):
     #:    A new more powerful syntax was introduced
     #:    that allows also custom job script directive prefixes.
     #:
+    #: .. note::
+    #:    .. versionchanged:: 2.22
+    #:
+    #:    The attr:`extra_resources` is now used during the generation of
+    #:    allowing its definition after the :func:`setup` phase.
     extra_resources = fields.TypedField('extra_resources',
                                         typ.Dict[str, typ.Dict[str, object]])
 
@@ -959,12 +964,6 @@ class RegressionTest(metaclass=RegressionTestMeta):
             msg.format('local' if self.is_local else
                        self._current_partition.scheduler.registered_name))
 
-        # num_gpus_per_node is a managed resource
-        if self.num_gpus_per_node > 0:
-            self.extra_resources.setdefault(
-                '_rfm_gpu', {'num_gpus_per_node': self.num_gpus_per_node}
-            )
-
         if self.local:
             scheduler_type = getscheduler('local')
             launcher_type = getlauncher('local')
@@ -979,16 +978,6 @@ class RegressionTest(metaclass=RegressionTestMeta):
                                sched_access=self._current_partition.access,
                                sched_exclusive_access=self.exclusive_access,
                                **job_opts)
-
-        # Get job options from managed resources and prepend them to
-        # job_opts. We want any user supplied options to be able to
-        # override those set by the framework.
-        resources_opts = []
-        for r, v in self.extra_resources.items():
-            resources_opts.extend(
-                self._current_partition.get_resource(r, **v))
-
-        self._job.options = resources_opts + self._job.options
 
     def _setup_perf_logging(self):
         self.logger.debug('setting up performance logging')
@@ -1184,6 +1173,22 @@ class RegressionTest(metaclass=RegressionTestMeta):
                 user_environ,
                 self._cdt_environ
             ]
+
+        # num_gpus_per_node is a managed resource
+        if self.num_gpus_per_node > 0:
+            self.extra_resources.setdefault(
+                '_rfm_gpu', {'num_gpus_per_node': self.num_gpus_per_node}
+            )
+
+        # Get job options from managed resources and prepend them to
+        # job_opts. We want any user supplied options to be able to
+        # override those set by the framework.
+        resources_opts = []
+        for r, v in self.extra_resources.items():
+            resources_opts.extend(
+                self._current_partition.get_resource(r, **v))
+
+        self._job.options = resources_opts + self._job.options
 
         with os_ext.change_dir(self._stagedir):
             try:


### PR DESCRIPTION
* Move the handling of the `extra_resources` during the
  `run` phase.

* Change the corresponding unit test to reflect the change.

Fixes #1089 