### PR TITLE
[test] Update CP2K CPU small check

### DIFF
--- a/cscs-checks/apps/cp2k/cp2k_check.py
+++ b/cscs-checks/apps/cp2k/cp2k_check.py
@@ -62,7 +62,7 @@ class Cp2kCpuCheck(Cp2kCheck):
             'maint': {
                 'small': {
                     'dom:mc': {'time': (202.2, None, 0.05, 's')},
-                    'daint:mc': {'time': (214.5, None, 0.15, 's')}
+                    'daint:mc': {'time': (180.9, None, 0.08, 's')}
                 },
                 'large': {
                     'daint:mc': {'time': (141.0, None, 0.05, 's')}
@@ -71,7 +71,7 @@ class Cp2kCpuCheck(Cp2kCheck):
             'prod': {
                 'small': {
                     'dom:mc': {'time': (202.2, None, 0.05, 's')},
-                    'daint:mc': {'time': (214.5, None, 0.15, 's')}
+                    'daint:mc': {'time': (180.9, None, 0.08, 's')}
                 },
                 'large': {
                     'daint:mc': {'time': (113.0, None, 0.05, 's')}


### PR DESCRIPTION
I have used the performance data stored in `/apps/daint/UES/jenscscs/regression/production/logs/daint/mc` starting November 7th 2019, after the last upgrade of Piz Daint:
- `Cp2kCpuCheck_small_prod.log`, 138 data points, average `180.9 s`, 95% within ~7.5% threshold (rounded to 8%)