### PR TITLE
[test] Fix osext import in CUDA tests

### DIFF
--- a/cscs-checks/prgenv/cuda/cuda_aware_mpi.py
+++ b/cscs-checks/prgenv/cuda/cuda_aware_mpi.py
@@ -6,7 +6,7 @@
 import os
 import reframe as rfm
 import reframe.utility.sanity as sn
-import reframe.utility.os_ext as osx
+import reframe.utility.osext as osext
 
 
 @rfm.simple_test
@@ -54,7 +54,7 @@ class CudaAwareMPICheck(rfm.CompileOnlyRegressionTest):
     @rfm.run_before('compile')
     def cdt2008_pgi_workaround(self):
         if (self.current_environ.name == 'PrgEnv-pgi' and
-            osx.cray_cdt_version() == '20.08' and
+            osext.cray_cdt_version() == '20.08' and
             self.current_system.name in ['daint', 'dom']):
             self.variables['CUDA_HOME'] = '$CUDATOOLKIT_HOME'
 

--- a/cscs-checks/prgenv/cuda/cuda_samples.py
+++ b/cscs-checks/prgenv/cuda/cuda_samples.py
@@ -6,7 +6,7 @@
 import os
 import reframe as rfm
 import reframe.utility.sanity as sn
-import reframe.utility.os_ext as osx
+import reframe.utility.osext as osext
 
 
 class CudaSamples(rfm.RegressionTest):
@@ -46,7 +46,7 @@ class CudaSamples(rfm.RegressionTest):
     @rfm.run_before('compile')
     def cdt2008_pgi_workaround(self):
         if (self.current_environ.name == 'PrgEnv-pgi' and
-            osx.cray_cdt_version() == '20.08' and
+            osext.cray_cdt_version() == '20.08' and
             self.current_system.name in ['daint', 'dom']):
             self.variables['CUDA_HOME'] = '$CUDATOOLKIT_HOME'
 


### PR DESCRIPTION
I've also changed the alias `osx` to `osext` for compliance with the rest of the tests.

This has to be merged asap, because the tests are broken in the master.