### PR TITLE
[bugfix] Fix parsing of multiline exec_host in qstat output

### DIFF
--- a/reframe/core/schedulers/torque.py
+++ b/reframe/core/schedulers/torque.py
@@ -61,10 +61,12 @@ class TorqueJobScheduler(PbsJobScheduler):
             raise JobError('qstat failed: %s' % completed.stderr, job.jobid)
 
         nodelist_match = re.search(
-            r'exec_host = (?P<nodespec>\S+)', completed.stdout
+             re.compile(r'exec_host = (?P<nodespec>[\S\t\n]+)', re.MULTILINE),
+             completed.stdout
         )
         if nodelist_match:
             nodespec = nodelist_match.group('nodespec')
+            nodespec = re.sub(r'[\n\t]*', '', nodespec)
             self._set_nodelist(job, nodespec)
 
         state_match = re.search(


### PR DESCRIPTION
Hi ! In Torque-managed jobs, the exec_host field in the qstat output may span multiple
lines as the number of compute nodes gets larger, like this:
```
exec_host = r26i13n04/0-35+r26i13n07/0-35+r26i13n19/0-35+r25i13n15/0-35+r2<linebreak>
<tab>5i13n18/0-35+r25i27n03/0-35+r25i27n04/0-35+r25i27n05/0-35+r25i27n07/0-<linebreak>
<tab>35+r25i27n08/0-35+r25i27n10/0-35+r25i27n11/0-35+r25i27n23/0-35
```
Before this commit, only the first line would be parsed, and hence the node list would be incomplete at best.
I have tried out this fix on a 10-node job and it works as expected.

I briefly looked into adding a unit test for this, but that does not seem straightforward in this case?