### PR TITLE
[bugfix] Fail properly when the source code language cannot be guessed

### DIFF
--- a/reframe/core/buildsystems.py
+++ b/reframe/core/buildsystems.py
@@ -375,7 +375,6 @@ class SingleSource(BuildSystem):
             raise BuildSystemError(
                 'a source file is required when using the %s build system' %
                 type(self).__name__)
-
         cc = self._cc(environ)
         cxx = self._cxx(environ)
         ftn = self._ftn(environ)
@@ -426,8 +425,9 @@ class SingleSource(BuildSystem):
             cmd_parts += [nvcc, *cppflags, *cxxflags, self.srcfile,
                           '-o', executable, *ldflags]
         else:
-            BuildSystemError('could not guess language of file: %s' %
-                             self.srcfile)
+            raise BuildSystemError(
+                f'could not guess language of file: {self.srcfile}'
+            )
 
         return [' '.join(cmd_parts)]
 

--- a/reframe/core/buildsystems.py
+++ b/reframe/core/buildsystems.py
@@ -375,6 +375,7 @@ class SingleSource(BuildSystem):
             raise BuildSystemError(
                 'a source file is required when using the %s build system' %
                 type(self).__name__)
+
         cc = self._cc(environ)
         cxx = self._cxx(environ)
         ftn = self._ftn(environ)

--- a/unittests/test_buildsystems.py
+++ b/unittests/test_buildsystems.py
@@ -239,16 +239,6 @@ def test_compiler_pick(lang):
 
 def test_singlesource_unknown_language():
     build_system = bs.SingleSource()
-    build_system.cc = 'cc'
-    build_system.cxx = 'CC'
-    build_system.ftn = 'ftn'
-    build_system.nvcc = 'nvcc'
     build_system.srcfile = 'foo.bar'
-    compilers = {
-        'C': build_system.cc,
-        'C++': build_system.cxx,
-        'Fortran': build_system.ftn,
-        'CUDA': build_system.nvcc
-    }
     with pytest.raises(BuildSystemError, match='could not guess language'):
         build_system.emit_build_commands(ProgEnvironment('testenv'))

--- a/unittests/test_buildsystems.py
+++ b/unittests/test_buildsystems.py
@@ -235,3 +235,20 @@ def test_compiler_pick(lang):
     }
     assert ([f'{compilers[lang]} {build_system.srcfile} -o foo.x'] ==
             build_system.emit_build_commands(ProgEnvironment('testenv')))
+
+
+def test_singlesource_unknown_language():
+    build_system = bs.SingleSource()
+    build_system.cc = 'cc'
+    build_system.cxx = 'CC'
+    build_system.ftn = 'ftn'
+    build_system.nvcc = 'nvcc'
+    build_system.srcfile = 'foo.bar'
+    compilers = {
+        'C': build_system.cc,
+        'C++': build_system.cxx,
+        'Fortran': build_system.ftn,
+        'CUDA': build_system.nvcc
+    }
+    with pytest.raises(BuildSystemError, match='could not guess language'):
+        build_system.emit_build_commands(ProgEnvironment('testenv'))

--- a/unittests/test_pipeline.py
+++ b/unittests/test_pipeline.py
@@ -457,6 +457,21 @@ def test_sourcepath_upref(local_exec_ctx):
         test.compile()
 
 
+def test_sourcepath_non_existent(local_exec_ctx):
+    @fixtures.custom_prefix('unittests/resources/checks')
+    class MyTest(rfm.CompileOnlyRegressionTest):
+        def __init__(self):
+            self.valid_prog_environs = ['*']
+            self.valid_systems = ['*']
+
+    test = MyTest()
+    test.setup(*local_exec_ctx)
+    test.sourcepath = 'non_existent.c'
+    test.compile()
+    with pytest.raises(BuildError):
+        test.compile_wait()
+
+
 def test_extra_resources(testsys_system):
     @fixtures.custom_prefix('unittests/resources/checks')
     class MyTest(HelloTest):


### PR DESCRIPTION
* The SingleSource build system now raises an exception when
it fails to guess the programming language of the source file.

* Add unittests.

Fixes #1546 