### PR TITLE
[bugfix] Print current environment and partition correctly even if a test fails before the setup

### DIFF
--- a/reframe/frontend/statistics.py
+++ b/reframe/frontend/statistics.py
@@ -106,9 +106,13 @@ class TestStats:
                     'time_total': t.duration('total')
                 }
                 partition = t.testcase.partition
+                environ = t.testcase.environ
+                # We take partition and environment from the test case and not
+                # from the check, since if the test fails before `setup()`,
+                # these are not set inside the check.
                 entry['system'] = partition.fullname
                 entry['scheduler'] = partition.scheduler.registered_name
-                entry['environment'] = t.testcase.environ.name
+                entry['environment'] = environ.name
                 if check.job:
                     entry['jobid'] = check.job.jobid
                     entry['job_stderr'] = check.stderr.evaluate()

--- a/reframe/frontend/statistics.py
+++ b/reframe/frontend/statistics.py
@@ -105,11 +105,12 @@ class TestStats:
                     'time_setup': t.duration('setup'),
                     'time_total': t.duration('total')
                 }
-                partition = t.testcase.partition
-                environ = t.testcase.environ
+
                 # We take partition and environment from the test case and not
                 # from the check, since if the test fails before `setup()`,
                 # these are not set inside the check.
+                partition = t.testcase.partition
+                environ = t.testcase.environ
                 entry['system'] = partition.fullname
                 entry['scheduler'] = partition.scheduler.registered_name
                 entry['environment'] = environ.name

--- a/reframe/frontend/statistics.py
+++ b/reframe/frontend/statistics.py
@@ -105,15 +105,10 @@ class TestStats:
                     'time_setup': t.duration('setup'),
                     'time_total': t.duration('total')
                 }
-                partition = check.current_partition
-                environ = check.current_environ
-                if partition:
-                    entry['system'] = partition.fullname
-                    entry['scheduler'] = partition.scheduler.registered_name
-
-                if environ:
-                    entry['environment'] = environ.name
-
+                partition = t.testcase.partition
+                entry['system'] = partition.fullname
+                entry['scheduler'] = partition.scheduler.registered_name
+                entry['environment'] = t.testcase.environ.name
                 if check.job:
                     entry['jobid'] = check.job.jobid
                     entry['job_stderr'] = check.stderr.evaluate()


### PR DESCRIPTION
Fixes https://github.com/eth-cscs/reframe/issues/1502