### PR TITLE
[bugfix] Do not update progress count when a test fails with status ERROR

### DIFF
--- a/reframe/frontend/printer.py
+++ b/reframe/frontend/printer.py
@@ -56,7 +56,7 @@ class PrettyPrinter:
                 status = color.colorize(status, color.GREEN)
 
         final_msg = f'[ {status} ] '
-        if status_stripped in ['OK', 'SKIP', 'FAIL', 'ERROR']:
+        if status_stripped in ['OK', 'SKIP', 'FAIL']:
             self._progress_count += 1
             width = len(str(self._progress_total))
             padded_progress = str(self._progress_count).rjust(width)


### PR DESCRIPTION
This is a simple bug fix for the progress report. The testcases that print `ERROR` have already printed `OK` before so `_progress_count` should not be updated. The `(x/total)` message will also be omitted.