### PR TITLE
[bug] Add importlib_metadata to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+importlib_metadata
 jsonschema
 pytest>=5.0.0
 coverage


### PR DESCRIPTION
While working on the improved spack recipe for ReFrame, I got the following error:
```bash
==> Installing py-pip
...
==> Installing reframe
...
$ ml reframe
$ reframe -l
Traceback (most recent call last):
  File "/users/hvictor/spack-victor/opt/spack/linux-centos8-broadwell/gcc-8.3.1/reframe-bootstrap-z2zqkak5qb5kepxr2p4pyryrbck4ma2c/external/jsonschema/__init__.py", line 31, in <module>
    from importlib import metadata
ImportError: cannot import name 'metadata'
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "/users/hvictor/spack-victor/opt/spack/linux-centos8-broadwell/gcc-8.3.1/reframe-bootstrap-z2zqkak5qb5kepxr2p4pyryrbck4ma2c/bin/reframe", line 18, in <module>
    import reframe.frontend.cli as cli  # noqa: F401, F403
  File "/users/hvictor/spack-victor/opt/spack/linux-centos8-broadwell/gcc-8.3.1/reframe-bootstrap-z2zqkak5qb5kepxr2p4pyryrbck4ma2c/reframe/__init__.py", line 26, in <module>
    from reframe.core.pipeline import *     # noqa: F401, F403
  File "/users/hvictor/spack-victor/opt/spack/linux-centos8-broadwell/gcc-8.3.1/reframe-bootstrap-z2zqkak5qb5kepxr2p4pyryrbck4ma2c/reframe/core/pipeline.py", line 26, in <module>
    import reframe.core.runtime as rt
  File "/users/hvictor/spack-victor/opt/spack/linux-centos8-broadwell/gcc-8.3.1/reframe-bootstrap-z2zqkak5qb5kepxr2p4pyryrbck4ma2c/reframe/core/runtime.py", line 14, in <module>
    import reframe.core.config as config
  File "/users/hvictor/spack-victor/opt/spack/linux-centos8-broadwell/gcc-8.3.1/reframe-bootstrap-z2zqkak5qb5kepxr2p4pyryrbck4ma2c/reframe/core/config.py", line 10, in <module>
    import jsonschema
  File "/users/hvictor/spack-victor/opt/spack/linux-centos8-broadwell/gcc-8.3.1/reframe-bootstrap-z2zqkak5qb5kepxr2p4pyryrbck4ma2c/external/jsonschema/__init__.py", line 33, in <module>
    import importlib_metadata as metadata
```