### PR TITLE
[test] Implement workaround for PETSc test when using PrgEnv-intel and static linking

### DIFF
--- a/cscs-checks/libraries/petsc/petsc_helloworld.py
+++ b/cscs-checks/libraries/petsc/petsc_helloworld.py
@@ -15,17 +15,18 @@ class PetscPoisson2DCheck(rfm.RegressionTest):
                       '(%s linking)') % linkage
         self.valid_systems = ['daint:gpu', 'daint:mc',
                               'dom:gpu', 'dom:mc', 'tiger:gpu']
-        self.valid_prog_environs = ['PrgEnv-cray', 'PrgEnv-gnu']
-        if linkage == 'dynamic':
-            # FIXME: static compilation yields a link error in case of
-            # PrgEnv-intel (Cray Bug #255701)
-            self.valid_prog_environs += ['PrgEnv-intel']
-
+        self.valid_prog_environs = ['PrgEnv-cray', 'PrgEnv-gnu',
+                                    'PrgEnv-intel']
         self.sourcepath = 'poisson2d.c'
         self.modules = ['cray-petsc']
         self.num_tasks = 16
         self.num_tasks_per_node = 8
         self.build_system = 'SingleSource'
+        # FIXME: static compilation yields a link error in case of
+        # PrgEnv-intel (Cray Bug #255701) workaround use C++ compiler
+        if linkage == 'static':
+            self.build_system.cc = 'CC'
+
         self.variables = {'CRAYPE_LINK_TYPE': linkage}
         self.executable_opts = ['-da_grid_x 4', '-da_grid_y 4', '-ksp_monitor']
 


### PR DESCRIPTION
for static linking the C++ compiler is used until Cray fixes the problem

Cray Bug #255701