### PR TITLE
[test] Update QE CPU checks

### DIFF
--- a/cscs-checks/apps/espresso/espresso_check.py
+++ b/cscs-checks/apps/espresso/espresso_check.py
@@ -33,7 +33,7 @@ class QECheck(rfm.RunOnlyRegressionTest):
                     'time': (159.0, None, 0.05, 's'),
                 },
                 'daint:mc': {
-                    'time': (151.6, None, 0.05, 's')
+                    'time': (147.3, None, 0.41, 's')
                 },
             }
         else:
@@ -41,7 +41,7 @@ class QECheck(rfm.RunOnlyRegressionTest):
             self.num_tasks_per_node = 36
             self.reference = {
                 'daint:mc': {
-                    'time': (157.0, None, 0.40, 's')
+                    'time': (149.7, None, 0.52, 's')
                 },
             }
 


### PR DESCRIPTION
I have used the performance data stored in `/apps/daint/UES/jenscscs/regression/production/logs/daint/mc` starting November 7th 2019, after the last upgrade of Piz Daint:
- `QECheck_large.log`, 145 data points, average `149.7 s`, 95% within 52% threshold
- `QECheck_small.log`, 164 data points, average `147.3 s`, 95% within 41% threshold

The thresholds required to reach the 95th percentile are huge, since the standard deviation of the samples is high. 
However, the thresholds would be even higher if I select only recent data points after the last maintenance (January 29th 2020).
