### PR TITLE
[bugfix] Fix string alignment in failure statistics

### DIFF
--- a/reframe/frontend/statistics.py
+++ b/reframe/frontend/statistics.py
@@ -137,8 +137,8 @@ class TestStats:
         stats_title = 'FAILURE STATISTICS'
         stats_end = line_width * '-'
         stats_body = []
-        row_format = "{:<11} {:<5} {}"
-        stats_hline = row_format.format(11*'-', 5*'-', 60*'-')
+        row_format = "{:<13} {:<5} {}"
+        stats_hline = row_format.format(13*'-', 5*'-', 60*'-')
         stats_header = row_format.format('Phase', '#', 'Failing test cases')
         num_tests = len(self.tasks(current_run))
         num_failures = 0

--- a/unittests/test_cli.py
+++ b/unittests/test_cli.py
@@ -234,7 +234,7 @@ class TestFrontend(unittest.TestCase):
         returncode, stdout, stderr = self._run_reframe()
 
         assert r'FAILURE STATISTICS' in stdout
-        assert r'sanity      1     [SanityFailureCheck' in stdout
+        assert r'sanity        1     [SanityFailureCheck' in stdout
         assert 'Traceback' not in stdout
         assert 'Traceback' not in stderr
         assert returncode != 0


### PR DESCRIPTION
I have increased the first column from 11 to 13. Because the `compile_wait` has length of 12.


Fixes #1260 