### PR TITLE
[test] Remove PrgEnv-cray_classic from Dom and add it to Daint

### DIFF
--- a/config/cscs.py
+++ b/config/cscs.py
@@ -141,6 +141,7 @@ site_configuration = {
                     'environs': [
                         'builtin',
                         'PrgEnv-cray',
+                        'PrgEnv-cray_classic',
                         'PrgEnv-gnu',
                         'PrgEnv-intel',
                         'PrgEnv-pgi'
@@ -175,6 +176,7 @@ site_configuration = {
                     'environs': [
                         'builtin',
                         'PrgEnv-cray',
+                        'PrgEnv-cray_classic',
                         'PrgEnv-gnu',
                         'PrgEnv-intel',
                         'PrgEnv-pgi'
@@ -221,6 +223,7 @@ site_configuration = {
                     'environs': [
                         'builtin',
                         'PrgEnv-cray',
+                        'PrgEnv-cray_classic',
                         'PrgEnv-gnu',
                         'PrgEnv-intel',
                         'PrgEnv-pgi'
@@ -288,7 +291,6 @@ site_configuration = {
                     'environs': [
                         'builtin',
                         'PrgEnv-cray',
-                        'PrgEnv-cray_classic',
                         'PrgEnv-gnu',
                         'PrgEnv-intel',
                         'PrgEnv-pgi'
@@ -323,7 +325,6 @@ site_configuration = {
                     'environs': [
                         'builtin',
                         'PrgEnv-cray',
-                        'PrgEnv-cray_classic',
                         'PrgEnv-gnu',
                         'PrgEnv-intel',
                         'PrgEnv-pgi'
@@ -364,7 +365,6 @@ site_configuration = {
                     'environs': [
                         'builtin',
                         'PrgEnv-cray',
-                        'PrgEnv-cray_classic',
                         'PrgEnv-gnu',
                         'PrgEnv-intel',
                         'PrgEnv-pgi'


### PR DESCRIPTION
- The classic CCE compiler and the corresponding modules are removed for CCE 10, which is the default in CDT 20.06, so this PR removes the corresponding environment on Dom.
- Similarly we add this classic CCE environment on Daint, since it has been forgotten.

Fixes UES-927.