### PR TITLE
[bugfix] Fix unit test error due the PID 1 problem when running inside a Docker container

### DIFF
--- a/unittests/test_schedulers.py
+++ b/unittests/test_schedulers.py
@@ -483,7 +483,13 @@ def test_submit_max_pending_time(make_job, exec_ctx, scheduler):
 def assert_process_died(pid):
     try:
         os.kill(pid, 0)
-        pytest.fail('process %s is still alive' % pid)
+        if os.getpid() == 1:
+            # We are running in a container; so pid is likely a zombie; reap it
+            if os.waitpid(pid, os.WNOHANG)[0] == 0:
+                pytest.fail(f'process {pid} is still alive')
+        else:
+            pytest.fail(f'process {pid} is still alive')
+
     except (ProcessLookupError, PermissionError):
         pass
 


### PR DESCRIPTION
The `assert_process_died()` function was failing for the local scheduler when the unit tests were run inside a container. The reason for that is that the Python process was run with pid=1, thus inheriting the children that were killed in some of the unit tests. Since these children were never waited for, the remained zombies, thus having still a valid PID.