### PR TITLE
[feat] Support multiple tags in `extract*` sanity functions

### DIFF
--- a/reframe/utility/sanity.py
+++ b/reframe/utility/sanity.py
@@ -538,8 +538,8 @@ def _callable_name(fn):
 
 def _extractiter_singletag(patt, filename, tag, conv, encoding):
     if isinstance(conv, collections.Iterable):
-        raise SanityError('multiple conversion functions given for the single '
-                          f'capturing group {tag!r}')
+        raise SanityError(f'multiple conversion functions given for the '
+                          f'single capturing group {tag!r}')
 
     for m in finditer(patt, filename, encoding):
         try:

--- a/reframe/utility/sanity.py
+++ b/reframe/utility/sanity.py
@@ -1,4 +1,4 @@
-# Copyrigh 2016-2020 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# Copyright 2016-2020 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
 # ReFrame Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/reframe/utility/sanity.py
+++ b/reframe/utility/sanity.py
@@ -538,9 +538,8 @@ def _callable_name(fn):
 
 def _extractiter_singletag(patt, filename, tag, conv, encoding):
     if isinstance(conv, collections.Iterable):
-        raise SanityError(
-            f'multiple conversion functions given for single group: {tag}'
-        )
+        raise SanityError('multiple conversion functions given for the single '
+                          f'capturing group: {tag!r}')
 
     for m in finditer(patt, filename, encoding):
         try:
@@ -621,7 +620,7 @@ def extractall(patt, filename, tag=0, conv=None, encoding='utf-8'):
         returns the whole line that was matched.
     :arg conv: A callable or iterable of callables taking a single argument
         and returning a new value.
-        If not an iterable it will be used to convert the extracted values for
+        If not an iterable, it will be used to convert the extracted values for
         all the capturing groups specified in ``tag``.
         Otherwise, each conversion function will be used to convert the value
         extracted from the corresponding capturing group in ``tag``.

--- a/reframe/utility/sanity.py
+++ b/reframe/utility/sanity.py
@@ -539,7 +539,7 @@ def _callable_name(fn):
 def _extractiter_singletag(patt, filename, tag, conv, encoding):
     if isinstance(conv, collections.Iterable):
         raise SanityError('multiple conversion functions given for the single '
-                          f'capturing group: {tag!r}')
+                          f'capturing group {tag!r}')
 
     for m in finditer(patt, filename, encoding):
         try:

--- a/unittests/test_sanity_functions.py
+++ b/unittests/test_sanity_functions.py
@@ -597,6 +597,9 @@ class TestPatternMatchingFunctions(unittest.TestCase):
             fp.write('Step: 1\n')
             fp.write('Step: 2\n')
             fp.write('Step: 3\n')
+            fp.write('Number: 1 2\n')
+            fp.write('Number: 2 4\n')
+            fp.write('Number: 3 6\n')
 
     def tearDown(self):
         os.remove(self.tempfile)
@@ -649,6 +652,46 @@ class TestPatternMatchingFunctions(unittest.TestCase):
                                         self.tempfile, 'no', int))
         for expected, v in enumerate(res, start=1):
             assert expected == v
+
+    def test_extractall_multiple_tags(self):
+        # Check multiple numeric groups
+        res = sn.evaluate(sn.extractall(
+            r'Number: (\d+) (\d+)', self.tempfile, (1, 2)))
+        for expected, v in enumerate(res, start=1):
+            assert str(expected) == v[0]
+            assert str(2 * expected) == v[1]
+
+        # Check multiple named groups
+        res = sn.evaluate(sn.extractall(
+            r'Number: (?P<no1>\d+) (?P<no2>\d+)', self.tempfile,
+            ('no1', 'no2')))
+        for expected, v in enumerate(res, start=1):
+            assert str(expected) == v[0]
+            assert str(2 * expected) == v[1]
+
+        # Check single convert function
+        res = sn.evaluate(sn.extractall(r'Number: (?P<no1>\d+) (?P<no2>\d+)',
+                                        self.tempfile, ('no1', 'no2'), int))
+        for expected, v in enumerate(res, start=1):
+            assert expected == v[0]
+            assert 2 * expected == v[1]
+
+        # Check multiple convert functions
+        res = sn.evaluate(sn.extractall(r'Number: (?P<no1>\d+) (?P<no2>\d+)',
+                                        self.tempfile, ('no1', 'no2'),
+                                        (int, float)))
+        for expected, v in enumerate(res, start=1):
+            assert expected == v[0]
+            assert 2 * expected == v[1]
+            assert isinstance(v[1], float)
+
+        # Check fewer convert functions than tags
+        res = sn.evaluate(sn.extractall(r'Number: (?P<no1>\d+) (?P<no2>\d+)',
+                                        self.tempfile, ('no1', 'no2'),
+                                        [int]))
+        for expected, v in enumerate(res, start=1):
+            assert expected == v[0]
+            assert 2 * expected == v[1]
 
     def test_extractall_encoding(self):
         res = sn.evaluate(

--- a/unittests/test_sanity_functions.py
+++ b/unittests/test_sanity_functions.py
@@ -685,19 +685,13 @@ class TestPatternMatchingFunctions(unittest.TestCase):
             assert 2 * expected == v[1]
             assert isinstance(v[1], float)
 
-        # Check more convert functions than tags
+        # Check more conversion functions than tags
         res = sn.evaluate(sn.extractall(r'Number: (?P<no1>\d+) (?P<no2>\d+)',
                                         self.tempfile, ('no1', 'no2'),
                                         [int, float, float, float]))
         for expected, v in enumerate(res, start=1):
             assert expected == v[0]
             assert 2 * expected == v[1]
-
-        # Check multiple convert functions and single tag
-        res = sn.evaluate(sn.extractall(
-            r'Number: (?P<no>\d+) \d+', self.tempfile, 'no', [int, float]))
-        for expected, v in enumerate(res, start=1):
-            assert expected == v
 
         # Check fewer convert functions than tags
         res = sn.evaluate(sn.extractall(r'Number: (?P<no1>\d+) (?P<no2>\d+)',
@@ -706,6 +700,12 @@ class TestPatternMatchingFunctions(unittest.TestCase):
         for expected, v in enumerate(res, start=1):
             assert expected == v[0]
             assert 2 * expected == v[1]
+
+        # Check multiple conversion functions and a single tag
+        with pytest.raises(SanityError):
+            res = sn.evaluate(sn.extractall(
+                r'Number: (?P<no>\d+) \d+', self.tempfile, 'no', [int, float])
+            )
 
     def test_extractall_encoding(self):
         res = sn.evaluate(

--- a/unittests/test_sanity_functions.py
+++ b/unittests/test_sanity_functions.py
@@ -659,7 +659,7 @@ class TestPatternMatchingFunctions(unittest.TestCase):
             r'Number: (\d+) (\d+)', self.tempfile, (1, 2)))
         for expected, v in enumerate(res, start=1):
             assert str(expected) == v[0]
-            assert str(2 * expected) == v[1]
+            assert str(2*expected) == v[1]
 
         # Check multiple named groups
         res = sn.evaluate(sn.extractall(
@@ -667,7 +667,7 @@ class TestPatternMatchingFunctions(unittest.TestCase):
             ('no1', 'no2')))
         for expected, v in enumerate(res, start=1):
             assert str(expected) == v[0]
-            assert str(2 * expected) == v[1]
+            assert str(2*expected) == v[1]
 
         # Check single convert function
         res = sn.evaluate(sn.extractall(r'Number: (?P<no1>\d+) (?P<no2>\d+)',
@@ -684,6 +684,20 @@ class TestPatternMatchingFunctions(unittest.TestCase):
             assert expected == v[0]
             assert 2 * expected == v[1]
             assert isinstance(v[1], float)
+
+        # Check more convert functions than tags
+        res = sn.evaluate(sn.extractall(r'Number: (?P<no1>\d+) (?P<no2>\d+)',
+                                        self.tempfile, ('no1', 'no2'),
+                                        [int, float, float, float]))
+        for expected, v in enumerate(res, start=1):
+            assert expected == v[0]
+            assert 2 * expected == v[1]
+
+        # Check multiple convert functions and single tag
+        res = sn.evaluate(sn.extractall(
+            r'Number: (?P<no>\d+) \d+', self.tempfile, 'no', [int, float]))
+        for expected, v in enumerate(res, start=1):
+            assert expected == v
 
         # Check fewer convert functions than tags
         res = sn.evaluate(sn.extractall(r'Number: (?P<no1>\d+) (?P<no2>\d+)',


### PR DESCRIPTION
* Support also passing of multiple conversion functions for
  each tag to be extracted.

Fixes #1245 