### PR TITLE
[feat] Add support for logging all performance variables to a single line

### DIFF
--- a/docs/config_reference.rst
+++ b/docs/config_reference.rst
@@ -699,7 +699,13 @@ All logging handlers share the following set of common attributes:
    - ``%(check_perf_upper_thres)s``: The upper threshold of the performance difference from the reference value expressed as a fractional value.
      See the :attr:`reframe.core.pipeline.RegressionTest.reference` attribute of regression tests for more details.
    - ``%(check_perf_value)s``: The performance value obtained for a certain performance variable.
-   - ``%(check_perf_var)s``: The name of the `performance variable <tutorial_basic.html#writing-a-performance-test>`__ being logged.
+   - ``%(check_perf_var)s``: The name of the `performance variable <tutorial_basics.html#writing-a-performance-test>`__ being logged.
+   - ``%(check_perf_all_lower_thress)s``: Comma-separated list of lower thresholds of the performance differences from the reference values expressed as fractional values.
+   - ``%(check_perf_all_refs)s``: Comma-separated list of reference performance values of all performance variables.
+   - ``%(check_perf_all_units)s``: Comma-separated list of units of measurement for the measured performance variables.
+   - ``%(check_perf_all_upper_thress)s``: Comma-separated list of upper thresholds of the performance differences from the reference values expressed as a fractional values.
+   - ``%(check_perf_all_values)s``: Comma-separated list of performance values obtained for all performance variables.
+   - ``%(check_perf_all_vars)s``: Comma-separated list of names of the `performance variables <tutorial_basics.html#writing-a-performance-test>`__ being logged.
    - ``%(osuser)s``: The name of the OS user running ReFrame.
    - ``%(osgroup)s``: The name of the OS group running ReFrame.
    - ``%(version)s``: The ReFrame version.

--- a/docs/configure.rst
+++ b/docs/configure.rst
@@ -192,6 +192,29 @@ Finally, there is a special set of handlers for handling performance log message
 These are stored in the ``handlers_perflog`` property.
 The performance handler in this example will create a file per test and per system/partition combination and will append the performance data to it every time the test is run.
 Notice in the ``format`` property how the message to be logged is structured such that it can be easily parsed from post processing tools.
+In the previous example, each performance metric defined in :attr:`reframe.core.pipeline.RegressionTest.perf_patterns` is logged on a separate line. To change this behavior, log record attributes such as ``%(check_perf_value)s`` should be changed to ``%(check_perf_all_values)s``. The following example will log comma-separated lists of all performance metrics on a single line.
+
+.. code:: python
+
+    'handlers_perflog': [
+        {
+            'type': 'filelog',
+            'prefix': '%(check_system)s/%(check_partition)s',
+            'level': 'info',
+            'format': (
+                '%(check_job_completion_time)s|reframe %(version)s|'
+                '%(check_info)s|jobid=%(check_jobid)s|'
+                'perf_vars=%(check_perf_all_vars)s|'
+                'perf_values=%(check_perf_all_values)s|'
+                'perf_refs=%(check_perf_all_refs)s|'
+                'perf_lower_thress=%(check_perf_all_lower_thress)s|'
+                'perf_upper_thress=%(check_perf_all_upper_thress)s|'
+                'perf_units=%(check_perf_all_units)s)'
+            ),
+            'append': True
+        }
+    ]
+
 Apart from file logging, ReFrame offers more advanced performance logging capabilities through Syslog and Graylog.
 
 


### PR DESCRIPTION
This PR introduces log record attributes such as `%(check_perf_all_values)s` that will be filled in with a comma-separated list of values from all entries in `perf_patterns`. When the existing log record attributes such as `%(check_perf_value)s` are omitted, this changes the existing behavior that a separate line is logged for each entry in `per_patterns`.

Closes #1543 