### PR TITLE
[feat] Allow Syslog's address to be set from an environment variable

### DIFF
--- a/docs/manpage.rst
+++ b/docs/manpage.rst
@@ -637,7 +637,7 @@ Here is an alphabetical list of the environment variables recognized by ReFrame:
       ================================== ==================
 
 
-.. envvar:: RFM_GRAYLOG_SERVER
+.. envvar:: RFM_GRAYLOG_ADDRESS
 
    The address of the Graylog server to send performance logs.
    The address is specified in ``host:port`` format.
@@ -649,6 +649,15 @@ Here is an alphabetical list of the environment variables recognized by ReFrame:
       Associated command line option     N/A
       Associated configuration parameter :js:attr:`address` graylog log handler configuration parameter
       ================================== ==================
+
+
+.. versionadded:: 3.1
+
+
+.. envvar:: RFM_GRAYLOG_SERVER
+
+   .. deprecated:: 3.1
+      Please :envvar:`RFM_GRAYLOG_ADDRESS` instead.
 
 
 .. envvar:: RFM_IGNORE_CHECK_CONFLICTS
@@ -806,6 +815,23 @@ Here is an alphabetical list of the environment variables recognized by ReFrame:
       Associated configuration parameter :js:attr:`stagedir` system configuration parameter
       ================================== ==================
 
+
+.. envvar:: RFM_SYSLOG_ADDRESS
+
+   The address of the Syslog server to send performance logs.
+   The address is specified in ``host:port`` format.
+   If no port is specified, the address refers to a UNIX socket.
+
+   .. table::
+      :align: left
+
+      ================================== ==================
+      Associated command line option     N/A
+      Associated configuration parameter :js:attr:`address` syslog log handler configuration parameter
+      ================================== ==================
+
+
+.. versionadded:: 3.1
 
 .. envvar:: RFM_SYSTEM
 

--- a/reframe/frontend/cli.py
+++ b/reframe/frontend/cli.py
@@ -347,9 +347,15 @@ def main():
     # Options not associated with command-line arguments
     argparser.add_argument(
         dest='graylog_server',
-        envvar='RFM_GRAYLOG_SERVER',
+        envvar='RFM_GRAYLOG_ADDRESS',
         configvar='logging/handlers_perflog/graylog_address',
         help='Graylog server address'
+    )
+    argparser.add_argument(
+        dest='syslog_address',
+        envvar='RFM_SYSLOG_ADDRESS',
+        configvar='logging/handlers_perflog/syslog_address',
+        help='Syslog server address'
     )
     argparser.add_argument(
         dest='ignore_reqnodenotavail',
@@ -386,6 +392,12 @@ def main():
     printer = PrettyPrinter()
     printer.colorize = site_config.get('general/0/colorize')
     printer.inc_verbosity(site_config.get('general/0/verbose'))
+    if os.getenv('RFM_GRAYLOG_SERVER'):
+        printer.warning(
+            'RFM_GRAYLOG_SERVER environment variable is deprecated; '
+            'please use RFM_GRAYLOG_ADDRESS instead'
+        )
+        os.environ['RFM_GRAYLOG_ADDRESS'] = os.getenv('RFM_GRAYLOG_SERVER')
 
     if options.upgrade_config_file is not None:
         old_config, *new_config = options.upgrade_config_file.split(


### PR DESCRIPTION
- Also rename ``RFM_GRAYLOG_SERVER`` to ``RFM_GRAYLOG_ADDRESS`` for symmetry. ``RFM_GRAYLOG_SERVER`` is now deprecated.

Fixes #1056.