### PR TITLE
[test] Exclude Slurm memory overconsumption test from Tsa

### DIFF
--- a/cscs-checks/system/slurm/slurm.py
+++ b/cscs-checks/system/slurm/slurm.py
@@ -32,14 +32,13 @@ class SlurmCompiledBaseCheck(rfm.RegressionTest):
     def __init__(self):
         self.valid_systems = ['daint:gpu', 'daint:mc',
                               'dom:gpu', 'dom:mc',
-                              'kesch:cn', 'kesch:pn',
-                              'arolla:cn', 'arolla:pn',
-                              'tsa:cn', 'tsa:pn']
+                              'kesch:cn', 'kesch:pn']
         self.valid_prog_environs = ['PrgEnv-cray']
         self.tags = {'slurm', 'maintenance', 'ops',
                      'production', 'single-node'}
         self.num_tasks_per_node = 1
-        if self.current_system.name in ['arolla', 'kesch', 'tsa']:
+        if self.current_system.name in ['kesch']:
+            self.valid_prog_environs = ['PrgEnv-gnu']
             self.exclusive_access = True
 
         self.maintainers = ['RS', 'VH']

--- a/cscs-checks/system/slurm/slurm.py
+++ b/cscs-checks/system/slurm/slurm.py
@@ -38,7 +38,6 @@ class SlurmCompiledBaseCheck(rfm.RegressionTest):
                      'production', 'single-node'}
         self.num_tasks_per_node = 1
         if self.current_system.name in ['kesch']:
-            self.valid_prog_environs = ['PrgEnv-gnu']
             self.exclusive_access = True
 
         self.maintainers = ['RS', 'VH']


### PR DESCRIPTION
Test failed due to bug in SLURM on Tsa/Arolla, see also:
https://jira.cscs.ch/browse/UES-755