### PR TITLE
[doc] Add 'jsonschema' to documentation requirements

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -7,6 +7,7 @@ docutils>=0.14
 idna>=2.6
 imagesize>=0.7.1
 Jinja2>=2.9.6
+jsonschema
 livereload>=2.5.1
 pathtools>=0.1.2
 port-for==0.3.1


### PR DESCRIPTION
This fixes the `jsonschema` import error when trying to build the documentation on readthedocs.