### PR TITLE
[bugfix] Fix early abort when compile step fails with async policy

### DIFF
--- a/unittests/resources/checks/frontend_checks.py
+++ b/unittests/resources/checks/frontend_checks.py
@@ -220,3 +220,13 @@ class SelfKillCheck(rfm.RunOnlyRegressionTest, special=True):
         super().run()
         time.sleep(0.5)
         os.kill(os.getpid(), signal.SIGTERM)
+
+
+class CompileFailureCheck(rfm.RegressionTest):
+    def __init__(self):
+        self.valid_systems = ['*']
+        self.valid_prog_environs = ['*']
+        self.sanity_patterns = sn.assert_found(r'hello', self.stdout)
+        self.sourcesdir = None
+        self.sourcepath = 'x.c'
+        self.prebuild_cmd = ['echo foo > x.c']


### PR DESCRIPTION
Fixes #1330 

Exceptions raised from build tasks within `compile_wait` with the async policy are not caught by `reschedule_task`, and so bubble up and stop the reframe process. Any queued jobs then get abandoned.

This PR catches exceptions that should cause the test, but not the whole reframe run, to fail