### PR TITLE
[bugfix] Fix deprecation warnings in unit tests

### DIFF
--- a/ci-scripts/ci-runner.bash
+++ b/ci-scripts/ci-runner.bash
@@ -163,8 +163,8 @@ if [ $CI_GENERIC -eq 1 ]; then
     echo "========================================"
     echo "Running unit tests with generic settings"
     echo "========================================"
-    checked_exec ./test_reframe.py
-    checked_exec ! ./bin/reframe.py --system=generic -l 2>&1 | \
+    checked_exec ./test_reframe.py -W=error::reframe.core.exceptions.ReframeDeprecationWarning
+    checked_exec ! ./bin/reframe.py -W=error::reframe.core.exceptions.ReframeDeprecationWarning --system=generic -l 2>&1 | \
         grep -- '--- Logging error ---'
 elif [ $CI_TUTORIAL -eq 1 ]; then
     # Run tutorial checks
@@ -190,7 +190,7 @@ else
     echo "Running unit tests"
     echo "=================="
 
-    checked_exec ./test_reframe.py --rfm-user-config=config/cscs-ci.py
+    checked_exec ./test_reframe.py -W=error::reframe.core.exceptions.ReframeDeprecationWarning --rfm-user-config=config/cscs-ci.py
 
     if [[ $(hostname) =~ dom ]]; then
         PATH_save=$PATH
@@ -199,7 +199,7 @@ else
             echo "Running unit tests with ${backend}"
             echo "=================================="
             export PATH=/apps/dom/UES/karakasv/slurm-wrappers/bin:$PATH
-            checked_exec ./test_reframe.py --rfm-user-config=config/cscs-${backend}.py
+            checked_exec ./test_reframe.py -W=error::reframe.core.exceptions.ReframeDeprecationWarning --rfm-user-config=config/cscs-${backend}.py
         done
         export PATH=$PATH_save
     fi

--- a/unittests/resources/checks/frontend_checks.py
+++ b/unittests/resources/checks/frontend_checks.py
@@ -85,7 +85,7 @@ class PerformanceFailureCheck(BaseFrontendCheck):
 
 
 @rfm.simple_test
-class CustomPerformanceFailureCheck(BaseFrontendCheck):
+class CustomPerformanceFailureCheck(BaseFrontendCheck, special=True):
     '''Simulate a performance check that ignores completely logging'''
 
     def __init__(self):

--- a/unittests/resources/checks_unlisted/selfkill.py
+++ b/unittests/resources/checks_unlisted/selfkill.py
@@ -25,7 +25,7 @@ class SelfKillCheck(rfm.RunOnlyRegressionTest):
         self.tags = {type(self).__name__}
         self.maintainers = ['TM']
 
-    def run(self):
-        super().run()
+    @rfm.run_before('run')
+    def self_kill(self):
         time.sleep(0.5)
         os.kill(os.getpid(), signal.SIGTERM)

--- a/unittests/resources/checks_unlisted/selfkill.py
+++ b/unittests/resources/checks_unlisted/selfkill.py
@@ -15,7 +15,7 @@ import reframe.utility.sanity as sn
 
 
 @rfm.simple_test
-class SelfKillCheck(rfm.RunOnlyRegressionTest):
+class SelfKillCheck(rfm.RunOnlyRegressionTest, special=True):
     def __init__(self):
         self.local = True
         self.valid_systems = ['*']
@@ -25,7 +25,7 @@ class SelfKillCheck(rfm.RunOnlyRegressionTest):
         self.tags = {type(self).__name__}
         self.maintainers = ['TM']
 
-    @rfm.run_before('run')
-    def self_kill(self):
+    def run(self):
+        super().run()
         time.sleep(0.5)
         os.kill(os.getpid(), signal.SIGTERM)


### PR DESCRIPTION
It fixes the deprecation warnings on the unittests and changes jenkins script so that it treats `ReframeDeprecationWarning` as error.

Fixes #1285 