### PR TITLE
[test] Extend GPU burn test to report GPU node with smallest flops

### DIFF
--- a/cscs-checks/microbenchmarks/gpu/gpu_burn/gpu_burn_test.py
+++ b/cscs-checks/microbenchmarks/gpu/gpu_burn/gpu_burn_test.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 import os
-import sys
 
 import reframe as rfm
 import reframe.utility.sanity as sn

--- a/cscs-checks/microbenchmarks/gpu/gpu_burn/gpu_burn_test.py
+++ b/cscs-checks/microbenchmarks/gpu/gpu_burn/gpu_burn_test.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 import os
+import sys
 
 import reframe as rfm
 import reframe.utility.sanity as sn
@@ -142,20 +143,19 @@ class GpuBurnTest(rfm.RegressionTest):
         rptf = os.path.join(self.stagedir, sn.evaluate(self.stdout))
         self.nids = sn.extractall(regex, rptf, 1)
         self.flops = sn.extractall(regex, rptf, 2, float)
-        index = -1
-        flops_min = sn.min(self.flops)
-        for ii in range(len(sn.evaluate(self.flops))):
-            if self.flops[ii] == flops_min:
-                index = ii
-                break
+        flops_min, index = sys.float_info.max, None
+        for i, flops in enumerate(self.flops):
+            if flops < flops_min:
+                flops_min, index = flops, i
 
         self.unit = f'GF/s ({self.nids[index]})'
+        unit = (0, None, None, self.unit)
         self.perf_patterns['smallest_flops'] = flops_min
-        self.reference['dom:gpu:smallest_flops'] = (0, None, None, self.unit)
-        self.reference['daint:gpu'] = (0, None, None, self.unit)
-        self.reference['arolla:cn'] = (0, None, None, self.unit)
-        self.reference['tsa:cn'] = (0, None, None, self.unit)
-        self.reference['ault:amda100'] = (0, None, None, self.unit)
-        self.reference['ault:amdv100'] = (0, None, None, self.unit)
-        self.reference['ault:intelv100'] = (0, None, None, self.unit)
-        self.reference['ault:amdvega'] = (0, None, None, self.unit)
+        self.reference['dom:gpu:smallest_flops'] = unit
+        self.reference['daint:gpu:smallest_flops'] = unit
+        self.reference['arolla:cn:smallest_flops'] = unit
+        self.reference['tsa:cn:smallest_flops'] = unit
+        self.reference['ault:amda100:smallest_flops'] = unit
+        self.reference['ault:amdv100:smallest_flops'] = unit
+        self.reference['ault:intelv100:smallest_flops'] = unit
+        self.reference['ault:amdvega:smallest_flops'] = unit

--- a/cscs-checks/microbenchmarks/gpu/gpu_burn/gpu_burn_test.py
+++ b/cscs-checks/microbenchmarks/gpu/gpu_burn/gpu_burn_test.py
@@ -38,35 +38,35 @@ class GpuBurnTest(rfm.RegressionTest):
 
         self.reference = {
             'dom:gpu': {
-                'perf': (4115, -0.10, None, 'Gflop/s'),
+                # 'perf': (4115, -0.10, None, 'Gflop/s'),
                 'max_temp': (0, None, None, 'Celsius')
             },
             'daint:gpu': {
-                'perf': (4115, -0.10, None, 'Gflop/s'),
+                # 'perf': (4115, -0.10, None, 'Gflop/s'),
                 'max_temp': (0, None, None, 'Celsius')
             },
             'arolla:cn': {
-                'perf': (5861, -0.10, None, 'Gflop/s'),
+                # 'perf': (5861, -0.10, None, 'Gflop/s'),
                 'max_temp': (0, None, None, 'Celsius')
             },
             'tsa:cn': {
-                'perf': (5861, -0.10, None, 'Gflop/s'),
+                # 'perf': (5861, -0.10, None, 'Gflop/s'),
                 'max_temp': (0, None, None, 'Celsius')
             },
             'ault:amda100': {
-                'perf': (15000, -0.10, None, 'Gflop/s'),
+                # 'perf': (15000, -0.10, None, 'Gflop/s'),
                 'max_temp': (0, None, None, 'Celsius')
             },
             'ault:amdv100': {
-                'perf': (5500, -0.10, None, 'Gflop/s'),
+                # 'perf': (5500, -0.10, None, 'Gflop/s'),
                 'max_temp': (0, None, None, 'Celsius')
             },
             'ault:intelv100': {
-                'perf': (5500, -0.10, None, 'Gflop/s'),
+                # 'perf': (5500, -0.10, None, 'Gflop/s'),
                 'max_temp': (0, None, None, 'Celsius')
             },
             'ault:amdvega': {
-                'perf': (3450, -0.10, None, 'Gflop/s'),
+                # 'perf': (3450, -0.10, None, 'Gflop/s'),
                 'max_temp': (0, None, None, 'Celsius')
             },
         }
@@ -138,24 +138,19 @@ class GpuBurnTest(rfm.RegressionTest):
             self.num_gpus_per_node = 1
 
     @rfm.run_before('performance')
-    def report_smallest_node(self):
+    def report_nid_with_smallest_flops(self):
         regex = r'\[(\S+)\] GPU\s+\d\(OK\): (\d+) GF/s'
         rptf = os.path.join(self.stagedir, sn.evaluate(self.stdout))
         self.nids = sn.extractall(regex, rptf, 1)
         self.flops = sn.extractall(regex, rptf, 2, float)
-        flops_min, index = sys.float_info.max, None
-        for i, flops in enumerate(self.flops):
-            if flops < flops_min:
-                flops_min, index = flops, i
-
+        # find index of smallest flops:
+        index = self.flops.evaluate().index(min(self.flops))
         self.unit = f'GF/s ({self.nids[index]})'
-        unit = (0, None, None, self.unit)
-        self.perf_patterns['smallest_flops'] = flops_min
-        self.reference['dom:gpu:smallest_flops'] = unit
-        self.reference['daint:gpu:smallest_flops'] = unit
-        self.reference['arolla:cn:smallest_flops'] = unit
-        self.reference['tsa:cn:smallest_flops'] = unit
-        self.reference['ault:amda100:smallest_flops'] = unit
-        self.reference['ault:amdv100:smallest_flops'] = unit
-        self.reference['ault:intelv100:smallest_flops'] = unit
-        self.reference['ault:amdvega:smallest_flops'] = unit
+        self.reference['dom:gpu:perf'] = (4115, -0.10, None, self.unit)
+        self.reference['daint:gpu:perf'] = (4115, -0.10, None, self.unit)
+        self.reference['arolla:cn:perf'] = (5861, -0.10, None, self.unit)
+        self.reference['tsa:cn:perf'] = (5861, -0.10, None, self.unit)
+        self.reference['ault:amda100:perf'] = (15000, -0.10, None, self.unit)
+        self.reference['ault:amdv100:perf'] = (5500, -0.10, None, self.unit)
+        self.reference['ault:intelv100:perf'] = (5500, -0.10, None, self.unit)
+        self.reference['ault:amdvega:perf'] = (3450, -0.10, None, self.unit)

--- a/cscs-checks/microbenchmarks/gpu/gpu_burn/gpu_burn_test.py
+++ b/cscs-checks/microbenchmarks/gpu/gpu_burn/gpu_burn_test.py
@@ -33,41 +33,35 @@ class GpuBurnTest(rfm.RegressionTest):
                 r'(?P<temp>\S*) Celsius')
         self.perf_patterns = {
             'perf': sn.min(sn.extractall(patt, self.stdout, 'perf', float)),
+            'temp': sn.max(sn.extractall(patt, self.stdout, 'temp', float)),
         }
 
         self.reference = {
             'dom:gpu': {
-                # 'perf': (4115, -0.10, None, 'Gflop/s'),
-                'max_temp': (0, None, None, 'Celsius')
+                'perf': (4115, -0.10, None, 'Gflop/s'),
             },
             'daint:gpu': {
-                # 'perf': (4115, -0.10, None, 'Gflop/s'),
-                'max_temp': (0, None, None, 'Celsius')
+                'perf': (4115, -0.10, None, 'Gflop/s'),
             },
             'arolla:cn': {
-                # 'perf': (5861, -0.10, None, 'Gflop/s'),
-                'max_temp': (0, None, None, 'Celsius')
+                'perf': (5861, -0.10, None, 'Gflop/s'),
             },
             'tsa:cn': {
-                # 'perf': (5861, -0.10, None, 'Gflop/s'),
-                'max_temp': (0, None, None, 'Celsius')
+                'perf': (5861, -0.10, None, 'Gflop/s'),
             },
             'ault:amda100': {
-                # 'perf': (15000, -0.10, None, 'Gflop/s'),
-                'max_temp': (0, None, None, 'Celsius')
+                'perf': (15000, -0.10, None, 'Gflop/s'),
             },
             'ault:amdv100': {
-                # 'perf': (5500, -0.10, None, 'Gflop/s'),
-                'max_temp': (0, None, None, 'Celsius')
+                'perf': (5500, -0.10, None, 'Gflop/s'),
             },
             'ault:intelv100': {
-                # 'perf': (5500, -0.10, None, 'Gflop/s'),
-                'max_temp': (0, None, None, 'Celsius')
+                'perf': (5500, -0.10, None, 'Gflop/s'),
             },
             'ault:amdvega': {
-                # 'perf': (3450, -0.10, None, 'Gflop/s'),
-                'max_temp': (0, None, None, 'Celsius')
+                'perf': (3450, -0.10, None, 'Gflop/s'),
             },
+            '*': {'temp': (0, None, None, 'degC')}
         }
 
         self.maintainers = ['AJ', 'TM']
@@ -142,14 +136,11 @@ class GpuBurnTest(rfm.RegressionTest):
         rptf = os.path.join(self.stagedir, sn.evaluate(self.stdout))
         self.nids = sn.extractall(regex, rptf, 1)
         self.flops = sn.extractall(regex, rptf, 2, float)
-        # find index of smallest flops:
+
+        # Find index of smallest flops and update reference dictionary to
+        # include our patched units
         index = self.flops.evaluate().index(min(self.flops))
-        self.unit = f'GF/s ({self.nids[index]})'
-        self.reference['dom:gpu:perf'] = (4115, -0.10, None, self.unit)
-        self.reference['daint:gpu:perf'] = (4115, -0.10, None, self.unit)
-        self.reference['arolla:cn:perf'] = (5861, -0.10, None, self.unit)
-        self.reference['tsa:cn:perf'] = (5861, -0.10, None, self.unit)
-        self.reference['ault:amda100:perf'] = (15000, -0.10, None, self.unit)
-        self.reference['ault:amdv100:perf'] = (5500, -0.10, None, self.unit)
-        self.reference['ault:intelv100:perf'] = (5500, -0.10, None, self.unit)
-        self.reference['ault:amdvega:perf'] = (3450, -0.10, None, self.unit)
+        unit = f'GF/s ({self.nids[index]})'
+        for key, ref in self.reference.items():
+            if not key.endswith(':temp'):
+                self.reference[key] = (*ref[:3], unit)


### PR DESCRIPTION
GpuBurnTest
- dom:gpu
   - PrgEnv-gnu
      * num_tasks: 22
      * perf: 4091.0 Gflop/s
      * smallest_flops: 4091.0 GF/s (nid00008)

Goal is to report nidname when the test fails to meet perf. reference 
`'perf': (4115, -0.10, None, 'Gflop/s')`
but I am not sure how to do that... Feel free to push 
For now, replacing `perf:` with the last line gives some info.