### PR TITLE
[bugfix] Fix crash when creating a regression test interactively

### DIFF
--- a/reframe/core/pipeline.py
+++ b/reframe/core/pipeline.py
@@ -670,7 +670,10 @@ class RegressionTest(metaclass=RegressionTestMeta):
         try:
             prefix = cls._rfm_custom_prefix
         except AttributeError:
-            prefix = os.path.abspath(os.path.dirname(inspect.getfile(cls)))
+            if os_ext.is_interactive():
+                prefix = os.getcwd()
+            else:
+                prefix = os.path.abspath(os.path.dirname(inspect.getfile(cls)))
 
         obj._rfm_init(name, prefix)
         return obj

--- a/reframe/utility/os_ext.py
+++ b/reframe/utility/os_ext.py
@@ -229,7 +229,7 @@ def inpath(entry, pathvar):
 
 def is_interactive():
     '''Returns whether the given Python session is interactive'''
-    return bool(getattr(sys, 'ps1', sys.flags.interactive))
+    return hasattr(sys, 'ps1') or sys.flags.interactive
 
 
 def subdirs(dirname, recurse=False):

--- a/reframe/utility/os_ext.py
+++ b/reframe/utility/os_ext.py
@@ -227,6 +227,11 @@ def inpath(entry, pathvar):
     return entry in set(pathvar.split(':'))
 
 
+def is_interactive():
+    '''Returns whether the given Python session is interactive'''
+    return bool(getattr(sys, 'ps1', sys.flags.interactive))
+
+
 def subdirs(dirname, recurse=False):
     '''Returns a list of dirname + its subdirectories. If recurse is True,
     recursion is performed in pre-order.'''

--- a/unittests/test_utility.py
+++ b/unittests/test_utility.py
@@ -173,10 +173,16 @@ class TestOSTools(unittest.TestCase):
                                os.path.join(prefix, 'broken1'))
         shutil.rmtree(prefix)
 
+    # FIXME: This should be changed in order to use the `monkeypatch`
+    # fixture of `pytest` instead of creating an instance of `MonkeyPatch`
     def test_is_interactive(self):
-        # Set `sys.ps1` to immitate an interactive session
-        sys.ps1 = 'rfm>>> '
-        assert os_ext.is_interactive()
+        from _pytest.monkeypatch import MonkeyPatch  # noqa: F401, F403
+
+        monkey = MonkeyPatch()
+        with monkey.context() as c:
+            # Set `sys.ps1` to immitate an interactive session
+            c.setattr(sys, 'ps1', 'rfm>>> ', raising=False)
+            assert os_ext.is_interactive()
 
     def test_is_url(self):
         repo_https = 'https://github.com/eth-cscs/reframe.git'

--- a/unittests/test_utility.py
+++ b/unittests/test_utility.py
@@ -173,6 +173,11 @@ class TestOSTools(unittest.TestCase):
                                os.path.join(prefix, 'broken1'))
         shutil.rmtree(prefix)
 
+    def test_is_interactive(self):
+        # Set `sys.ps1` to immitate an interactive session
+        sys.ps1 = 'rfm>>> '
+        assert os_ext.is_interactive()
+
     def test_is_url(self):
         repo_https = 'https://github.com/eth-cscs/reframe.git'
         repo_ssh = 'git@github.com:eth-cscs/reframe.git'


### PR DESCRIPTION
* Also create `is_interactive` function in `os_ext` to check whether
  the session is interactive.

* Add unittest for the above function.

Fixes #1194 