### PR TITLE
[bugfix] Fix configuration option value for non-existent name-addressable configuration objects

### DIFF
--- a/reframe/core/config.py
+++ b/reframe/core/config.py
@@ -139,7 +139,6 @@ class _SiteConfig:
                     # Element addressable by name
                     x, found = x[1:], False
                     for obj in value:
-                        value, found = obj, True
                         if obj['name'] == x:
                             value, found = obj, True
                             break

--- a/unittests/test_config.py
+++ b/unittests/test_config.py
@@ -258,6 +258,11 @@ def test_select_subconfig():
     assert site_config.get('environments/0/cxx') == 'CC'
     assert site_config.get('general/0/check_search_path') == ['c:d']
 
+    # Test default values for non-existent name-addressable objects
+    # See https://github.com/eth-cscs/reframe/issues/1339
+    assert site_config.get('modes/@foo/options') == []
+    assert site_config.get('modes/10/options') == []
+
     # Test inexistent options
     site_config.select_subconfig('testsys')
     assert site_config.get('systems/1/name') is None


### PR DESCRIPTION
Fixes #1339.