### PR TITLE
[test] Remove kesch:pn from supported systems of FlexAlltoallTest

### DIFF
--- a/cscs-checks/microbenchmarks/osu/osu_tests.py
+++ b/cscs-checks/microbenchmarks/osu/osu_tests.py
@@ -56,7 +56,7 @@ class AlltoallTest(rfm.RegressionTest):
 class FlexAlltoallTest(rfm.RegressionTest):
     def __init__(self):
         self.valid_systems = ['daint:gpu', 'daint:mc',
-                              'dom:gpu', 'dom:mc', 
+                              'dom:gpu', 'dom:mc',
                               'tiger:gpu', 'kesch:cn',
                               'arolla:cn', 'arolla:pn',
                               'tsa:cn', 'tsa:pn']

--- a/cscs-checks/microbenchmarks/osu/osu_tests.py
+++ b/cscs-checks/microbenchmarks/osu/osu_tests.py
@@ -56,8 +56,8 @@ class AlltoallTest(rfm.RegressionTest):
 class FlexAlltoallTest(rfm.RegressionTest):
     def __init__(self):
         self.valid_systems = ['daint:gpu', 'daint:mc',
-                              'dom:gpu', 'dom:mc', 'tiger:gpu',
-                              'kesch:cn', 'kesch:pn',
+                              'dom:gpu', 'dom:mc', 
+                              'tiger:gpu', 'kesch:cn',
                               'arolla:cn', 'arolla:pn',
                               'tsa:cn', 'tsa:pn']
         self.valid_prog_environs = ['PrgEnv-cray']


### PR DESCRIPTION
Removing `kesch:pn` from `FlexAlltoallTest`, as suggested by @vkarak in https://jira.cscs.ch/browse/UES-740. 
Please note that if we want to keep it, I can just export the correct path for ` MV2_USE_GPUDIRECT_GDRCOPY` in the check, as I have reported in https://jira.cscs.ch/browse/UES-533.
As a matter of fact, `daint:mc`, `dom:mc`, `arolla:pn` and `tsa:pn` are also listed in the check.