### PR TITLE
[bugfix] Capture all pending test tasks in the exit loop of the asynchronous execution policy

### DIFF
--- a/reframe/frontend/executors/policies.py
+++ b/reframe/frontend/executors/policies.py
@@ -18,7 +18,7 @@ from reframe.frontend.executors import (ExecutionPolicy, RegressionTask,
                                         TaskEventListener, ABORT_REASONS)
 
 
-def values_len(d):
+def dictlist_len(d):
     return functools.reduce(lambda l, r: l + len(r), d.values(), 0)
 
 
@@ -422,7 +422,7 @@ class AsynchronousExecutionPolicy(ExecutionPolicy, TaskEventListener):
         num_polls = 0
         t_start = datetime.now()
         while (self._running_tasks or self._waiting_tasks or
-               self._completed_tasks or values_len(self._ready_tasks)):
+               self._completed_tasks or dictlist_len(self._ready_tasks)):
             getlogger().debug('running tasks: %s' % len(self._running_tasks))
             num_polls += len(self._running_tasks)
             try:

--- a/reframe/frontend/executors/policies.py
+++ b/reframe/frontend/executors/policies.py
@@ -416,7 +416,8 @@ class AsynchronousExecutionPolicy(ExecutionPolicy, TaskEventListener):
         pollrate = PollRateFunction(0.2, 60)
         num_polls = 0
         t_start = datetime.now()
-        while (self._running_tasks or self._waiting_tasks):
+        while (self._running_tasks or self._waiting_tasks or
+               self._completed_tasks or sum(self._ready_tasks.values(), []):
             getlogger().debug('running tasks: %s' % len(self._running_tasks))
             num_polls += len(self._running_tasks)
             try:

--- a/reframe/frontend/executors/policies.py
+++ b/reframe/frontend/executors/policies.py
@@ -417,7 +417,7 @@ class AsynchronousExecutionPolicy(ExecutionPolicy, TaskEventListener):
         num_polls = 0
         t_start = datetime.now()
         while (self._running_tasks or self._waiting_tasks or
-               self._completed_tasks or sum(self._ready_tasks.values(), []):
+               self._completed_tasks or sum(self._ready_tasks.values(), [])):
             getlogger().debug('running tasks: %s' % len(self._running_tasks))
             num_polls += len(self._running_tasks)
             try:

--- a/reframe/frontend/executors/policies.py
+++ b/reframe/frontend/executors/policies.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 import contextlib
+import functools
 import itertools
 import math
 import sys
@@ -15,6 +16,10 @@ from reframe.core.exceptions import (TaskDependencyError, TaskExit)
 from reframe.core.logging import getlogger
 from reframe.frontend.executors import (ExecutionPolicy, RegressionTask,
                                         TaskEventListener, ABORT_REASONS)
+
+
+def values_len(d):
+    return functools.reduce(lambda l, r: l + len(r), d.values(), 0)
 
 
 def _cleanup_all(tasks, *args, **kwargs):
@@ -417,7 +422,7 @@ class AsynchronousExecutionPolicy(ExecutionPolicy, TaskEventListener):
         num_polls = 0
         t_start = datetime.now()
         while (self._running_tasks or self._waiting_tasks or
-               self._completed_tasks or sum(self._ready_tasks.values(), [])):
+               self._completed_tasks or values_len(self._ready_tasks)):
             getlogger().debug('running tasks: %s' % len(self._running_tasks))
             num_polls += len(self._running_tasks)
             try:


### PR DESCRIPTION
Besides `_running_tasks` and `_waiting_tasks`, we can have a more strict check in the async policy main loop. In this way we make sure that the tasks will run in the correct reframe "retry".

I couldn't find how to reproduce the bug, but it should fix #1398 .