### PR TITLE
[misc] Use `check_job_completion_time` with timezone info for performance logging in all settings files

### DIFF
--- a/config/cscs-ci.py
+++ b/config/cscs-ci.py
@@ -172,7 +172,7 @@ class ReframeSettings:
                 'prefix': '%(check_system)s/%(check_partition)s',
                 'level': 'INFO',
                 'format': (
-                    '%(asctime)s|reframe %(version)s|'
+                    '%(check_job_completion_time)s|reframe %(version)s|'
                     '%(check_info)s|jobid=%(check_jobid)s|'
                     'num_tasks=%(check_num_tasks)s|'
                     '%(check_perf_var)s=%(check_perf_value)s|'
@@ -181,6 +181,7 @@ class ReframeSettings:
                     'u=%(check_perf_upper_thres)s)|'
                     '%(check_perf_unit)s'
                 ),
+                'datefmt': '%FT%T%:z',
                 'append': True
             }
         ]

--- a/config/cscs-pbs.py
+++ b/config/cscs-pbs.py
@@ -137,7 +137,7 @@ class ReframeSettings:
                 'prefix': '%(check_system)s/%(check_partition)s',
                 'level': 'INFO',
                 'format': (
-                    '%(asctime)s|reframe %(version)s|'
+                    '%(check_job_completion_time)s|reframe %(version)s|'
                     '%(check_info)s|jobid=%(check_jobid)s|'
                     'num_tasks=%(check_num_tasks)s|'
                     '%(check_perf_var)s=%(check_perf_value)s|'
@@ -145,6 +145,7 @@ class ReframeSettings:
                     '(l=%(check_perf_lower_thres)s, '
                     'u=%(check_perf_upper_thres)s)'
                 ),
+                'datefmt': '%FT%T%:z',
                 'append': True
             }
         ]

--- a/config/cscs.py
+++ b/config/cscs.py
@@ -623,7 +623,7 @@ class ReframeSettings:
                 'prefix': '%(check_system)s/%(check_partition)s',
                 'level': 'INFO',
                 'format': (
-                    '%(asctime)s|reframe %(version)s|'
+                    '%(check_job_completion_time)s|reframe %(version)s|'
                     '%(check_info)s|jobid=%(check_jobid)s|'
                     'num_tasks=%(check_num_tasks)s|'
                     '%(check_perf_var)s=%(check_perf_value)s|'
@@ -632,6 +632,7 @@ class ReframeSettings:
                     'u=%(check_perf_upper_thres)s)|'
                     '%(check_perf_unit)s'
                 ),
+                'datefmt': '%FT%T%:z',
                 'append': True
             }
         ]

--- a/config/tiger.py
+++ b/config/tiger.py
@@ -144,7 +144,7 @@ class ReframeSettings:
                 'prefix': '%(check_system)s/%(check_partition)s',
                 'level': 'INFO',
                 'format': (
-                    '%(asctime)s|reframe %(version)s|'
+                    '%(check_job_completion_time)s|reframe %(version)s|'
                     '%(check_info)s|jobid=%(check_jobid)s|'
                     '%(check_perf_var)s=%(check_perf_value)s|'
                     'ref=%(check_perf_ref)s '
@@ -152,6 +152,7 @@ class ReframeSettings:
                     'u=%(check_perf_upper_thres)s)|'
                     '%(check_perf_unit)s'
                 ),
+                'datefmt': '%FT%T%:z',
                 'append': True
             }
         ]

--- a/reframe/settings.py
+++ b/reframe/settings.py
@@ -86,7 +86,7 @@ class ReframeSettings:
                 'prefix': '%(check_system)s/%(check_partition)s',
                 'level': 'INFO',
                 'format': (
-                    '%(asctime)s|reframe %(version)s|'
+                    '%(check_job_completion_time)s|reframe %(version)s|'
                     '%(check_info)s|jobid=%(check_jobid)s|'
                     '%(check_perf_var)s=%(check_perf_value)s|'
                     'ref=%(check_perf_ref)s '
@@ -94,6 +94,7 @@ class ReframeSettings:
                     'u=%(check_perf_upper_thres)s)|'
                     '%(check_perf_unit)s'
                 ),
+                'datefmt': '%FT%T%:z',
                 'append': True
             }
         ]

--- a/schemas/settings.py
+++ b/schemas/settings.py
@@ -166,7 +166,7 @@ site_configuration = {
                     'prefix': '%(check_system)s/%(check_partition)s',
                     'level': 'info',
                     'format': (
-                        '%(asctime)s|reframe %(version)s|'
+                        '%(check_job_completion_time)s|reframe %(version)s|'
                         '%(check_info)s|jobid=%(check_jobid)s|'
                         '%(check_perf_var)s=%(check_perf_value)s|'
                         'ref=%(check_perf_ref)s '
@@ -174,6 +174,7 @@ site_configuration = {
                         'u=%(check_perf_upper_thres)s)|'
                         '%(check_perf_unit)s'
                     ),
+                    'datefmt': '%FT%T%:z',
                     'append': True
                 }
             ]

--- a/tutorial/config/settings.py
+++ b/tutorial/config/settings.py
@@ -120,13 +120,14 @@ class ReframeSettings:
                 'prefix': '%(check_system)s/%(check_partition)s',
                 'level': 'INFO',
                 'format': (
-                    '%(asctime)s|reframe %(version)s|'
+                    '%(check_job_completion_time)s|reframe %(version)s|'
                     '%(check_info)s|jobid=%(check_jobid)s|'
                     '%(check_perf_var)s=%(check_perf_value)s|'
                     'ref=%(check_perf_ref)s '
                     '(l=%(check_perf_lower_thres)s, '
                     'u=%(check_perf_upper_thres)s)'
                 ),
+                'datefmt': '%FT%T%:z',
                 'append': True
             }
         ]

--- a/unittests/resources/settings.py
+++ b/unittests/resources/settings.py
@@ -154,7 +154,7 @@ class ReframeSettings:
                 'prefix': '%(check_system)s/%(check_partition)s',
                 'level': 'INFO',
                 'format': (
-                    '%(asctime)s|reframe %(version)s|'
+                    '%(check_job_completion_time)s|reframe %(version)s|'
                     '%(check_info)s|jobid=%(check_jobid)s|'
                     '%(check_perf_var)s=%(check_perf_value)s|'
                     'ref=%(check_perf_ref)s '
@@ -162,6 +162,7 @@ class ReframeSettings:
                     'u=%(check_perf_upper_thres)s)|'
                     '%(check_perf_unit)s'
                 ),
+                'datefmt': '%FT%T%:z',
                 'append': True
             }
         ]


### PR DESCRIPTION
Use `check_job_completion_time` with timezone info for performance logging formatting instead of `asctime` attribute.

The changes are applied in the cscs configuration files, the example and the tutorial configuration.

Fixes UES-709.