### PR TITLE
[bugfix] Make unit test for TERM signal handling more robust

### DIFF
--- a/unittests/resources/checks_unlisted/selfkill.py
+++ b/unittests/resources/checks_unlisted/selfkill.py
@@ -8,6 +8,7 @@
 #
 import os
 import signal
+import time
 
 import reframe as rfm
 import reframe.utility.sanity as sn
@@ -24,6 +25,7 @@ class SelfKillCheck(rfm.RunOnlyRegressionTest):
         self.tags = {type(self).__name__}
         self.maintainers = ['TM']
 
-    @rfm.run_after('run')
-    def kill(self):
+    def run(self):
+        super().run()
+        time.sleep(0.5)
         os.kill(os.getpid(), signal.SIGTERM)

--- a/unittests/resources/checks_unlisted/selfkill.py
+++ b/unittests/resources/checks_unlisted/selfkill.py
@@ -1,0 +1,29 @@
+# Copyright 2016-2020 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# ReFrame Project Developers. See the top-level LICENSE file for details.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+#
+# Check for testing handling of the TERM signal
+#
+import os
+import signal
+
+import reframe as rfm
+import reframe.utility.sanity as sn
+
+
+@rfm.simple_test
+class SelfKillCheck(rfm.RunOnlyRegressionTest):
+    def __init__(self):
+        self.local = True
+        self.valid_systems = ['*']
+        self.valid_prog_environs = ['*']
+        self.executable = 'echo hello'
+        self.sanity_patterns = sn.assert_found('hello', self.stdout)
+        self.tags = {type(self).__name__}
+        self.maintainers = ['TM']
+
+    @rfm.run_after('run')
+    def kill(self):
+        os.kill(os.getpid(), signal.SIGTERM)

--- a/unittests/test_policies.py
+++ b/unittests/test_policies.py
@@ -6,7 +6,6 @@
 import collections
 import itertools
 import os
-import multiprocessing
 import pytest
 import time
 import tempfile
@@ -269,6 +268,7 @@ class TestSerialExecutionPolicy(unittest.TestCase):
                            match='received TERM signal'):
             self.runall(checks)
 
+        self.assert_all_dead()
         assert self.runner.stats.num_cases() == 1
         assert len(self.runner.stats.failures()) == 1
 

--- a/unittests/test_policies.py
+++ b/unittests/test_policies.py
@@ -261,41 +261,16 @@ class TestSerialExecutionPolicy(unittest.TestCase):
                 assert os.path.exists(os.path.join(check.outputdir, 'out.txt'))
 
     def test_sigterm(self):
-        # Wrapper of self.runall which is used from a child process and
-        # passes any exception, number of cases and failures to the parent
-        # process
-        def _runall(checks, ns):
-            exc = None
-            try:
-                self.runall(checks)
-            except BaseException as e:
-                exc = e
-            finally:
-                ns.exc = exc
-                ns.num_cases = self.runner.stats.num_cases()
-                ns.num_failures = len(self.runner.stats.failures())
+        self.loader = RegressionCheckLoader(
+            ['unittests/resources/checks_unlisted/selfkill.py']
+        )
+        checks = self.loader.load_all()
+        with pytest.raises(ReframeForceExitError,
+                           match='received TERM signal'):
+            self.runall(checks)
 
-        with multiprocessing.Manager() as manager:
-            ns = manager.Namespace()
-            p = multiprocessing.Process(target=_runall,
-                                        args=([SleepCheck(20)], ns))
-
-            p.start()
-
-            # Allow some time so that the SleepCheck is submitted.
-            # The sleep time of the submitted test is much larger to
-            # ensure that it does not finish before the termination signal
-            time.sleep(0.2)
-            p.terminate()
-            p.join()
-
-            # Either the test is submitted and it fails due to the termination
-            # or it is not yet submitted when the termination signal is sent
-            assert (ns.num_cases, ns.num_failures) in {(1, 1), (0, 0)}
-            with pytest.raises(ReframeForceExitError,
-                               match='received TERM signal'):
-                if ns.exc:
-                    raise ns.exc
+        assert self.runner.stats.num_cases() == 1
+        assert len(self.runner.stats.failures()) == 1
 
     def test_dependencies_with_retries(self):
         self.runner._max_retries = 2


### PR DESCRIPTION
* Explicitly call `os.kill` from a regression check.

Related to #1217 