### PR TITLE
[feat] Control verbosity of check failure info

### DIFF
--- a/reframe/core/decorators.py
+++ b/reframe/core/decorators.py
@@ -48,7 +48,7 @@ def _register_test(cls, args=None):
             try:
                 ret.append(_instantiate(cls, args))
             except Exception:
-                frame = user_frame(sys.exc_info()[2])
+                frame = user_frame(*sys.exc_info())
                 msg = "skipping test due to errors: %s: " % cls.__name__
                 msg += "use `-v' for more information\n"
                 msg += "  FILE: %s:%s" % (frame.filename, frame.lineno)

--- a/reframe/core/exceptions.py
+++ b/reframe/core/exceptions.py
@@ -340,5 +340,4 @@ def what(exc_type, exc_value, tb):
         if str(exc_value):
             reason += f': {exc_value}'
 
-    exc_str = ''.join(traceback.format_exception(exc_type, exc_value, tb))
-    return 'unexpected error: %s\n%s' % (exc_value, exc_str)
+    return reason

--- a/reframe/frontend/cli.py
+++ b/reframe/frontend/cli.py
@@ -15,6 +15,7 @@ import traceback
 import reframe
 import reframe.core.config as config
 import reframe.core.environments as env
+import reframe.core.exceptions as errors
 import reframe.core.logging as logging
 import reframe.core.runtime as runtime
 import reframe.frontend.argparse as argparse
@@ -22,10 +23,6 @@ import reframe.frontend.check_filters as filters
 import reframe.frontend.dependency as dependency
 import reframe.utility.jsonext as jsonext
 import reframe.utility.osext as osext
-from reframe.core.exceptions import (
-    EnvironError, ConfigError, ReframeError,
-    ReframeDeprecationWarning, ReframeFatalError, format_exception
-)
 from reframe.frontend.executors import Runner, generate_testcases
 from reframe.frontend.executors.policies import (SerialExecutionPolicy,
                                                  AsynchronousExecutionPolicy)
@@ -452,7 +449,7 @@ def main():
     try:
         try:
             site_config = config.load_config(options.config_file)
-        except ReframeDeprecationWarning as e:
+        except errors.ReframeDeprecationWarning as e:
             printer.warning(e)
             converted = config.convert_old_config(options.config_file)
             printer.warning(
@@ -482,7 +479,7 @@ def main():
             options.update_config(site_config)
 
         logging.configure_logging(site_config)
-    except (OSError, ConfigError) as e:
+    except (OSError, errors.ConfigError) as e:
         printer.error(f'failed to load configuration: {e}')
         sys.exit(1)
 
@@ -491,7 +488,7 @@ def main():
     printer.inc_verbosity(site_config.get('general/0/verbose'))
     try:
         runtime.init_runtime(site_config)
-    except ConfigError as e:
+    except errors.ConfigError as e:
         printer.error(f'failed to initialize runtime: {e}')
         sys.exit(1)
 
@@ -506,7 +503,7 @@ def main():
             for m in site_config.get('general/0/module_mappings'):
                 rt.modules_system.load_mapping(m)
 
-    except (ConfigError, OSError) as e:
+    except (errors.ConfigError, OSError) as e:
         printer.error('could not load module mappings: %s' % e)
         sys.exit(1)
 
@@ -579,7 +576,7 @@ def main():
         try:
             checks_found = loader.load_all()
         except OSError as e:
-            raise ReframeError from e
+            raise errors.ReframeError from e
 
         # Filter checks by name
         checks_matched = checks_found
@@ -650,7 +647,7 @@ def main():
         # Load the environment for the current system
         try:
             runtime.loadenv(rt.system.preload_environ)
-        except EnvironError as e:
+        except errors.EnvironError as e:
             printer.error("failed to load current system's environment; "
                           "please check your configuration")
             printer.debug(str(e))
@@ -659,7 +656,7 @@ def main():
         for m in site_config.get('general/0/user_modules'):
             try:
                 rt.modules_system.load_module(m, force=True)
-            except EnvironError as e:
+            except errors.EnvironError as e:
                 printer.warning("could not load module '%s' correctly: "
                                 "Skipping..." % m)
                 printer.debug(str(e))
@@ -694,7 +691,9 @@ def main():
                 errmsg = "invalid option for --flex-alloc-nodes: '{0}'"
                 sched_flex_alloc_nodes = int(options.flex_alloc_nodes)
                 if sched_flex_alloc_nodes <= 0:
-                    raise ConfigError(errmsg.format(options.flex_alloc_nodes))
+                    raise errors.ConfigError(
+                        errmsg.format(options.flex_alloc_nodes)
+                    )
             except ValueError:
                 sched_flex_alloc_nodes = options.flex_alloc_nodes
 
@@ -712,8 +711,9 @@ def main():
             try:
                 max_retries = int(options.max_retries)
             except ValueError:
-                raise ConfigError('--max-retries is not a valid integer: %s' %
-                                  max_retries) from None
+                raise errors.ConfigError(
+                    f'--max-retries is not a valid integer: {max_retries}'
+                ) from None
             runner = Runner(exec_policy, printer, max_retries)
             try:
                 time_start = time.time()
@@ -734,10 +734,10 @@ def main():
 
                 # Print a failure report if we had failures in the last run
                 if runner.stats.failures():
-                    printer.info(runner.stats.failure_report())
+                    runner.stats.print_failure_report(printer)
                     success = False
                     if options.failure_stats:
-                        printer.info(runner.stats.failure_stats())
+                        runner.stats.print_failure_stats(printer)
 
                 if options.performance_report:
                     printer.info(runner.stats.performance_report())
@@ -783,11 +783,18 @@ def main():
 
     except KeyboardInterrupt:
         sys.exit(1)
-    except ReframeError as e:
+    except errors.ReframeError as e:
         printer.error(str(e))
         sys.exit(1)
-    except (Exception, ReframeFatalError):
-        printer.error(format_exception(*sys.exc_info()))
+    except (Exception, errors.ReframeFatalError):
+        exc_info = sys.exc_info()
+        tb = ''.join(traceback.format_exception(*exc_info))
+        printer.error(errors.what(*exc_info))
+        if errors.is_severe(*exc_info):
+            printer.error(tb)
+        else:
+            printer.verbose(tb)
+
         sys.exit(1)
     finally:
         try:
@@ -796,7 +803,7 @@ def main():
                 log_files = logging.save_log_files(rt.output_prefix)
 
         except OSError as e:
-            printer.error('could not save log file: %s' % e)
+            printer.error(f'could not save log file: {e}')
             sys.exit(1)
         finally:
             if not log_files:

--- a/reframe/frontend/statistics.py
+++ b/reframe/frontend/statistics.py
@@ -3,8 +3,9 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
+import traceback
 import reframe.core.runtime as rt
-from reframe.core.exceptions import format_exception, StatisticsError
+import reframe.core.exceptions as errors
 
 
 class TestStats:
@@ -28,7 +29,7 @@ class TestStats:
         try:
             return self._alltasks[run]
         except IndexError:
-            raise StatisticsError('no such run: %s' % run) from None
+            raise errors.StatisticsError('no such run: %s' % run) from None
 
     def failures(self, run=-1):
         return [t for t in self.tasks(run) if t.failed]
@@ -130,7 +131,13 @@ class TestStats:
                     entry['stagedir'] = check.stagedir
                     entry['fail_phase'] = t.failed_stage
                     if t.exc_info is not None:
-                        entry['fail_reason'] = format_exception(*t.exc_info)
+                        entry['fail_reason'] = errors.what(*t.exc_info)
+                        entry['fail_info'] = {
+                            'exc_type':  t.exc_info[0],
+                            'exc_value': t.exc_info[1],
+                            'traceback': t.exc_info[2]
+                        }
+                        entry['fail_severe'] = errors.is_severe(*t.exc_info)
                 else:
                     entry['result'] = 'success'
                     entry['outputdir'] = check.outputdir
@@ -161,10 +168,10 @@ class TestStats:
 
         return self._run_data
 
-    def failure_report(self):
+    def print_failure_report(self, printer):
         line_width = 78
-        report = [line_width * '=']
-        report.append('SUMMARY OF FAILURES')
+        printer.info(line_width * '=')
+        printer.info('SUMMARY OF FAILURES')
         run_report = self.json()[-1]
         last_run = run_report['runid']
         for r in run_report['testcases']:
@@ -174,27 +181,32 @@ class TestStats:
             retry_info = (
                 f'(for the last of {last_run} retries)' if last_run > 0 else ''
             )
-            report.append(line_width * '-')
-            report.append(f"FAILURE INFO for {r['name']} {retry_info}")
-            report.append(f"  * Test Description: {r['description']}")
-            report.append(f"  * System partition: {r['system']}")
-            report.append(f"  * Environment: {r['environment']}")
-            report.append(f"  * Stage directory: {r['stagedir']}")
+            printer.info(line_width * '-')
+            printer.info(f"FAILURE INFO for {r['name']} {retry_info}")
+            printer.info(f"  * Test Description: {r['description']}")
+            printer.info(f"  * System partition: {r['system']}")
+            printer.info(f"  * Environment: {r['environment']}")
+            printer.info(f"  * Stage directory: {r['stagedir']}")
             nodelist = ','.join(r['nodelist']) if r['nodelist'] else None
-            report.append(f"  * Node list: {nodelist}")
+            printer.info(f"  * Node list: {nodelist}")
             job_type = 'local' if r['scheduler'] == 'local' else 'batch job'
             jobid = r['jobid']
-            report.append(f"  * Job type: {job_type} (id={r['jobid']})")
-            report.append(f"  * Maintainers: {r['maintainers']}")
-            report.append(f"  * Failing phase: {r['fail_phase']}")
-            report.append(f"  * Rerun with '-n {r['name']}"
-                          f" -p {r['environment']} --system {r['system']}'")
-            report.append(f"  * Reason: {r['fail_reason']}")
+            printer.info(f"  * Job type: {job_type} (id={r['jobid']})")
+            printer.info(f"  * Maintainers: {r['maintainers']}")
+            printer.info(f"  * Failing phase: {r['fail_phase']}")
+            printer.info(f"  * Rerun with '-n {r['name']}"
+                         f" -p {r['environment']} --system {r['system']}'")
+            printer.info(f"  * Reason: {r['fail_reason']}")
 
-        report.append(line_width * '-')
-        return '\n'.join(report)
+            tb = ''.join(traceback.format_exception(*r['fail_info'].values()))
+            if r['fail_severe']:
+                printer.info(tb)
+            else:
+                printer.verbose(tb)
 
-    def failure_stats(self):
+        printer.info(line_width * '-')
+
+    def print_failure_stats(self, printer):
         failures = {}
         current_run = rt.runtime().current_run
         for tf in (t for t in self.tasks(current_run) if t.failed):
@@ -234,9 +246,8 @@ class TestStats:
                 stats_body.append(row_format.format('', '', str(f)))
 
         if stats_body:
-            return '\n'.join([stats_start, stats_title, *stats_body,
-                              stats_end])
-        return ''
+            for line in (stats_start, stats_title, *stats_body, stats_end):
+                printer.info(line)
 
     def performance_report(self):
         # FIXME: Adapt this function to use the JSON report

--- a/reframe/schemas/runreport.json
+++ b/reframe/schemas/runreport.json
@@ -41,8 +41,21 @@
                                 "build_stdout": {"type": ["string", "null"]},
                                 "description": {"type": "string"},
                                 "environment": {"type": ["string", "null"]},
+                                "fail_info": {
+                                    "type": ["object", "null"],
+                                    "properties": {
+                                        "exc_type": {"type": "string"},
+                                        "exc_value": {"type": "string"},
+                                        "traceback": {
+                                            "type": "array",
+                                            "items": {"type": "string"}
+                                        }
+                                    },
+                                    "required": ["exc_type", "exc_value", "traceback"]
+                                },
                                 "fail_phase": {"type": ["string", "null"]},
                                 "fail_reason": {"type": ["string", "null"]},
+                                "fail_severe": {"type": "boolean"},
                                 "jobid": {"type": ["number", "null"]},
                                 "job_stderr": {"type": ["string", "null"]},
                                 "job_stdout": {"type": ["string", "null"]},

--- a/reframe/utility/jsonext.py
+++ b/reframe/utility/jsonext.py
@@ -3,13 +3,25 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
+import inspect
 import json
+import traceback
 
 
 class _ReframeJsonEncoder(json.JSONEncoder):
     def default(self, obj):
         if hasattr(obj, '__rfm_json_encode__'):
             return obj.__rfm_json_encode__()
+
+        # Treat some non-ReFrame objects specially
+        if isinstance(obj, type) and issubclass(obj, BaseException):
+            return obj.__name__
+
+        if isinstance(obj, BaseException):
+            return str(obj)
+
+        if inspect.istraceback(obj):
+            return traceback.format_tb(obj)
 
         return json.JSONEncoder.default(self, obj)
 

--- a/unittests/test_policies.py
+++ b/unittests/test_policies.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
+import io
 import json
 import jsonschema
 import os
@@ -17,6 +18,7 @@ import reframe.frontend.dependency as dependency
 import reframe.frontend.executors as executors
 import reframe.frontend.executors.policies as policies
 import reframe.utility as util
+import reframe.utility.jsonext as jsonext
 import reframe.utility.osext as osext
 from reframe.core.exceptions import (AbortTaskError,
                                      JobNotStartedError,
@@ -122,7 +124,7 @@ def _validate_runreport(report):
     with open(schema_filename) as fp:
         schema = json.loads(fp.read())
 
-    jsonschema.validate(report, schema)
+    jsonschema.validate(json.loads(report), schema)
 
 
 def test_runall(make_runner, make_cases, common_exec_ctx):
@@ -163,7 +165,14 @@ def test_runall(make_runner, make_cases, common_exec_ctx):
         },
         'runs': run_stats
     }
-    _validate_runreport(report)
+
+    # We dump the report first, in order to get any object conversions right
+    final_report = None
+    with io.StringIO() as fp:
+        jsonext.dump(report, fp, indent=2)
+        final_report = fp.getvalue()
+
+    _validate_runreport(final_report)
 
 
 def test_runall_skip_system_check(make_runner, make_cases, common_exec_ctx):


### PR DESCRIPTION
To achieve this, the way the failure report is generated had to be redesigned:

- The former `failure_report()` and `failure_stats()` are now printing directly through a printer object, thus their output is controlled with the universal verbosity levels of the framework.
- The exception information is kept in detail in the produced JSON report.
- The former `format_exception()` function has been simplified to return only the reason of the failure (no tracebacks).
- The traceback are always stored in the JSON report and are printed either at the INFO or the VERBOSE level depending on the severity of the failure, which can be queried through the `is_severe()` method.

Fixes #491.