### PR TITLE
[test] Update QuantumESPRESSO GPU test

### DIFF
--- a/cscs-checks/apps/quantumespresso/quantumespresso_check.py
+++ b/cscs-checks/apps/quantumespresso/quantumespresso_check.py
@@ -117,20 +117,20 @@ class QuantumESPRESSOGpuCheck(QuantumESPRESSOCheck):
         references = {
             'maint': {
                 'small': {
-                    'dom:gpu': {'time': (60.0, None, 0.05, 's')},
-                    'daint:gpu': {'time': (60.0, None, 0.10, 's')}
+                    'dom:gpu': {'time': (61.0, None, 0.05, 's')},
+                    'daint:gpu': {'time': (61.0, None, 0.05, 's')}
                 },
                 'large': {
-                    'daint:gpu': {'time': (60.0, None, 0.10, 's')}
+                    'daint:gpu': {'time': (54.0, None, 0.05, 's')}
                 }
             },
             'prod': {
                 'small': {
-                    'dom:gpu': {'time': (60.0, None, 0.05, 's')},
-                    'daint:gpu': {'time': (60.0, None, 0.10, 's')}
+                    'dom:gpu': {'time': (61.0, None, 0.05, 's')},
+                    'daint:gpu': {'time': (61.0, None, 0.05, 's')}
                 },
                 'large': {
-                    'daint:gpu': {'time': (60.0, None, 0.10, 's')}
+                    'daint:gpu': {'time': (54.0, None, 0.05, 's')}
                 }
             }
         }


### PR DESCRIPTION
This pull request is addressing https://jira.cscs.ch/browse/UES-880: the performance values of the new QuantumESPRESSO GPU small and large checks can be retrieved from Kibana.
Starting April 30th, there are 20 records available for the two checks, with the following statistics:
Test   |      Average (s)      |  Standard Deviation (s)
----------|-------------:|------:
small | 60.697 | 1.058
large | 53.841 | 0.868

Setting the reference values as `61 s` and `54 s` with upper threshold `0.05` will ensure that 95% of the 20 records will fall within the threshold, since only one record lies outside in both data sets. 