### PR TITLE
[ci] Set the account dynamically in the configuration file for unit tests 

### DIFF
--- a/config/cscs-ci.py
+++ b/config/cscs-ci.py
@@ -7,6 +7,9 @@
 # CSCS CI settings
 #
 
+import reframe.utility.os_ext as os_ext
+
+
 site_configuration = {
     'systems': [
         {
@@ -27,7 +30,7 @@ site_configuration = {
                     'access': [
                         '--constraint=gpu',
                         '--partition=cscsci',
-                        '--account=jenscscs'
+                        f'--account={os_ext.osgroup()}'
                     ],
                     'environs': [
                         'builtin'
@@ -63,7 +66,7 @@ site_configuration = {
                     ],
                     'access': [
                         '--constraint=gpu',
-                        '--account=jenscscs'
+                        f'--account={os_ext.osgroup()}'
                     ],
                     'environs': [
                         'builtin'
@@ -88,7 +91,7 @@ site_configuration = {
                     ],
                     'access': [
                         'proc=gpu',
-                        '-A jenscscs'
+                        f'-A {os_ext.osgroup()}'
                     ],
                     'environs': [
                         'builtin'
@@ -105,7 +108,7 @@ site_configuration = {
                     ],
                     'access': [
                         '-l proc=gpu',
-                        '-A jenscscs'
+                        f'-A {os_ext.osgroup()}'
                     ],
                     'environs': [
                         'builtin'


### PR DESCRIPTION
Adding an option to `./test_reframe.py` for setting the account is not so straightforward as for the standard cli. It would require either to do hacks or to modify all the unit tests that use a temporary runtime. For this reason, I believe the solution proposed here is the best.

Fixes #1406.