### PR TITLE
[test] osu alltoall removed kesch:pn

### DIFF
--- a/cscs-checks/microbenchmarks/osu/osu_tests.py
+++ b/cscs-checks/microbenchmarks/osu/osu_tests.py
@@ -56,8 +56,8 @@ class AlltoallTest(rfm.RegressionTest):
 class FlexAlltoallTest(rfm.RegressionTest):
     def __init__(self):
         self.valid_systems = ['daint:gpu', 'daint:mc',
-                              'dom:gpu', 'dom:mc', 'tiger:gpu',
-                              'kesch:cn', 'kesch:pn',
+                              'dom:gpu', 'dom:mc',
+                              'kesch:cn', 'tiger:gpu',
                               'arolla:cn', 'arolla:pn',
                               'tsa:cn', 'tsa:pn']
         self.valid_prog_environs = ['PrgEnv-cray']


### PR DESCRIPTION
The default MPI library requires GPU components which are not available on the post processing nodes of kesch