### PR TITLE
[feat] Add utility function for retrieving Cray Linux Environment (CLE) information

### DIFF
--- a/reframe/utility/os_ext.py
+++ b/reframe/utility/os_ext.py
@@ -495,7 +495,12 @@ def cray_cle_info(filename='/etc/opt/cray/release/cle-release'):
         with open(filename) as fp:
             for line in fp:
                 key, value = line.split('=', maxsplit=1)
+                if key == 'PATCHSET':
+                    # Strip the date from the patchset
+                    value = value.split('-')[0]
+
                 info[key] = value.strip()
+
     except OSError:
         return None
 

--- a/reframe/utility/os_ext.py
+++ b/reframe/utility/os_ext.py
@@ -474,3 +474,36 @@ def cray_cdt_version():
         return match.group(1)
     except OSError:
         return None
+
+
+def cray_cle_info(filename='/etc/opt/cray/release/cle-release'):
+    '''Return cray CLE release information.
+
+    :arg filename: The file that contains the CLE release information
+
+    :returns: A named tuple with the following attributes that correspond to
+        the release information: :attr:`release`, :attr:`build`, :attr:`date`,
+        :attr:`arch`, :attr:`network`, :attr:`patchset`.
+    '''
+
+    cle_info = collections.namedtuple(
+        'cle_info',
+        ['release', 'build', 'date', 'arch', 'network', 'patchset']
+    )
+    try:
+        info = {}
+        with open(filename) as fp:
+            for line in fp:
+                key, value = line.split('=', maxsplit=1)
+                info[key] = value.strip()
+    except OSError:
+        return None
+
+    return cle_info(
+        info.get('RELEASE'),
+        info.get('BUILD'),
+        info.get('DATE'),
+        info.get('ARCH'),
+        info.get('NETWORK'),
+        info.get('PATCHSET'),
+    )

--- a/unittests/test_utility.py
+++ b/unittests/test_utility.py
@@ -1189,7 +1189,7 @@ def test_cray_cle_info(tmp_path):
     assert cle_info.build == '7.0.1227'
     assert cle_info.date == '20200326'
     assert cle_info.network == 'ari'
-    assert cle_info.patchset == '09-202003261814'
+    assert cle_info.patchset == '09'
 
 
 def test_cray_cle_info_no_such_file(tmp_path):
@@ -1209,4 +1209,4 @@ def test_cray_cle_info_missing_parts(tmp_path):
     assert cle_info.build is None
     assert cle_info.date is None
     assert cle_info.network is None
-    assert cle_info.patchset == '09-202003261814'
+    assert cle_info.patchset == '09'

--- a/unittests/test_utility.py
+++ b/unittests/test_utility.py
@@ -1171,3 +1171,42 @@ def test_cray_cdt_version_no_such_file(tmp_path, monkeypatch):
     rcfile = tmp_path / 'rcfile'
     monkeypatch.setenv('MODULERCFILE', str(rcfile))
     assert os_ext.cray_cdt_version() is None
+
+
+def test_cray_cle_info(tmp_path):
+    # Mock up a CLE release
+    cle_info_file = tmp_path / 'cle-release'
+    with open(cle_info_file, 'w') as fp:
+        fp.write('RELEASE=7.0.UP01\n'
+                 'BUILD=7.0.1227\n'
+                 'DATE=20200326\n'
+                 'ARCH=noarch\n'
+                 'NETWORK=ari\n'
+                 'PATCHSET=09-202003261814\n')
+
+    cle_info = os_ext.cray_cle_info(cle_info_file)
+    assert cle_info.release == '7.0.UP01'
+    assert cle_info.build == '7.0.1227'
+    assert cle_info.date == '20200326'
+    assert cle_info.network == 'ari'
+    assert cle_info.patchset == '09-202003261814'
+
+
+def test_cray_cle_info_no_such_file(tmp_path):
+    cle_info_file = tmp_path / 'cle-release'
+    assert os_ext.cray_cle_info(cle_info_file) is None
+
+
+def test_cray_cle_info_missing_parts(tmp_path):
+    # Mock up a CLE release
+    cle_info_file = tmp_path / 'cle-release'
+    with open(cle_info_file, 'w') as fp:
+        fp.write('RELEASE=7.0.UP01\n'
+                 'PATCHSET=09-202003261814\n')
+
+    cle_info = os_ext.cray_cle_info(cle_info_file)
+    assert cle_info.release == '7.0.UP01'
+    assert cle_info.build is None
+    assert cle_info.date is None
+    assert cle_info.network is None
+    assert cle_info.patchset == '09-202003261814'


### PR DESCRIPTION
I am not doing any special post processing of the values retrieved, since they are well formed strings that you can nicely compare:

```python
if cray_cle_info().release >= '7.0.UP00' and cray_cle_info().patchset < '09':
    # do sth
```