### PR TITLE
[bugfix] Properly expand environment variables for the filelog log handler

### DIFF
--- a/reframe/core/logging.py
+++ b/reframe/core/logging.py
@@ -247,8 +247,10 @@ def _create_file_handler(site_config, config_prefix):
 
 
 def _create_filelog_handler(site_config, config_prefix):
-    basedir = os.path.abspath(site_config.get(f'{config_prefix}/basedir'))
-    prefix  = site_config.get(f'{config_prefix}/prefix')
+    basedir = os.path.abspath(
+        osext.expandvars(site_config.get(f'{config_prefix}/basedir'))
+    )
+    prefix  = osext.expandvars(site_config.get(f'{config_prefix}/prefix'))
     filename_patt = os.path.join(basedir, prefix)
     append = site_config.get(f'{config_prefix}/append')
     return MultiFileHandler(filename_patt, mode='a+' if append else 'w+')

--- a/unittests/test_cli.py
+++ b/unittests/test_cli.py
@@ -364,8 +364,22 @@ def test_performance_check_failure(run_reframe, tmp_path, perflogdir):
                           'default' / 'PerformanceFailureCheck.log')
 
 
-def test_performance_report(run_reframe):
+def test_perflogdir_from_env(run_reframe, tmp_path, monkeypatch):
+    monkeypatch.setenv('FOODIR', str(tmp_path / 'perflogs'))
     returncode, stdout, stderr = run_reframe(
+        checkpath=['unittests/resources/checks/frontend_checks.py'],
+        more_options=['-t', 'PerformanceFailureCheck'],
+        perflogdir='$FOODIR'
+    )
+    assert returncode == 1
+    assert 'Traceback' not in stdout
+    assert 'Traceback' not in stderr
+    assert os.path.exists(tmp_path / 'perflogs' / 'generic' /
+                          'default' / 'PerformanceFailureCheck.log')
+
+
+def test_performance_report(run_reframe):
+    returncode, stdout, _ = run_reframe(
         checkpath=['unittests/resources/checks/frontend_checks.py'],
         more_options=['-t', 'PerformanceFailureCheck', '--performance-report']
     )


### PR DESCRIPTION
Fixes #1638.