### PR TITLE
[feat] Allow using colon separated paths with the `--module-path` option

### DIFF
--- a/docs/manpage.rst
+++ b/docs/manpage.rst
@@ -893,21 +893,6 @@ Here is an alphabetical list of the environment variables recognized by ReFrame:
       ================================== ==================
 
 
-.. versionadded:: 3.3
-
-.. envvar:: RFM_UNUSE_MODULE_PATHS
-
-   A colon-separated list of module paths to be unused before acting on any tests.
-
-   .. table::
-      :align: left
-
-      ================================== ==================
-      Associated command line option     :option:`--unuse-module-path`
-      Associated configuration parameter :js:attr:`unuse_module_paths` general configuration parameter
-      ================================== ==================
-
-
 .. envvar:: RFM_USE_LOGIN_SHELL
 
    Use a login shell for the generated job scripts.

--- a/reframe/frontend/cli.py
+++ b/reframe/frontend/cli.py
@@ -757,19 +757,19 @@ def main():
         for d in options.module_paths:
             if d.startswith('-'):
                 module_paths.setdefault('-', [])
-                module_paths.append(d[1:])
+                module_paths['-'].append(d[1:])
             elif d.startswith('+'):
                 module_paths.setdefault('+', [])
-                module_paths.append(d[1:])
+                module_paths['+'].append(d[1:])
             else:
                 module_paths.setdefault('x', [])
-                module_paths.append(d)
+                module_paths['x'].append(d)
 
         for op, paths in module_paths.items():
             if op == '+':
                 module_use(*paths)
             elif op == '-':
-                module_use(*paths)
+                module_unuse(*paths)
             else:
                 # First empty the current module path in a portable way
                 searchpath = [p for p in rt.modules_system.searchpath if p]

--- a/reframe/frontend/cli.py
+++ b/reframe/frontend/cli.py
@@ -738,34 +738,47 @@ def main():
             printer.debug(str(e))
             raise
 
+        def module_use(*paths):
+            try:
+                rt.modules_system.searchpath_add(*paths)
+            except errors.EnvironError as e:
+                printer.warning(f'could not add module paths correctly')
+                printer.debug(str(e))
+
+        def module_unuse(*paths):
+            try:
+                rt.modules_system.searchpath_remove(*paths)
+            except errors.EnvironError as e:
+                printer.warning(f'could not remove module paths correctly')
+                printer.debug(str(e))
+
         printer.debug('(Un)using module paths from command line')
+        module_paths = {}
         for d in options.module_paths:
             if d.startswith('-'):
-                try:
-                    rt.modules_system.searchpath_remove(d[1:])
-                except errors.EnvironError as e:
-                    printer.warning(
-                        f'could not remove module path {d} correctly; '
-                        f'skipping...'
-                    )
-                    printer.verbose(str(e))
+                module_paths.setdefault('-', [])
+                module_paths.append(d[1:])
             elif d.startswith('+'):
-                try:
-                    rt.modules_system.searchpath_add(d[1:])
-                except errors.EnvironError as e:
-                    printer.warning(
-                        f'could not add module path {d} correctly; '
-                        f'skipping...'
-                    )
-                    printer.verbose(str(e))
+                module_paths.setdefault('+', [])
+                module_paths.append(d[1:])
             else:
-                # Here we make sure that we don't try to remove an empty path
-                # from the searchpath
+                module_paths.setdefault('x', [])
+                module_paths.append(d)
+
+        for op, paths in module_paths.items():
+            if op == '+':
+                module_use(*paths)
+            elif op == '-':
+                module_use(*paths)
+            else:
+                # First empty the current module path in a portable way
                 searchpath = [p for p in rt.modules_system.searchpath if p]
                 if searchpath:
                     rt.modules_system.searchpath_remove(*searchpath)
 
-                rt.modules_system.searchpath_add(d)
+                # Treat `A:B` syntax as well in this case
+                paths = itertools.chain(*(p.split(':') for p in paths))
+                module_use(*paths)
 
         printer.debug('Loading user modules from command line')
         for m in site_config.get('general/0/user_modules'):

--- a/unittests/test_buildsystems.py
+++ b/unittests/test_buildsystems.py
@@ -3,8 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-import abc
-import functools
 import pytest
 
 import reframe.core.buildsystems as bs

--- a/unittests/test_cli.py
+++ b/unittests/test_cli.py
@@ -3,14 +3,14 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
+import contextlib
+import io
 import itertools
 import os
 import pathlib
 import pytest
 import re
 import sys
-from contextlib import redirect_stdout, redirect_stderr, suppress
-from io import StringIO
 
 import reframe.core.config as config
 import reframe.core.environments as env
@@ -26,11 +26,11 @@ def run_command_inline(argv, funct, *args, **kwargs):
     sys.argv = argv
     exitcode = None
 
-    captured_stdout = StringIO()
-    captured_stderr = StringIO()
+    captured_stdout = io.StringIO()
+    captured_stderr = io.StringIO()
     print(*sys.argv)
-    with redirect_stdout(captured_stdout):
-        with redirect_stderr(captured_stderr):
+    with contextlib.redirect_stdout(captured_stdout):
+        with contextlib.redirect_stderr(captured_stderr):
             try:
                 with rt.temp_runtime(None):
                     exitcode = funct(*args, **kwargs)
@@ -632,10 +632,8 @@ def test_overwrite_module_path(run_reframe, user_exec_ctx):
         pytest.skip('no modules system found')
 
     module_path = 'unittests/modules'
-    try:
+    with contextlib.suppress(KeyError):
         module_path += f':{os.environ["MODULEPATH"]}'
-    except KeyError:
-        pass
 
     returncode, stdout, stderr = run_reframe(
         more_options=[f'--module-path={module_path}', '--module=testmod_foo'],

--- a/unittests/test_cli.py
+++ b/unittests/test_cli.py
@@ -591,13 +591,13 @@ def test_unload_module(run_reframe, user_exec_ctx):
     assert returncode == 0
 
 
-def test_unuse_module_path(run_reframe, user_exec_ctx, monkeypatch):
+def test_unuse_module_path(run_reframe, user_exec_ctx):
     ms = rt.runtime().modules_system
     if ms.name == 'nomod':
         pytest.skip('no modules system found')
 
     module_path = 'unittests/modules'
-    monkeypatch.setenv('MODULEPATH', module_path)
+    ms.searchpath_add(module_path)
     returncode, stdout, stderr = run_reframe(
         more_options=[f'--module-path=-{module_path}', '--module=testmod_foo'],
         config_file=fixtures.USER_CONFIG_FILE, action='run',
@@ -632,6 +632,11 @@ def test_overwrite_module_path(run_reframe, user_exec_ctx):
         pytest.skip('no modules system found')
 
     module_path = 'unittests/modules'
+    try:
+        module_path += f':{os.environ["MODULEPATH"]}'
+    except KeyError:
+        pass
+
     returncode, stdout, stderr = run_reframe(
         more_options=[f'--module-path={module_path}', '--module=testmod_foo'],
         config_file=fixtures.USER_CONFIG_FILE, action='run',

--- a/unittests/test_cli.py
+++ b/unittests/test_cli.py
@@ -7,12 +7,10 @@ import contextlib
 import io
 import itertools
 import os
-import pathlib
 import pytest
 import re
 import sys
 
-import reframe.core.config as config
 import reframe.core.environments as env
 import reframe.core.logging as logging
 import reframe.core.runtime as rt

--- a/unittests/test_pipeline.py
+++ b/unittests/test_pipeline.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 import os
-import pathlib
 import pytest
 import re
 
@@ -14,8 +13,7 @@ import reframe.utility.osext as osext
 import reframe.utility.sanity as sn
 import unittests.fixtures as fixtures
 from reframe.core.exceptions import (BuildError, PipelineError, ReframeError,
-                                     ReframeSyntaxError, PerformanceError,
-                                     SanityError)
+                                     PerformanceError, SanityError)
 from reframe.frontend.loader import RegressionCheckLoader
 from unittests.resources.checks.hellocheck import HelloTest
 from unittests.resources.checks.pinnedcheck import PinnedTest
@@ -812,7 +810,6 @@ def test_name_compileonly_test():
 
 
 def test_registration_of_tests():
-    import sys
     import unittests.resources.checks_unlisted.good as mod
 
     checks = mod._rfm_gettests()


### PR DESCRIPTION
This is only the case when neither the `+` nor the `-` prefixes are used. The reason for this enhancement is to allow an easier manipulation of the path through. The unit tests are also adapted.

This blocks #1538, since the unit tests are broken in master on Dom.