### PR TITLE
[bugfix] Fix `AttributeError` in flexible node allocation from the Slurm backend

### DIFF
--- a/reframe/core/schedulers/slurm.py
+++ b/reframe/core/schedulers/slurm.py
@@ -231,19 +231,19 @@ class SlurmJobScheduler(sched.JobScheduler):
         # Collect options that restrict node selection
         options = job.sched_access + job.options
         if job.sched_partition:
-            options.append('--partition=%s' % job.sched_partition)
+            options += ['--partition=%s' % job.sched_partition]
 
         if job.sched_account:
-            options.append('--account=%s' % job.sched_account)
+            options += ['--account=%s' % job.sched_account]
 
         if job.sched_nodelist:
-            options.append('--nodelist=%s' % job.sched_nodelist)
+            options += ['--nodelist=%s' % job.sched_nodelist]
 
         if job.sched_exclude_nodelist:
-            options.append('--exclude=%s' % job.sched_exclude_nodelist)
+            options += ['--exclude=%s' % job.sched_exclude_nodelist]
 
         if job.sched_reservation:
-            options.append('--reservation=%s' % job.sched_reservation)
+            options += ['--reservation=%s' % job.sched_reservation]
 
         option_parser = ArgumentParser()
         option_parser.add_argument('--reservation')

--- a/reframe/core/schedulers/slurm.py
+++ b/reframe/core/schedulers/slurm.py
@@ -228,22 +228,24 @@ class SlurmJobScheduler(sched.JobScheduler):
             os_ext.concat_files(job.stderr, *err_glob, overwrite=True)
 
     def filternodes(self, job, nodes):
-        # Collect options that restrict node selection
-        options = job.sched_access + job.options
+        # Collect options that restrict node selection, but we need to first
+        # create a mutable list out of the immutable SequenceView that
+        # sched_access is
+        options = list(job.sched_access + job.options)
         if job.sched_partition:
-            options += ['--partition=%s' % job.sched_partition]
+            options.append('--partition=%s' % job.sched_partition)
 
         if job.sched_account:
-            options += ['--account=%s' % job.sched_account]
+            options.append('--account=%s' % job.sched_account)
 
         if job.sched_nodelist:
-            options += ['--nodelist=%s' % job.sched_nodelist]
+            options.append('--nodelist=%s' % job.sched_nodelist)
 
         if job.sched_exclude_nodelist:
-            options += ['--exclude=%s' % job.sched_exclude_nodelist]
+            options.append('--exclude=%s' % job.sched_exclude_nodelist)
 
         if job.sched_reservation:
-            options += ['--reservation=%s' % job.sched_reservation]
+            options.append('--reservation=%s' % job.sched_reservation)
 
         option_parser = ArgumentParser()
         option_parser.add_argument('--reservation')

--- a/unittests/test_schedulers.py
+++ b/unittests/test_schedulers.py
@@ -23,6 +23,7 @@ from reframe.core.launchers.registry import getlauncher
 from reframe.core.schedulers import Job
 from reframe.core.schedulers.registry import getscheduler
 from reframe.core.schedulers.slurm import _SlurmNode, _create_nodes
+from reframe.utility import SequenceView
 
 
 class _TestJob(abc.ABC):
@@ -742,6 +743,16 @@ class TestSlurmFlexibleNodeAllocation(unittest.TestCase):
         self.testjob._sched_access = ['--constraint=f1']
         self.prepare_job()
         assert self.testjob.num_tasks == 8
+
+    def test_sched_access_idle_sequence_view(self):
+        self.testjob._sched_flex_alloc_nodes = 'idle'
+
+        # Here simulate passing a readonly 'sched_access' as returned
+        # by a 'SystemPartition' instance.
+        self.testjob._sched_access = SequenceView(['--constraint=f3'])
+        self.testjob._sched_partition = 'p3'
+        self.prepare_job()
+        assert self.testjob.num_tasks == 4
 
     def test_sched_access_constraint_partition(self):
         self.testjob._sched_flex_alloc_nodes = 'all'

--- a/unittests/test_schedulers.py
+++ b/unittests/test_schedulers.py
@@ -23,7 +23,6 @@ from reframe.core.launchers.registry import getlauncher
 from reframe.core.schedulers import Job
 from reframe.core.schedulers.registry import getscheduler
 from reframe.core.schedulers.slurm import _SlurmNode, _create_nodes
-from reframe.utility import SequenceView
 
 
 class _TestJob(abc.ABC):
@@ -745,6 +744,8 @@ class TestSlurmFlexibleNodeAllocation(unittest.TestCase):
         assert self.testjob.num_tasks == 8
 
     def test_sched_access_idle_sequence_view(self):
+        from reframe.utility import SequenceView
+
         self.testjob._sched_flex_alloc_nodes = 'idle'
 
         # Here simulate passing a readonly 'sched_access' as returned


### PR DESCRIPTION
* Fix `AttributeError` raised when trying to mutate a `SequenceView`
  object in the `filternodes` method of the slurm scheduler.

* Add a corresponding unittest.

Fixes #1258 