### PR TITLE
[feat] Add a `--rerun-failed` option that will allow ReFrame to run only the failed test cases in a separate invocation

### DIFF
--- a/reframe/frontend/statistics.py
+++ b/reframe/frontend/statistics.py
@@ -82,6 +82,7 @@ class TestStats:
                     'build_stderr': None,
                     'build_stdout': None,
                     'description': check.descr,
+                    'prefix': check.prefix,
                     'environment': None,
                     'fail_reason': None,
                     'fail_phase': None,

--- a/reframe/schemas/runreport.json
+++ b/reframe/schemas/runreport.json
@@ -40,6 +40,7 @@
                                 "build_stderr": {"type": ["string", "null"]},
                                 "build_stdout": {"type": ["string", "null"]},
                                 "description": {"type": "string"},
+                                "prefix": {"type": "string"},
                                 "environment": {"type": ["string", "null"]},
                                 "fail_phase": {"type": ["string", "null"]},
                                 "fail_reason": {"type": ["string", "null"]},


### PR DESCRIPTION
Closes #1222 