### PR TITLE
[bugfix] Use new the 2020 pip dependency resolver in the bootstrap script

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -53,10 +53,10 @@ CMD $python -m ensurepip --root external/ --default-pip
 export PATH=$(pwd)/external/usr/bin:$PATH
 export PYTHONPATH=$(pwd)/external:$(pwd)/external/usr/lib/python$pyver/site-packages:$PYTHONPATH
 
-CMD $python -m pip install -q --upgrade pip --target=external/
-CMD $python -m pip install -q -r requirements.txt --target=external/ --upgrade
+CMD $python -m pip install --no-cache-dir -q --upgrade pip --target=external/
+CMD $python -m pip install --use-feature=2020-resolver --no-cache-dir -q -r requirements.txt --target=external/ --upgrade
 
 if [ x"$1" == x"+docs" ]; then
-    CMD $python -m pip install -q -r docs/requirements.txt --target=external/ --upgrade
+    CMD $python -m pip install --use-feature=2020-resolver --no-cache-dir -q -r docs/requirements.txt --target=external/ --upgrade
     make -C docs
 fi

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ jsonschema
 pytest>=5.0.0
 coverage
 setuptools
+wcwidth


### PR DESCRIPTION
This solves the following error when installing ReFrame's dependencies with the bootstrap script:

```
ERROR: After October 2020 you may experience errors when installing or updating packages. This is because pip will change the way that it resolves dependency conflicts.

We recommend you use --use-feature=2020-resolver to test your packages with the new resolver before it becomes the default.
```

This PR also disallows pip cache in the bootstrap script.