### PR TITLE
[feat] Print the current working directory in "ReFrame paths" output section

### DIFF
--- a/reframe/frontend/cli.py
+++ b/reframe/frontend/cli.py
@@ -446,6 +446,7 @@ def main():
     printer.info('%03s Check search path : %s' %
                  ('(R)' if loader.recurse else '',
                   "'%s'" % ':'.join(loader.load_path)))
+    printer.info('    Current working dir  : %s' % os.getcwd())
     printer.info('    Stage dir prefix     : %s' % rt.resources.stage_prefix)
     printer.info('    Output dir prefix    : %s' % rt.resources.output_prefix)
     printer.info(


### PR DESCRIPTION
Instead of printing
```
...
Reframe paths
=============
    Check prefix      :
    Check search path : '/tmp/str.py'
    Current working dir  : /tmp
    Stage dir prefix     : /tmp/stage/
    Output dir prefix    : /tmp/output/
    Perf. logging prefix : /tmp/perflogs
...
```

Reframe now adds the current working dir to the output like
```
...
Reframe paths
=============
    Check prefix      :
    Check search path : '/tmp/str.py'
    Current working dir  : /tmp
    Stage dir prefix     : /tmp/stage/
    Output dir prefix    : /tmp/output/
    Perf. logging prefix : /tmp/perflogs
...
```