### PR TITLE
[bugfix] Add missing launchers `upcrun` and `upcxx-run` in configuration schema

### DIFF
--- a/reframe/schemas/config.json
+++ b/reframe/schemas/config.json
@@ -169,7 +169,8 @@
                                     "type": "string",
                                     "enum": [
                                         "alps",  "ibrun", "local", "mpirun",
-                                        "mpiexec", "srun", "srunalloc", "ssh"
+                                        "mpiexec", "srun", "srunalloc", "ssh",
+                                        "upcrun", "upcxx-run"
                                     ]
                                 },
                                 "access": {


### PR DESCRIPTION
ReFrame 3 upstreamed support for UPC and UPC++ launchers from Berkeley Lab. This PR fixes a missed change to the launcher schemes. Without this, tests which request the `upcrun` or `upcxx-run` launchers will fail because ReFrame cannot find them in this list.