### PR TITLE
[feat] Drop support for Python 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 dist: xenial
 language: python
 python:
-    - "3.5"
     - "3.6"
     - "3.7"
     - "3.8"

--- a/docs/started.rst
+++ b/docs/started.rst
@@ -13,7 +13,7 @@ Requirements
 
   .. note::
     .. versionchanged:: 3.0
-      Drop support for Python 3.5.
+      Support for Python 3.5 has been dropped.
 
 Optional
 ~~~~~~~~

--- a/docs/started.rst
+++ b/docs/started.rst
@@ -5,11 +5,15 @@ Getting Started
 Requirements
 ------------
 
-* Python 3.5 or higher. Python 2 is not supported.
+* Python 3.6 or higher. Python 2 is not supported.
 
   .. note::
     .. versionchanged:: 2.8
       A functional TCL modules system is no more required. ReFrame can now operate without a modules system at all.
+
+  .. note::
+    .. versionchanged:: 3.0
+      Drop support for Python 3.5.
 
 Optional
 ~~~~~~~~

--- a/reframe/__init__.py
+++ b/reframe/__init__.py
@@ -9,7 +9,7 @@ import sys
 
 VERSION = '3.0-dev2'
 INSTALL_PREFIX = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
-MIN_PYTHON_VERSION = (3, 5, 0)
+MIN_PYTHON_VERSION = (3, 6, 0)
 
 # Check python version
 if sys.version_info[:3] < MIN_PYTHON_VERSION:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 jsonschema
-pytest>=3.5.0
+pytest>=5.0.0
 coverage
 setuptools

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,6 @@ setuptools.setup(
     scripts=['bin/reframe'],
     classifiers=(
         'Development Status :: 5 - Production/Stable',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',


### PR DESCRIPTION
* Add note regarding dropping support of Python 3.5 in docs.

* Stricter requirements for a newer pytest version.

Fixes #1202 