### PR TITLE
[feat] Support RFC3339 compliant time zone formatting when logging time fields

### DIFF
--- a/docs/running.rst
+++ b/docs/running.rst
@@ -849,7 +849,7 @@ All handlers accept the following set of attributes (keys) in their configuratio
 
 * ``level``: (default: ``DEBUG``) The lowest level of log records that this handler can process.
 * ``format`` (default: ``'%(message)s'``): Format string for the printout of the log record.
-  ReFrame supports all the `format strings <https://docs.python.org/3.6/library/logging.html#logrecord-attributes>`__ from Python's logging library and provides the following additional ones:
+  ReFrame supports all the `log record attributes <https://docs.python.org/3.6/library/logging.html#logrecord-attributes>`__ from Python's logging library and provides the following additional ones:
 
   - ``check_environ``: The programming environment a test is currently executing for.
   - ``check_info``: Print live information of the currently executing check.
@@ -877,14 +877,19 @@ All handlers accept the following set of attributes (keys) in their configuratio
   - ``osgroup``: The group name of the OS user running ReFrame.
   - ``version``: The ReFrame version.
 
-* ``datefmt`` (default: ``'%FT%T'``) The format that will be used for outputting timestamps (i.e., the ``%(asctime)s`` field).
-  Acceptable formats must conform to standard library's `time.strftime() <https://docs.python.org/3.6/library/time.html#time.strftime>`__ function.
+* ``datefmt`` (default: ``'%FT%T'``) The format that will be used for outputting timestamps (i.e., the ``%(asctime)s`` and the ``%(check_job_completion_time)s`` fields).
+  In addition to the format directives supported by the standard library's `time.strftime() <https://docs.python.org/3.6/library/time.html#time.strftime>`__ function, ReFrame allows you to use the ``%:z`` directive -- a GNU ``date`` extension --  that will print the time zone difference in a RFC3339 compliant way, i.e., ``+/-HH:MM`` instead of ``+/-HHMM``.
 
 .. caution::
    The ``testcase_name`` logging attribute is replaced with the ``check_info``, which is now also configurable
 
    .. versionchanged:: 2.10
 
+
+.. note::
+   Support for fully RFC3339 compliant time zone formatting.
+
+   .. versionadded:: 3.0
 
 
 File log handlers

--- a/reframe/core/logging.py
+++ b/reframe/core/logging.py
@@ -152,14 +152,11 @@ class RFC3339Formatter(logging.Formatter):
 
     def format(self, record):
         datefmt = self.datefmt or self.default_time_format
-        try:
-            if record.check_job_completion_time is not None:
-                ct = self.converter(record.check_job_completion_time)
-                record.check_job_completion_time = _format_time_rfc3339(
-                    ct, datefmt
-                )
-        except AttributeError:
-            pass
+        if record.check_job_completion_time is not None:
+            ct = self.converter(record.check_job_completion_time)
+            record.check_job_completion_time = _format_time_rfc3339(
+                ct, datefmt
+            )
 
         return super().format(record)
 

--- a/reframe/core/schedulers/__init__.py
+++ b/reframe/core/schedulers/__init__.py
@@ -3,7 +3,7 @@
 #
 
 import abc
-from datetime import datetime
+import time
 
 import reframe.core.environments as env
 import reframe.core.fields as fields
@@ -17,6 +17,8 @@ from reframe.core.logging import getlogger
 class JobScheduler(abc.ABC):
     @abc.abstractmethod
     def completion_time(self, job):
+        '''The completion time of this job expressed in seconds from the Epoch.
+        '''
         pass
 
     @abc.abstractmethod
@@ -332,7 +334,7 @@ class Job:
             raise JobNotStartedError('cannot wait an unstarted job')
 
         self.scheduler.wait(self)
-        self._completion_time = self._completion_time or datetime.now()
+        self._completion_time = self._completion_time or time.time()
 
     def cancel(self):
         if self.jobid is None:
@@ -346,7 +348,7 @@ class Job:
 
         done = self.scheduler.finished(self)
         if done:
-            self._completion_time = self._completion_time or datetime.now()
+            self._completion_time = self._completion_time or time.time()
 
         return done
 

--- a/reframe/core/schedulers/slurm.py
+++ b/reframe/core/schedulers/slurm.py
@@ -103,7 +103,7 @@ class SlurmJobScheduler(sched.JobScheduler):
             not slurm_state_completed(job.state)):
             return self._completion_time
 
-        with env.temp_environment(variables={'SLURM_TIME_FORMAT': 'standard'}):
+        with env.temp_environment(variables={'SLURM_TIME_FORMAT': '%s'}):
             completed = os_ext.run_command(
                 'sacct -S %s -P -j %s -o jobid,end' %
                 (datetime.now().strftime('%F'), job.jobid),
@@ -116,11 +116,7 @@ class SlurmJobScheduler(sched.JobScheduler):
         if not state_match:
             return None
 
-        self._completion_time = max(
-            datetime.strptime(s.group('end'), '%Y-%m-%dT%H:%M:%S')
-            for s in state_match
-        )
-
+        self._completion_time = max(float(s.group('end')) for s in state_match)
         return self._completion_time
 
     def _format_option(self, var, option):


### PR DESCRIPTION
This PR adds a new time formatting directive for log record timestamps, namely the GNU `date` extension `%:z`. This directive will print the time zone difference in fully RFC3339 compliant way, i.e., `+/-HH:MM` instead or `+/-HHMM`, which `%z` prints.

This PR also replaces how `Job`'s completion time is stored and retrieved, also inside the Slurm backend. We use `time.time()` to retrieve the time in seconds from the Epoch instead of `datetime.now()`, because `datetime` does not store time zone information. Also all backends are now required to provide the completion time in seconds from the Epoch, so Slurm backend was modified accordingly.

Fixes #1061.

@brandongc FYI