### PR TITLE
[test] Update CP2K GPU checks

### DIFF
--- a/cscs-checks/apps/cp2k/cp2k_check.py
+++ b/cscs-checks/apps/cp2k/cp2k_check.py
@@ -105,19 +105,19 @@ class Cp2kGpuCheck(Cp2kCheck):
             'maint': {
                 'small': {
                     'dom:gpu': {'time': (251.8, None, 0.15, 's')},
-                    'daint:gpu': {'time': (262.6, None, 0.10, 's')}
+                    'daint:gpu': {'time': (241.3, None, 0.05, 's')}
                 },
                 'large': {
-                    'daint:gpu': {'time': (222.6, None, 0.05, 's')}
+                    'daint:gpu': {'time': (199.6, None, 0.06, 's')}
                 }
             },
             'prod': {
                 'small': {
                     'dom:gpu': {'time': (240.0, None, 0.05, 's')},
-                    'daint:gpu': {'time': (262.6, None, 0.10, 's')}
+                    'daint:gpu': {'time': (241.3, None, 0.05, 's')}
                 },
                 'large': {
-                    'daint:gpu': {'time': (222.6, None, 0.05, 's')}
+                    'daint:gpu': {'time': (199.6, None, 0.06, 's')}
                 }
             }
         }


### PR DESCRIPTION
I have used the performance data stored in `/apps/daint/UES/jenscscs/regression/production/logs/daint/gpu` starting November 7th 2019, after the last upgrade of Piz Daint:
- `Cp2kGpuCheck_small_prod.log`, 139 data points, average `241.3 s`, 95% within 3.1% threshold (nonetheless I propose to use the 5% threshold, since I don't know if it is the case to go below 5%)
- `Cp2kGpuCheck_small_prod.log`, 138 data points, average `199.6 s`, 95% within 6% threshold