### PR TITLE
[test] Remove C++ language bindings from MPI checks

### DIFF
--- a/cscs-checks/prgenv/src/mpi/hello_world_mpi.cpp
+++ b/cscs-checks/prgenv/src/mpi/hello_world_mpi.cpp
@@ -8,10 +8,9 @@ int main(int argc, char *argv[]) {
   int resultlen = -1;
   char mpilibversion[MPI_MAX_LIBRARY_VERSION_STRING];
 
-  MPI::Init(argc, argv);
-
-  rank = MPI::COMM_WORLD.Get_rank();
-  size = MPI::COMM_WORLD.Get_size();
+  MPI_Init(&argc, &argv);
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+  MPI_Comm_size(MPI_COMM_WORLD, &size);
   printf("Hello World from thread %d out of %d from process %d out of %d\n",
        0, 1, rank, size);
 
@@ -19,7 +18,7 @@ int main(int argc, char *argv[]) {
   MPI_Get_library_version(mpilibversion, &resultlen);
   printf( "# MPI-%d.%d = %s\n", mpiversion, mpisubversion, mpilibversion);
 
-  MPI::Finalize();
+  MPI_Finalize();
 
   return 0;
 } /* end func main */

--- a/cscs-checks/prgenv/src/mpi_thread/mpi_init_thread.cpp
+++ b/cscs-checks/prgenv/src/mpi_thread/mpi_init_thread.cpp
@@ -70,13 +70,13 @@ int main(int argc, char **argv) {
   MPI_Get_library_version(mpilibversion, &resultlen);
   printf( "# MPI-%d.%d = %s", mpiversion, mpisubversion, mpilibversion);
 
-  rank = MPI::COMM_WORLD.Get_rank();
-  size = MPI::COMM_WORLD.Get_size();
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+  MPI_Comm_size(MPI_COMM_WORLD, &size);
   cout << "tid=0 out of 1 from rank " << rank << " out of " << size << "\n";
 
   //std::cout << " mpi_thread_queried=" << mpi_thread_required << std::endl;
 
-  MPI::Finalize();
+  MPI_Finalize();
 
   return 0;
 } /* end func main */


### PR DESCRIPTION
The C++ language bindings have been deprecated.