### PR TITLE
[bugfix] Send test attributes correctly with the Graylog handler

### DIFF
--- a/docs/config_reference.rst
+++ b/docs/config_reference.rst
@@ -706,8 +706,8 @@ All logging handlers share the following set of common attributes:
    - ``%(check_perf_value)s``: The performance value obtained for a certain performance variable.
    - ``%(check_perf_var)s``: The name of the `performance variable <tutorial_basic.html#writing-a-performance-test>`__ being logged.
    - ``%(check_ATTR)s``: This will log the value of the attribute ``ATTR`` of the currently executing regression test.
-     Mappings will be logged as ``k1=v1,k2=v2,..`` and all other iterables, except strings, will be logged as comma-separated lists.
-     If ``ATTR`` is not an attribute of the test, ``%(check_ATTR)s`` will be logged as ``<undefined>``.
+     Dictionaries will be logged in JSON format and all other iterables, except strings, will be logged as comma-separated lists.
+     If ``ATTR`` is not an attribute of the test, ``%(check_ATTR)s`` will be logged as ``null``.
      This allows users to log arbitrary attributes of their tests.
      For the complete list of test attributes, please refer to :doc:`regression_test_api`.
    - ``%(osuser)s``: The name of the OS user running ReFrame.

--- a/reframe/core/buildsystems.py
+++ b/reframe/core/buildsystems.py
@@ -176,6 +176,9 @@ class BuildSystem(abc.ABC):
     def __str__(self):
         return type(self).__name__
 
+    def __rfm_json_encode__(self):
+        return str(self)
+
 
 class Make(BuildSystem):
     '''A build system for compiling codes using ``make``.

--- a/reframe/core/buildsystems.py
+++ b/reframe/core/buildsystems.py
@@ -173,6 +173,9 @@ class BuildSystem(abc.ABC):
     def _ldflags(self, environ):
         return self._resolve_flags('ldflags', environ)
 
+    def __str__(self):
+        return type(self).__name__
+
 
 class Make(BuildSystem):
     '''A build system for compiling codes using ``make``.

--- a/reframe/core/deferrable.py
+++ b/reframe/core/deferrable.py
@@ -76,7 +76,10 @@ class _DeferredExpression:
         return iter(self.evaluate())
 
     def __rfm_json_encode__(self):
-        return self.evaluate()
+        try:
+            return self.evaluate()
+        except BaseException:
+            return None
 
     # Overload Python operators to be able to defer any expression
     #

--- a/reframe/core/logging.py
+++ b/reframe/core/logging.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 import abc
-import collections.abc
 import logging
 import logging.handlers
 import numbers

--- a/reframe/core/logging.py
+++ b/reframe/core/logging.py
@@ -165,27 +165,13 @@ def _format_time_rfc3339(timestamp, datefmt):
 
 
 def _xfmt(val):
-    from reframe.core.deferrable import _DeferredExpression
+    import reframe.utility.jsonext as jsonext
 
-    if val is None:
-        return '<undefined>'
-
-    try:
-        if isinstance(val, _DeferredExpression):
-            return val.evaluate()
-
-        if isinstance(val, str):
-            return val
-
-        if isinstance(val, collections.abc.Mapping):
-            return ','.join(f'{k}={v}' for k, v in val.items())
-
-        if isinstance(val, collections.abc.Iterable):
-            return ','.join(val)
-    except BaseException:
-        return '<error>'
-    else:
+    if isinstance(val, str):
         return val
+
+    ret = jsonext.dumps(val)
+    return str(val) if ret is None else ret
 
 
 class CheckFieldFormatter(logging.Formatter):
@@ -477,10 +463,8 @@ class LoggerAdapter(logging.LoggerAdapter):
             return
 
         for attr, val in self.check.__dict__.items():
-            if attr.startswith('_'):
-                continue
-
-            self.extra[f'check_{attr}'] = _xfmt(val)
+            if not attr.startswith('_'):
+                self.extra[f'check_{attr}'] = _xfmt(val)
 
         self.extra['check_info'] = self.check.info()
         if self.check.current_system:

--- a/reframe/core/logging.py
+++ b/reframe/core/logging.py
@@ -477,6 +477,9 @@ class LoggerAdapter(logging.LoggerAdapter):
             return
 
         for attr, val in self.check.__dict__.items():
+            if attr.startswith('_'):
+                continue
+
             self.extra[f'check_{attr}'] = _xfmt(val)
 
         self.extra['check_info'] = self.check.info()

--- a/reframe/core/logging.py
+++ b/reframe/core/logging.py
@@ -5,7 +5,6 @@
 
 import abc
 import collections.abc
-import functools
 import logging
 import logging.handlers
 import numbers
@@ -146,8 +145,8 @@ class MultiFileHandler(logging.FileHandler):
         except OSError as e:
             raise LoggingError('logging failed') from e
 
-        self.baseFilename = os.path.join(
-            dirname, record.__rfm_check__.name + '.log')
+        self.baseFilename = os.path.join(dirname,
+                                         f'{record.__rfm_check__.name}.log')
         self.stream = self._streams.get(self.baseFilename, None)
         super().emit(record)
         self._streams[self.baseFilename] = self.stream
@@ -305,7 +304,6 @@ def _create_stream_handler(site_config, config_prefix):
 def _create_graylog_handler(site_config, config_prefix):
     try:
         import pygelf
-
     except ImportError:
         return None
 

--- a/reframe/core/pipeline.py
+++ b/reframe/core/pipeline.py
@@ -939,9 +939,13 @@ class RegressionTest(metaclass=RegressionTestMeta):
         This attribute is evaluated lazily, so it can by used inside sanity
         expressions.
 
-        :type: :class:`str`.
+        :type: :class:`str` or :class:`None` if a run job has not yet been
+            created.
         '''
-        return self._job.stdout
+        if self.job is None:
+            return None
+
+        return self.job.stdout
 
     @property
     @sn.sanity_function
@@ -953,9 +957,13 @@ class RegressionTest(metaclass=RegressionTestMeta):
         This attribute is evaluated lazily, so it can by used inside sanity
         expressions.
 
-        :type: :class:`str`.
+        :type: :class:`str` or :class:`None` if a run job has not yet been
+            created.
         '''
-        return self._job.stderr
+        if self.job is None:
+            return None
+
+        return self.job.stderr
 
     @property
     def build_job(self):
@@ -964,12 +972,18 @@ class RegressionTest(metaclass=RegressionTestMeta):
     @property
     @sn.sanity_function
     def build_stdout(self):
-        return self._build_job.stdout
+        if self.build_job is None:
+            return None
+
+        return self.build_job.stdout
 
     @property
     @sn.sanity_function
     def build_stderr(self):
-        return self._build_job.stderr
+        if self.build_job is None:
+            return None
+
+        return self.build_job.stderr
 
     def info(self):
         '''Provide live information for this test.
@@ -1842,12 +1856,18 @@ class CompileOnlyRegressionTest(RegressionTest, special=True):
     @property
     @sn.sanity_function
     def stdout(self):
-        return self._build_job.stdout
+        if self.build_job is None:
+            return None
+
+        return self.build_job.stdout
 
     @property
     @sn.sanity_function
     def stderr(self):
-        return self._build_job.stderr
+        if self.build_job is None:
+            return None
+
+        return self.build_job.stderr
 
     def run(self):
         '''The run stage of the regression test pipeline.

--- a/reframe/core/pipeline.py
+++ b/reframe/core/pipeline.py
@@ -942,10 +942,7 @@ class RegressionTest(metaclass=RegressionTestMeta):
         :type: :class:`str` or :class:`None` if a run job has not yet been
             created.
         '''
-        if self.job is None:
-            return None
-
-        return self.job.stdout
+        return self.job.stdout if self.job else None
 
     @property
     @sn.sanity_function
@@ -960,10 +957,7 @@ class RegressionTest(metaclass=RegressionTestMeta):
         :type: :class:`str` or :class:`None` if a run job has not yet been
             created.
         '''
-        if self.job is None:
-            return None
-
-        return self.job.stderr
+        return self.job.stderr if self.job else None
 
     @property
     def build_job(self):
@@ -972,18 +966,12 @@ class RegressionTest(metaclass=RegressionTestMeta):
     @property
     @sn.sanity_function
     def build_stdout(self):
-        if self.build_job is None:
-            return None
-
-        return self.build_job.stdout
+        return self.build_job.stdout if self.build_job else None
 
     @property
     @sn.sanity_function
     def build_stderr(self):
-        if self.build_job is None:
-            return None
-
-        return self.build_job.stderr
+        return self.build_job.stderr if self.build_job else None
 
     def info(self):
         '''Provide live information for this test.
@@ -1856,18 +1844,12 @@ class CompileOnlyRegressionTest(RegressionTest, special=True):
     @property
     @sn.sanity_function
     def stdout(self):
-        if self.build_job is None:
-            return None
-
-        return self.build_job.stdout
+        return self.build_job.stdout if self.build_job else None
 
     @property
     @sn.sanity_function
     def stderr(self):
-        if self.build_job is None:
-            return None
-
-        return self.build_job.stderr
+        return self.build_job.stderr if self.build_job else None
 
     def run(self):
         '''The run stage of the regression test pipeline.

--- a/reframe/utility/jsonext.py
+++ b/reframe/utility/jsonext.py
@@ -17,13 +17,19 @@ class _ReframeJsonEncoder(json.JSONEncoder):
         if isinstance(obj, type) and issubclass(obj, BaseException):
             return obj.__name__
 
+        if isinstance(obj, set):
+            return list(obj)
+
         if isinstance(obj, BaseException):
             return str(obj)
 
         if inspect.istraceback(obj):
             return traceback.format_tb(obj)
 
-        return json.JSONEncoder.default(self, obj)
+        try:
+            return json.JSONEncoder.default(self, obj)
+        except TypeError:
+            return None
 
 
 def dump(obj, fp, **kwargs):

--- a/reframe/utility/jsonext.py
+++ b/reframe/utility/jsonext.py
@@ -8,6 +8,26 @@ import json
 import traceback
 
 
+def encode(obj):
+    if hasattr(obj, '__rfm_json_encode__'):
+        return obj.__rfm_json_encode__()
+
+    # Treat some non-ReFrame objects specially
+    if isinstance(obj, type) and issubclass(obj, BaseException):
+        return obj.__name__
+
+    if isinstance(obj, set):
+        return list(obj)
+
+    if isinstance(obj, BaseException):
+        return str(obj)
+
+    if inspect.istraceback(obj):
+        return traceback.format_tb(obj)
+
+    return None
+
+
 class _ReframeJsonEncoder(json.JSONEncoder):
     def default(self, obj):
         if hasattr(obj, '__rfm_json_encode__'):
@@ -33,10 +53,12 @@ class _ReframeJsonEncoder(json.JSONEncoder):
 
 
 def dump(obj, fp, **kwargs):
-    kwargs['cls'] = _ReframeJsonEncoder
+    # kwargs['cls'] = _ReframeJsonEncoder
+    kwargs.setdefault('default', encode)
     return json.dump(obj, fp, **kwargs)
 
 
 def dumps(obj, **kwargs):
-    kwargs['cls'] = _ReframeJsonEncoder
+    # kwargs['cls'] = _ReframeJsonEncoder
+    kwargs.setdefault('default', encode)
     return json.dumps(obj, **kwargs)

--- a/reframe/utility/jsonext.py
+++ b/reframe/utility/jsonext.py
@@ -28,37 +28,11 @@ def encode(obj):
     return None
 
 
-class _ReframeJsonEncoder(json.JSONEncoder):
-    def default(self, obj):
-        if hasattr(obj, '__rfm_json_encode__'):
-            return obj.__rfm_json_encode__()
-
-        # Treat some non-ReFrame objects specially
-        if isinstance(obj, type) and issubclass(obj, BaseException):
-            return obj.__name__
-
-        if isinstance(obj, set):
-            return list(obj)
-
-        if isinstance(obj, BaseException):
-            return str(obj)
-
-        if inspect.istraceback(obj):
-            return traceback.format_tb(obj)
-
-        try:
-            return json.JSONEncoder.default(self, obj)
-        except TypeError:
-            return None
-
-
 def dump(obj, fp, **kwargs):
-    # kwargs['cls'] = _ReframeJsonEncoder
     kwargs.setdefault('default', encode)
     return json.dump(obj, fp, **kwargs)
 
 
 def dumps(obj, **kwargs):
-    # kwargs['cls'] = _ReframeJsonEncoder
     kwargs.setdefault('default', encode)
     return json.dumps(obj, **kwargs)

--- a/unittests/test_logging.py
+++ b/unittests/test_logging.py
@@ -163,7 +163,7 @@ def test_logger_dynamic_attributes(logfile, logger_with_check):
     logger_with_check.logger.handlers[0].setFormatter(formatter)
     logger_with_check.info('xxx')
     assert _pattern_in_logfile(
-        r'hello extras\|custom,attr\|<undefined>\|a=1,b=2', logfile
+        r'hello extras\|custom,attr\|null\|{"a": 1, "b": 2}', logfile
     )
 
 
@@ -173,7 +173,7 @@ def test_logger_dynamic_attributes_deferrables(logfile, logger_with_check):
     )
     logger_with_check.logger.handlers[0].setFormatter(formatter)
     logger_with_check.info('xxx')
-    assert _pattern_in_logfile(r'hello\|<error>', logfile)
+    assert _pattern_in_logfile(r'"hello"\|null', logfile)
 
 
 def test_rfc3339_timezone_extension(logfile, logger_with_check,


### PR DESCRIPTION
The implementation of the dynamic log record based on arbitrary test attributes is revised completely. It does not happen anymore in the formatter, because the formatter is not used by the Graylog handler and this was the reason for #1640. All public test attributes as well as some interesting properties are put in the logger's `extra` dict. This will be transferred to the log record by Python's logging mechanism. At this point, we do NOT format anything, except the `check_job_completion_time`, in order to be sent correctly to Graylog. The formatting of the record is an exclusive duty of the formatter object, which formats the final log message through its `formatMessage()` method. We don't format the record attributes directly, but we use a proxy dictionary, which holds the formatted values, in order to produce the final message from the format string. All attributes, except lists, tuples, sets and strings are formatted using our `jsonext.dumps()` function. For compatibility with the current behaviour, lists, tuples and sets are formatted as comma-separated lists, whereas strings are passed as-is (NB: if they were JSON formatted, they would be quoted). This allows users to use the `%(check_perf_patterns)s` format specifier in order to get all the performance variables and values at once as a JSON object. If a requested test attribute cannot be found, it will be logged as `null`.

The Graylog handler sends to the remote end the full log record converted to JSON. Again here, we use our JSON encoding method. There are some limitations to this. If a field is logged as `null` it will not be indexed and it will not show up in the Kibana logs. Also, for some reason that I cannot understand, the same happens for boolean fields. It would be rather complicated to format these fields as strings and transfer them, without messing with the log record, so I chose not to do it, because in principle it's not a handler's responsibility to format a log record.

Fixes #1640.