### PR TITLE
[bugfix] Use absolute path as stage and output directory prefixes

### DIFF
--- a/reframe/core/runtime.py
+++ b/reframe/core/runtime.py
@@ -119,17 +119,21 @@ class RuntimeContext:
     def output_prefix(self):
         '''The output prefix directory of ReFrame.'''
         if self.outputdir:
-            return os.path.join(self.outputdir, self.timestamp)
+            ret = os.path.join(self.outputdir, self.timestamp)
         else:
-            return os.path.join(self.prefix, 'output', self.timestamp)
+            ret = os.path.join(self.prefix, 'output', self.timestamp)
+
+        return os.path.abspath(ret)
 
     @property
     def stage_prefix(self):
         '''The stage prefix directory of ReFrame.'''
         if self.stagedir:
-            return os.path.join(self.stagedir, self.timestamp)
+            ret = os.path.join(self.stagedir, self.timestamp)
         else:
-            return os.path.join(self.prefix, 'stage', self.timestamp)
+            ret = os.path.join(self.prefix, 'stage', self.timestamp)
+
+        return os.path.abspath(ret)
 
     def make_stagedir(self, *dirs, wipeout=True):
         return self._makedir(self.stage_prefix,

--- a/reframe/frontend/cli.py
+++ b/reframe/frontend/cli.py
@@ -440,7 +440,6 @@ def main():
                    f"{':'.join(loader.load_path)!r}")
     print_infoline('stage directory', repr(rt.stage_prefix))
     print_infoline('output directory', repr(rt.output_prefix))
-    print_infoline('performance logs', repr(rt.perflogdir))
     printer.info('')
     try:
         # Locate and load checks


### PR DESCRIPTION
Also remove perflogdir from the output.

Fixes #1294.