### PR TITLE
[bugfix] Fix statistics crash when reporting task dependency errors

### DIFF
--- a/reframe/core/exceptions.py
+++ b/reframe/core/exceptions.py
@@ -282,7 +282,7 @@ def user_frame(exc_type, exc_value, tb):
 
     '''
     if not inspect.istraceback(tb):
-        raise ValueError('could not retrieve frame: argument not a traceback')
+        return None
 
     for finfo in reversed(inspect.getinnerframes(tb)):
         relpath = os.path.relpath(finfo.filename, sys.path[0])


### PR DESCRIPTION
This happens because `TaskDependencyError`s are not associated with a stack trace, so this was raising ` ValueError`:

```
./bin/reframe: Traceback (most recent call last):
  File "/users/karakasv/Devel/reframe/reframe/frontend/cli.py", line 738, in main
    runner.stats.print_failure_report(printer)
  File "/users/karakasv/Devel/reframe/reframe/frontend/statistics.py", line 175, in print_failure_report
    run_report = self.json()[-1]
  File "/users/karakasv/Devel/reframe/reframe/frontend/statistics.py", line 134, in json
    entry['fail_reason'] = errors.what(*t.exc_info)
  File "/users/karakasv/Devel/reframe/reframe/core/exceptions.py", line 329, in what
    frame = user_frame(exc_type, exc_value, tb)
  File "/users/karakasv/Devel/reframe/reframe/core/exceptions.py", line 286, in user_frame
    raise ValueError('could not retrieve frame: argument not a traceback')
ValueError: could not retrieve frame: argument not a traceback
```