### PR TITLE
tmod4 Cray collections

### DIFF
--- a/reframe/core/modules.py
+++ b/reframe/core/modules.py
@@ -687,7 +687,6 @@ class TMod4Impl(TModImpl):
         else:
             cmd = 'load'
 
-        # print(f'#cscs load_module: {cmd} {module.name}')
         self._exec_module_command(
             cmd, str(module),
             msg="could not load module '%s' correctly" % module)
@@ -706,7 +705,6 @@ class TMod4Impl(TModImpl):
         else:
             cmd = 'load'
 
-        # print(f'#cscs emit_load_instr: {cmd} {module}')
         return f'module {cmd} {module}'
 
     def emit_unload_instr(self, module):

--- a/reframe/core/modules.py
+++ b/reframe/core/modules.py
@@ -678,8 +678,8 @@ class TMod4Impl(TModImpl):
         #             msg += completed.args
         #         else:
         #             msg += ' '.join(completed.args)
-
-    raise EnvironError(msg)
+        #
+        #     raise EnvironError(msg)
 
     def load_module(self, module):
         if module.name.startswith('PrgEnv-'):

--- a/reframe/core/modules.py
+++ b/reframe/core/modules.py
@@ -670,16 +670,16 @@ class TMod4Impl(TModImpl):
         completed = os_ext.run_command(command, check=True)
         namespace = {}
         exec(completed.stdout, {}, namespace)
-#         if not namespace['_mlstatus']:
-#             # _mlstatus is set by the TMod4 Python bindings
-#             if msg is None:
-#                 msg = 'modules system command failed: '
-#                 if isinstance(completed.args, str):
-#                     msg += completed.args
-#                 else:
-#                     msg += ' '.join(completed.args)
-# 
-#             raise EnvironError(msg)
+        # if not namespace['_mlstatus']:
+        #     # _mlstatus is set by the TMod4 Python bindings
+        #     if msg is None:
+        #         msg = 'modules system command failed: '
+        #         if isinstance(completed.args, str):
+        #             msg += completed.args
+        #         else:
+        #             msg += ' '.join(completed.args)
+
+    raise EnvironError(msg)
 
     def load_module(self, module):
         if module.name.startswith('PrgEnv-'):
@@ -716,17 +716,18 @@ class TMod4Impl(TModImpl):
         return f'module unload {module}'
 
     def conflicted_modules(self, module):
-         if module.name.startswith('PrgEnv-'):
-             show = 'saveshow'
-         else:
-             show = 'show'
- 
-         completed = self._run_module_command(
-             f'{show}', str(module), msg=f"745 could not show module {module} / {module.name}")
-         return [Module(m.group(1))
-                 for m in re.finditer(r'^conflict\s+(\S+)',
-                                      completed.stderr, re.MULTILINE)]
- 
+        if module.name.startswith('PrgEnv-'):
+            show = 'saveshow'
+        else:
+            show = 'show'
+
+        completed = self._run_module_command(
+            f'{show}', str(module), msg=f"could not show module {module}")
+        return [Module(m.group(1))
+                for m in re.finditer(r'^conflict\s+(\S+)',
+                                     completed.stderr, re.MULTILINE)]
+
+
 # }}}
 # {{{ lmod
 class LModImpl(TModImpl):


### PR DESCRIPTION
Fix for https://github.com/eth-cscs/reframe/issues/1526

Provided that the config is:

```json
        {                                                                       
            'name': 'PrgEnv-cray',                                              
            'modules': [                                                        
                'PrgEnv-cray_20.08',                                            
            ]                                                                   
        },                                                                      
        {                                                                       
            'name': 'PrgEnv-gnu',                                               
            'modules': [                                                        
                'PrgEnv-gnu_20.08',                                             
            ]                                                                   
        },                            
```

and `module savelist` has:

```python
Named collection list:
 1) PrgEnv-cray   2) PrgEnv-cray_20.08   3) PrgEnv-gnu   4) PrgEnv-gnu_20.08  
```

> module show CrayGNU/.20.08

```
/apps/eiger/UES/tools/easybuild/modules/all/CrayGNU/.20.08:
module-whatis   dummy
```

then the generated scripts look good:

```c
module restore PrgEnv-gnu_20.08
module load CrayGNU/.20.08
module load ddt/20.1.1-Suse-15.0
```