### PR TITLE
[test] Adapt CP2K checks for Eiger

### DIFF
--- a/cscs-checks/apps/cp2k/cp2k_check.py
+++ b/cscs-checks/apps/cp2k/cp2k_check.py
@@ -3,7 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-import os
 import reframe as rfm
 import reframe.utility.sanity as sn
 

--- a/cscs-checks/apps/cp2k/cp2k_check.py
+++ b/cscs-checks/apps/cp2k/cp2k_check.py
@@ -11,11 +11,7 @@ class Cp2kCheck(rfm.RunOnlyRegressionTest):
     def __init__(self):
         self.valid_prog_environs = ['builtin']
         self.modules = ['CP2K']
-        if (self.current_system.name in ['eiger']):
-            self.executable = '--cpu-bind=cores cp2k.psmp'
-        else:
-            self.executable = 'cp2k.psmp'
-
+        self.executable = 'cp2k.psmp'
         self.executable_opts = ['H2O-256.inp']
 
         energy = sn.extractsingle(r'\s+ENERGY\| Total FORCE_EVAL \( QS \) '
@@ -94,22 +90,22 @@ class Cp2kCpuCheck(Cp2kCheck):
                 'small': {
                     'dom:mc': {'time': (202.2, None, 0.05, 's')},
                     'daint:mc': {'time': (180.9, None, 0.08, 's')},
-                    'eiger:mc': {'time': (72.0, None, 0.08, 's')}
+                    'eiger:mc': {'time': (70.0, None, 0.08, 's')}
                 },
                 'large': {
                     'daint:mc': {'time': (141.0, None, 0.05, 's')},
-                    'eiger:mc': {'time': (47.0, None, 0.05, 's')}
+                    'eiger:mc': {'time': (46.0, None, 0.05, 's')}
                 }
             },
             'prod': {
                 'small': {
                     'dom:mc': {'time': (202.2, None, 0.05, 's')},
                     'daint:mc': {'time': (180.9, None, 0.08, 's')},
-                    'eiger:mc': {'time': (72.0, None, 0.08, 's')}
+                    'eiger:mc': {'time': (70.0, None, 0.08, 's')}
                 },
                 'large': {
                     'daint:mc': {'time': (113.0, None, 0.05, 's')},
-                    'eiger:mc': {'time': (47.0, None, 0.05, 's')}
+                    'eiger:mc': {'time': (46.0, None, 0.05, 's')}
                 }
             }
         }
@@ -117,6 +113,13 @@ class Cp2kCpuCheck(Cp2kCheck):
         self.reference = references[variant][scale]
         self.tags |= {'maintenance' if variant == 'maint' else 'production'}
 
+    @rfm.run_before('run')
+    def set_task_distribution(self):
+        self.job.options = ['--distribution=block:block']
+ 
+    @rfm.run_before('run')
+    def set_cpu_binding(self):
+        self.job.launcher.options = ['--cpu-bind=cores']
 
 @rfm.parameterized_test(*([s, v]
                           for s in ['small', 'large']

--- a/cscs-checks/apps/cp2k/cp2k_check.py
+++ b/cscs-checks/apps/cp2k/cp2k_check.py
@@ -95,22 +95,22 @@ class Cp2kCpuCheck(Cp2kCheck):
                 'small': {
                     'dom:mc': {'time': (202.2, None, 0.05, 's')},
                     'daint:mc': {'time': (180.9, None, 0.08, 's')},
-                    'eiger:mc': {'time': (180.9, None, 0.08, 's')}
+                    'eiger:mc': {'time': (72.0, None, 0.08, 's')}
                 },
                 'large': {
                     'daint:mc': {'time': (141.0, None, 0.05, 's')},
-                    'eiger:mc': {'time': (141.0, None, 0.05, 's')}
+                    'eiger:mc': {'time': (47.0, None, 0.05, 's')}
                 }
             },
             'prod': {
                 'small': {
                     'dom:mc': {'time': (202.2, None, 0.05, 's')},
                     'daint:mc': {'time': (180.9, None, 0.08, 's')},
-                    'eiger:mc': {'time': (180.9, None, 0.08, 's')}
+                    'eiger:mc': {'time': (72.0, None, 0.08, 's')}
                 },
                 'large': {
                     'daint:mc': {'time': (113.0, None, 0.05, 's')},
-                    'eiger:mc': {'time': (113.0, None, 0.05, 's')}
+                    'eiger:mc': {'time': (47.0, None, 0.05, 's')}
                 }
             }
         }

--- a/cscs-checks/apps/cp2k/cp2k_check.py
+++ b/cscs-checks/apps/cp2k/cp2k_check.py
@@ -56,10 +56,10 @@ class Cp2kCpuCheck(Cp2kCheck):
         self.valid_systems = ['daint:mc', 'eiger:mc']
         if scale == 'small':
             self.valid_systems += ['dom:mc']
-            if (self.current_system.name in ['daint', 'dom']):
+            if self.current_system.name in ['daint', 'dom']:
                 self.num_tasks = 216
                 self.num_tasks_per_node = 36
-            elif (self.current_system.name in ['eiger']):
+            elif self.current_system.name == 'eiger':
                 self.num_tasks = 96
                 self.num_tasks_per_node = 16
                 self.num_cpus_per_task = 16
@@ -73,10 +73,10 @@ class Cp2kCpuCheck(Cp2kCheck):
                 }
 
         else:
-            if (self.current_system.name in ['daint', 'dom']):
+            if self.current_system.name in ['daint', 'dom']:
                 self.num_tasks = 576
                 self.num_tasks_per_node = 36
-            elif (self.current_system.name in ['eiger']):
+            elif self.current_system.name in ['eiger']:
                 self.num_tasks = 256
                 self.num_tasks_per_node = 16
                 self.num_cpus_per_task = 16

--- a/cscs-checks/apps/cp2k/cp2k_check.py
+++ b/cscs-checks/apps/cp2k/cp2k_check.py
@@ -16,7 +16,7 @@ class Cp2kCheck(rfm.RunOnlyRegressionTest):
             self.executable = '--cpu-bind=cores cp2k.psmp'
         else:
             self.executable = 'cp2k.psmp'
-        
+
         self.executable_opts = ['H2O-256.inp']
 
         energy = sn.extractsingle(r'\s+ENERGY\| Total FORCE_EVAL \( QS \) '
@@ -71,7 +71,7 @@ class Cp2kCpuCheck(Cp2kCheck):
                     'OMP_NUM_THREADS': '8',
                     'OMP_PLACES': 'cores',
                     'OMP_PROC_BIND': 'close'
-                } 
+                }
 
         else:
             if (self.current_system.name in ['daint', 'dom']):
@@ -88,7 +88,7 @@ class Cp2kCpuCheck(Cp2kCheck):
                     'OMP_NUM_THREADS': '8',
                     'OMP_PLACES': 'cores',
                     'OMP_PROC_BIND': 'close'
-                } 
+                }
 
         references = {
             'maint': {

--- a/cscs-checks/apps/cp2k/cp2k_check.py
+++ b/cscs-checks/apps/cp2k/cp2k_check.py
@@ -12,7 +12,11 @@ class Cp2kCheck(rfm.RunOnlyRegressionTest):
     def __init__(self):
         self.valid_prog_environs = ['builtin']
         self.modules = ['CP2K']
-        self.executable = 'cp2k.psmp'
+        if (self.current_system.name in ['eiger']):
+            self.executable = '--cpu-bind=cores cp2k.psmp'
+        else:
+            self.executable = 'cp2k.psmp'
+        
         self.executable_opts = ['H2O-256.inp']
 
         energy = sn.extractsingle(r'\s+ENERGY\| Total FORCE_EVAL \( QS \) '
@@ -57,13 +61,14 @@ class Cp2kCpuCheck(Cp2kCheck):
                 self.num_tasks = 216
                 self.num_tasks_per_node = 36
             elif (self.current_system.name in ['eiger']):
-                self.executable = '--cpu-bind=cores cp2k.psmp'
                 self.num_tasks = 96
                 self.num_tasks_per_node = 16
-                self.num_cpus_per_task = 8
+                self.num_cpus_per_task = 16
+                self.num_tasks_per_core = 1
+                self.use_multithreading = False
                 self.variables = {
                     'MPICH_OFI_STARTUP_CONNECT': '1',
-                    'OMP_NUM_THREADS': str(self.num_cpus_per_task),
+                    'OMP_NUM_THREADS': '8',
                     'OMP_PLACES': 'cores',
                     'OMP_PROC_BIND': 'close'
                 } 
@@ -73,13 +78,14 @@ class Cp2kCpuCheck(Cp2kCheck):
                 self.num_tasks = 576
                 self.num_tasks_per_node = 36
             elif (self.current_system.name in ['eiger']):
-                self.executable = '--cpu-bind=cores cp2k.psmp'
                 self.num_tasks = 256
                 self.num_tasks_per_node = 16
-                self.num_cpus_per_task = 8
+                self.num_cpus_per_task = 16
+                self.num_tasks_per_core = 1
+                self.use_multithreading = False
                 self.variables = {
                     'MPICH_OFI_STARTUP_CONNECT': '1',
-                    'OMP_NUM_THREADS': str(self.num_cpus_per_task),
+                    'OMP_NUM_THREADS': '8',
                     'OMP_PLACES': 'cores',
                     'OMP_PROC_BIND': 'close'
                 } 

--- a/cscs-checks/apps/cp2k/cp2k_check.py
+++ b/cscs-checks/apps/cp2k/cp2k_check.py
@@ -50,31 +50,61 @@ class Cp2kCpuCheck(Cp2kCheck):
     def __init__(self, scale, variant):
         super().__init__()
         self.descr = 'CP2K CPU check (version: %s, %s)' % (scale, variant)
-        self.valid_systems = ['daint:mc']
+        self.valid_systems = ['daint:mc', 'eiger:mc']
         if scale == 'small':
             self.valid_systems += ['dom:mc']
-            self.num_tasks = 216
-        else:
-            self.num_tasks = 576
+            if (self.current_system.name in ['daint', 'dom']):
+                self.num_tasks = 216
+                self.num_tasks_per_node = 36
+            elif (self.current_system.name in ['eiger']):
+                self.executable = '--cpu-bind=cores cp2k.psmp'
+                self.num_tasks = 96
+                self.num_tasks_per_node = 16
+                self.num_cpus_per_task = 8
+                self.variables = {
+                    'MPICH_OFI_STARTUP_CONNECT': '1',
+                    'OMP_NUM_THREADS': str(self.num_cpus_per_task),
+                    'OMP_PLACES': 'cores',
+                    'OMP_PROC_BIND': 'close'
+                } 
 
-        self.num_tasks_per_node = 36
+        else:
+            if (self.current_system.name in ['daint', 'dom']):
+                self.num_tasks = 576
+                self.num_tasks_per_node = 36
+            elif (self.current_system.name in ['eiger']):
+                self.executable = '--cpu-bind=cores cp2k.psmp'
+                self.num_tasks = 256
+                self.num_tasks_per_node = 16
+                self.num_cpus_per_task = 8
+                self.variables = {
+                    'MPICH_OFI_STARTUP_CONNECT': '1',
+                    'OMP_NUM_THREADS': str(self.num_cpus_per_task),
+                    'OMP_PLACES': 'cores',
+                    'OMP_PROC_BIND': 'close'
+                } 
+
         references = {
             'maint': {
                 'small': {
                     'dom:mc': {'time': (202.2, None, 0.05, 's')},
-                    'daint:mc': {'time': (180.9, None, 0.08, 's')}
+                    'daint:mc': {'time': (180.9, None, 0.08, 's')},
+                    'eiger:mc': {'time': (180.9, None, 0.08, 's')}
                 },
                 'large': {
-                    'daint:mc': {'time': (141.0, None, 0.05, 's')}
+                    'daint:mc': {'time': (141.0, None, 0.05, 's')},
+                    'eiger:mc': {'time': (141.0, None, 0.05, 's')}
                 }
             },
             'prod': {
                 'small': {
                     'dom:mc': {'time': (202.2, None, 0.05, 's')},
-                    'daint:mc': {'time': (180.9, None, 0.08, 's')}
+                    'daint:mc': {'time': (180.9, None, 0.08, 's')},
+                    'eiger:mc': {'time': (180.9, None, 0.08, 's')}
                 },
                 'large': {
-                    'daint:mc': {'time': (113.0, None, 0.05, 's')}
+                    'daint:mc': {'time': (113.0, None, 0.05, 's')},
+                    'eiger:mc': {'time': (113.0, None, 0.05, 's')}
                 }
             }
         }


### PR DESCRIPTION
I have re-defined `self.executable = '--cpu-bind=cores cp2k.psmp'` as suggested by @jjotero, since I could not find a simpler way to add the `srun` flag `--cpu-bind=cores` to the command line. The apparently weird setting of `num_cpus_per_task=16` and `OMP_NUM_THREADS=8` yields a better performance with respect to `num_cpus_per_task=8` and `'OMP_NUM_THREADS': str(self.num_cpus_per_task)` (see the related issue https://jira.cscs.ch/projects/SD/queues/custom/48/SD-51051).

In order to improve a bit more the performance of the test, I would also like to add the following Slurm directive:
```
#SBATCH --distribution=block:block
```
I found in the documentation the `job_opts` parameter, but the warning says that in version 3.0 you may not override this method directly unless you are in special test (https://reframe-hpc.readthedocs.io/en/stable/regression_test_api.html?highlight=job_opts#reframe.core.pipeline.RegressionTest.setup).

Are there other options to add custom Slurm directives to the check without creating a check using `special=True`?