### PR TITLE
[bugfix] Fix handling of `perflogdir` in the configuration conversion tool

### DIFF
--- a/reframe/core/config.py
+++ b/reframe/core/config.py
@@ -511,7 +511,7 @@ def convert_old_config(filename, newfilename=None):
                 'target_systems': target_systems
             }
         )
-        if basedir == None:
+        if basedir is None:
             del converted['logging'][-1]['target_systems']
 
     converted['general'] = [{}]

--- a/reframe/core/config.py
+++ b/reframe/core/config.py
@@ -387,10 +387,8 @@ def convert_old_config(filename, newfilename=None):
         sys_dict = {'name': sys_name}
 
         system_perflogdir = sys_spec.pop('perflogdir', None)
-        if system_perflogdir in perflogdir:
-            perflogdir[system_perflogdir].append(sys_name)
-        else:
-            perflogdir[system_perflogdir] = [sys_name]
+        perflogdir.setdefault(system_perflogdir, [])
+        perflogdir[system_perflogdir].append(sys_name)
 
         sys_dict.update(sys_spec)
 
@@ -513,6 +511,8 @@ def convert_old_config(filename, newfilename=None):
                 'target_systems': target_systems
             }
         )
+        if basedir == None:
+            del converted['logging'][-1]['target_systems']
 
     converted['general'] = [{}]
     if hasattr(old_config, 'checks_path'):

--- a/reframe/core/config.py
+++ b/reframe/core/config.py
@@ -381,16 +381,16 @@ def convert_old_config(filename, newfilename=None):
         'environments': [],
         'logging': [],
     }
-    perflogdir = None
+    perflogdir = {}
     old_systems = old_config.site_configuration['systems'].items()
     for sys_name, sys_spec in old_systems:
         sys_dict = {'name': sys_name}
 
-        # FIXME: We pick the perflogdir that we first find we use it as
-        # filelog's basedir for all systems. This is not correct since
-        # per-system customizations of perflogdir will be lost
-        if perflogdir is None:
-            perflogdir = sys_spec.pop('perflogdir', None)
+        system_perflogdir = sys_spec.pop('perflogdir', None)
+        if system_perflogdir in perflogdir:
+            perflogdir[system_perflogdir].append(sys_name)
+        else:
+            perflogdir[system_perflogdir] = [sys_name]
 
         sys_dict.update(sys_spec)
 
@@ -482,34 +482,38 @@ def convert_old_config(filename, newfilename=None):
 
                 converted['modes'].append(new_mode)
 
-    def handler_list(handler_config):
+    def handler_list(handler_config, basedir=None):
         ret = []
         for h in handler_config:
-            new_h = h
+            new_h = h.copy()
             new_h['level'] = h['level'].lower()
             if h['type'] == 'graylog':
                 # `host` and `port` attribute are converted to `address`
                 new_h['address'] = h['host']
                 if 'port' in h:
                     new_h['address'] += ':' + h['port']
-            elif h['type'] == 'filelog' and perflogdir is not None:
-                new_h['basedir'] = perflogdir
+            elif h['type'] == 'filelog' and basedir is not None:
+                new_h['basedir'] = basedir
 
             ret.append(new_h)
 
         return ret
 
-    converted['logging'].append(
-        {
-            'level': old_config.logging_config['level'].lower(),
-            'handlers': handler_list(
-                old_config.logging_config['handlers']
-            ),
-            'handlers_perflog': handler_list(
-                old_config.perf_logging_config['handlers']
-            )
-        }
-    )
+    for basedir, target_systems in perflogdir.items():
+        converted['logging'].append(
+            {
+                'level': old_config.logging_config['level'].lower(),
+                'handlers': handler_list(
+                    old_config.logging_config['handlers']
+                ),
+                'handlers_perflog': handler_list(
+                    old_config.perf_logging_config['handlers'],
+                    basedir=basedir
+                ),
+                'target_systems': target_systems
+            }
+        )
+
     converted['general'] = [{}]
     if hasattr(old_config, 'checks_path'):
         converted['general'][0][

--- a/unittests/test_config.py
+++ b/unittests/test_config.py
@@ -37,6 +37,7 @@ def test_convert_old_config():
     site_config = config.load_config(converted)
     site_config.validate()
     assert len(site_config.get('systems')) == 3
+    assert len(site_config.get('logging')) == 2
 
     site_config.select_subconfig('testsys')
     assert len(site_config.get('systems/0/partitions')) == 2


### PR DESCRIPTION
Now the conversion tool will create different handlers for every different `perflogdir` in the old configuration file.

Closes #1280.