### PR TITLE
[test] Make SimpleMpiCheck with CUDA more robust

### DIFF
--- a/cscs-checks/cuda/cuda_checks.py
+++ b/cscs-checks/cuda/cuda_checks.py
@@ -1,12 +1,10 @@
 import os
-
 import reframe as rfm
 import reframe.utility.sanity as sn
 
 
 class CudaCheck(rfm.RegressionTest):
     def __init__(self):
-        super().__init__()
         self.valid_systems = ['daint:gpu', 'dom:gpu', 'kesch:cn', 'tiger:gpu']
         self.valid_prog_environs = ['PrgEnv-cray', 'PrgEnv-gnu']
         if self.current_system.name == 'kesch':
@@ -81,7 +79,7 @@ class CudaSimpleMPICheck(CudaCheck):
         self.descr = 'Simple example demonstrating how to use MPI with CUDA'
         self.sourcesdir = os.path.join(self.current_system.resourcesdir,
                                        'CUDA', 'simplempi')
-        self.executable = 'simplempi'
+        self.executable = './simplempi'
         self.num_tasks = 2
         self.num_tasks_per_node = 2
         self.sanity_patterns = sn.assert_found(r'Result = PASS', self.stdout)


### PR DESCRIPTION
- Prefix the executable with `./`. This will allow the test to run on systems with the `aprun` job launcher.
- Remove unnecessary call to base `__init__()`.

Fixes UES-657.