### PR TITLE
[bugfix] Improve unit tests for the handling of the TERM signal

### DIFF
--- a/unittests/test_policies.py
+++ b/unittests/test_policies.py
@@ -288,17 +288,14 @@ class TestSerialExecutionPolicy(unittest.TestCase):
             time.sleep(0.2)
             p.terminate()
             p.join()
-            exc = ns.exc
-            num_cases = ns.num_cases
-            num_failures = ns.num_failures
 
-        # Either the test is submitted and it fails due to the termination
-        # or it is not yet submitted when the termination signal is sent
-        assert (num_cases, num_failures) in {(1, 1), (0, 0)}
-        with pytest.raises(ReframeForceExitError,
-                           match='received TERM signal'):
-            if exc:
-                raise exc
+            # Either the test is submitted and it fails due to the termination
+            # or it is not yet submitted when the termination signal is sent
+            assert (ns.num_cases, ns.num_failures) in {(1, 1), (0, 0)}
+            with pytest.raises(ReframeForceExitError,
+                               match='received TERM signal'):
+                if ns.exc:
+                    raise ns.exc
 
     def test_dependencies_with_retries(self):
         self.runner._max_retries = 2

--- a/unittests/test_policies.py
+++ b/unittests/test_policies.py
@@ -262,32 +262,35 @@ class TestSerialExecutionPolicy(unittest.TestCase):
 
     def test_sigterm(self):
         # Wrapper of self.runall which is used from a child process and
-        # passes any exception to the parent process
-        def _runall(checks, conn):
+        # passes any exception, number of cases and failures to the parent
+        # process
+        def _runall(checks, ns):
             exc = None
             try:
                 self.runall(checks)
             except BaseException as e:
                 exc = e
+            finally:
+                ns.exc = exc
+                ns.num_cases = self.runner.stats.num_cases()
+                ns.num_failures = len(self.runner.stats.failures())
 
-            stats = self.runner.stats
-            conn.send((exc, stats.num_cases(), len(stats.failures())))
-            conn.close()
+        with multiprocessing.Manager() as manager:
+            ns = manager.Namespace()
+            p = multiprocessing.Process(target=_runall,
+                                        args=([SleepCheck(20)], ns))
 
-        rd_endpoint, wr_endpoint = multiprocessing.Pipe(duplex=False)
-        p = multiprocessing.Process(target=_runall,
-                                    args=([SleepCheck(3)], wr_endpoint))
-        p.start()
+            p.start()
 
-        # The unused write endpoint has to be closed from the parent to
-        # ensure that the `recv()` method of `rd_endpoint` returns
-        wr_endpoint.close()
-
-        # Allow some time so that the SleepCheck is submitted
-        time.sleep(1)
-        p.terminate()
-        p.join()
-        exc, num_cases, num_failures = rd_endpoint.recv()
+            # Allow some time so that the SleepCheck is submitted.
+            # The sleep time of the submitted test is much larger to
+            # ensure that it does not finish before the termination signal
+            time.sleep(0.2)
+            p.terminate()
+            p.join()
+            exc = ns.exc
+            num_cases = ns.num_cases
+            num_failures = ns.num_failures
 
         # Either the test is submitted and it fails due to the termination
         # or it is not yet submitted when the termination signal is sent


### PR DESCRIPTION
* Increase the time of the actual submitted SleepTest.

* Use `multiprocessing.Manager` and communicate with `Namespace`
  objects of the `Manager` instance between parent-child processes.

Fixes #1216 