### PR TITLE
[bugfix] Convert Syslog handler port parameter into integer

### DIFF
--- a/reframe/core/logging.py
+++ b/reframe/core/logging.py
@@ -222,7 +222,12 @@ def _create_syslog_handler(site_config, config_prefix):
     except ValueError:
         pass
     else:
-        address = (host, int(port))
+        try:
+            address = (host, int(port))
+        except ValueError:
+            raise ConfigError(
+                f'syslog address port not an integer: {port!r}'
+            ) from None
 
     facility = site_config.get(f'{config_prefix}/facility')
     try:

--- a/reframe/core/logging.py
+++ b/reframe/core/logging.py
@@ -222,7 +222,7 @@ def _create_syslog_handler(site_config, config_prefix):
     except ValueError:
         pass
     else:
-        address = (host, port)
+        address = (host, int(port))
 
     facility = site_config.get(f'{config_prefix}/facility')
     try:

--- a/unittests/test_logging.py
+++ b/unittests/test_logging.py
@@ -361,7 +361,7 @@ def test_syslog_handler_tcp_port_noint(temp_runtime):
         'handlers_perflog': []
     })
     next(runtime)
-    with pytest.raises(ConfigError):
+    with pytest.raises(ConfigError, match="not an integer: 'bar'"):
         rlog.configure_logging(rt.runtime().site_config)
 
 

--- a/unittests/test_logging.py
+++ b/unittests/test_logging.py
@@ -337,7 +337,7 @@ def test_syslog_handler(temp_runtime):
     if platform.system() == 'Linux':
         addr = '/dev/log'
     elif platform.system() == 'Darwin':
-        addr = '/dev/run/syslog'
+        addr = '/var/run/syslog'
     else:
         pytest.skip('unknown system platform')
 
@@ -349,6 +349,20 @@ def test_syslog_handler(temp_runtime):
     next(runtime)
     rlog.configure_logging(rt.runtime().site_config)
     rlog.getlogger().info('foo')
+
+
+def test_syslog_handler_tcp_port_noint(temp_runtime):
+    runtime = temp_runtime({
+        'level': 'info',
+        'handlers': [{
+            'type': 'syslog',
+            'address': 'foo.server.org:bar',
+        }],
+        'handlers_perflog': []
+    })
+    next(runtime)
+    with pytest.raises(ConfigError):
+        rlog.configure_logging(rt.runtime().site_config)
 
 
 def test_global_noconfig():


### PR DESCRIPTION
In our cluster, we use syslog to collect reframe tests data. We have found SysLogHandler require int type port instead of str type in codes now. It works fine in our cluster after change.