### PR TITLE
[bugfix] Fix possible deadlock in PBS-based scheduler backends when a job is cancelled immediately after submission

### DIFF
--- a/reframe/core/schedulers/pbs.py
+++ b/reframe/core/schedulers/pbs.py
@@ -51,6 +51,7 @@ class PbsJobScheduler(sched.JobScheduler):
         self._job_submit_timeout = rt.runtime().get_option(
             f'schedulers/@{self.registered_name}/job_submit_timeout'
         )
+        self._cancelled = False
 
         # Optional part of the job id refering to the PBS server
         self._pbs_server = None
@@ -140,7 +141,7 @@ class PbsJobScheduler(sched.JobScheduler):
             time.sleep(next(intervals))
 
     def cancel(self, job):
-        self._is_cancelling = True
+        self._cancelled = True
 
         # Recreate the full job id
         jobid = str(job.jobid)
@@ -156,9 +157,10 @@ class PbsJobScheduler(sched.JobScheduler):
 
     def finished(self, job):
         with os_ext.change_dir(job.workdir):
-            done = os.path.exists(job.stdout) and os.path.exists(job.stderr)
+            output_ready = (os.path.exists(job.stdout) and
+                            os.path.exists(job.stderr))
 
-        done = done or getattr(self, '_is_cancelling', False)
+        done = self._cancelled or output_ready
 
         if done:
             t_now = datetime.now()

--- a/reframe/core/schedulers/pbs.py
+++ b/reframe/core/schedulers/pbs.py
@@ -140,6 +140,8 @@ class PbsJobScheduler(sched.JobScheduler):
             time.sleep(next(intervals))
 
     def cancel(self, job):
+        self._is_cancelling = True
+
         # Recreate the full job id
         jobid = str(job.jobid)
         if self._pbs_server:
@@ -155,6 +157,8 @@ class PbsJobScheduler(sched.JobScheduler):
     def finished(self, job):
         with os_ext.change_dir(job.workdir):
             done = os.path.exists(job.stdout) and os.path.exists(job.stderr)
+
+        done = done or getattr(self, '_is_cancelling', False)
 
         if done:
             t_now = datetime.now()

--- a/reframe/core/schedulers/torque.py
+++ b/reframe/core/schedulers/torque.py
@@ -95,4 +95,5 @@ class TorqueJobScheduler(PbsJobScheduler):
             stdout = os.path.join(job.workdir, job.stdout)
             stderr = os.path.join(job.workdir, job.stderr)
             done = os.path.exists(stdout) and os.path.exists(stderr)
+            done = done or getattr(self, '_is_cancelling', False)
             return job.state == 'COMPLETED' and done

--- a/reframe/core/schedulers/torque.py
+++ b/reframe/core/schedulers/torque.py
@@ -94,6 +94,6 @@ class TorqueJobScheduler(PbsJobScheduler):
 
             stdout = os.path.join(job.workdir, job.stdout)
             stderr = os.path.join(job.workdir, job.stderr)
-            done = os.path.exists(stdout) and os.path.exists(stderr)
-            done = done or getattr(self, '_is_cancelling', False)
+            output_ready = os.path.exists(stdout) and os.path.exists(stderr)
+            done = self._cancelled or output_ready
             return job.state == 'COMPLETED' and done

--- a/unittests/test_schedulers.py
+++ b/unittests/test_schedulers.py
@@ -312,21 +312,10 @@ def test_submit_job_array(make_job, slurm_only, exec_ctx):
 
 def test_cancel(make_job, exec_ctx):
     minimal_job = make_job(sched_access=exec_ctx.access)
-    sched_name = minimal_job.scheduler.registered_name
     prepare_job(minimal_job, 'sleep 30')
     t_job = datetime.now()
     minimal_job.submit()
     minimal_job.cancel()
-
-    # Here we trick the pbs based schedulers which expect stdout and sterr
-    # to exist in order to consider the job finished.
-    if sched_name in {'pbs', 'torque'}:
-        if not os.path.exists(minimal_job.stdout):
-            os.mknod(minimal_job.stdout)
-
-        if not os.path.exists(minimal_job.stderr):
-            os.mknod(minimal_job.stderr)
-
     minimal_job.wait()
     t_job = datetime.now() - t_job
     assert minimal_job.finished()

--- a/unittests/test_schedulers.py
+++ b/unittests/test_schedulers.py
@@ -318,9 +318,9 @@ def test_cancel(make_job, exec_ctx):
     minimal_job.submit()
     minimal_job.cancel()
 
-    # Here we trick the torque scheduler which expects stdout and sterr
-    # to consider the job finished.
-    if sched_name == 'torque':
+    # Here we trick the pbs based schedulers which expect stdout and sterr
+    # to exist in order to consider the job finished.
+    if sched_name in {'pbs', 'torque'}:
         if not os.path.exists(minimal_job.stdout):
             os.mknod(minimal_job.stdout)
 


### PR DESCRIPTION
* Create the stdout, stderr files if the don't exist
  to make the torque scheduler treat the job as finished.

Fixes #1298 