### PR TITLE
[bugfix] Revert feature to preserve symbolic links in sources directory since it can lead to dangling links in the stage directory; users should use `readonly_files` instead

### DIFF
--- a/cscs-checks/microbenchmarks/gpu/gpu_burn/gpu_burn_test.py
+++ b/cscs-checks/microbenchmarks/gpu/gpu_burn/gpu_burn_test.py
@@ -22,10 +22,6 @@ class GpuBurnTest(rfm.RegressionTest):
         self.executable_opts = ['-d', '40']
         self.build_system = 'Make'
         self.executable = './gpu_burn.x'
-
-        # FIXME workaround due to issue #1639.
-        self.readonly_files = ['Xdevice']
-
         self.num_tasks = 0
         self.num_tasks_per_node = 1
         self.sanity_patterns = self.assert_num_tasks()

--- a/cscs-checks/microbenchmarks/gpu/kernel_latency/kernel_latency.py
+++ b/cscs-checks/microbenchmarks/gpu/kernel_latency/kernel_latency.py
@@ -28,10 +28,6 @@ class KernelLatencyTest(rfm.RegressionTest):
         self.num_tasks_per_node = 1
         self.build_system = 'Make'
         self.executable = 'kernel_latency.x'
-
-        # FIXME workaround due to issue #1639.
-        self.readonly_files = ['Xdevice']
-
         if kernel_version == 'sync':
             self.build_system.cppflags = ['-D SYNCKERNEL=1']
         else:

--- a/cscs-checks/microbenchmarks/gpu/shmem/shmem.py
+++ b/cscs-checks/microbenchmarks/gpu/shmem/shmem.py
@@ -19,10 +19,6 @@ class GPUShmemTest(rfm.RegressionTest):
         self.num_tasks_per_node = 1
         self.build_system = 'Make'
         self.executable = 'shmem.x'
-
-        # FIXME workaround due to issue #1639.
-        self.readonly_files = ['Xdevice']
-
         self.sanity_patterns = self.assert_count_gpus()
         self.perf_patterns = {
             'bandwidth': sn.min(sn.extractall(

--- a/reframe/core/pipeline.py
+++ b/reframe/core/pipeline.py
@@ -1116,8 +1116,7 @@ class RegressionTest(jsonext.JSONSerializable, metaclass=RegressionTestMeta):
         self.logger.debug(f'Symlinking files: {self.readonly_files}')
         try:
             osext.copytree_virtual(
-                path, self._stagedir, self.readonly_files, symlinks=True,
-                dirs_exist_ok=True
+                path, self._stagedir, self.readonly_files, dirs_exist_ok=True
             )
         except (OSError, ValueError, TypeError) as e:
             raise PipelineError('copying of files failed') from e

--- a/unittests/resources/checks/src/hello.sh.link
+++ b/unittests/resources/checks/src/hello.sh.link
@@ -1,1 +1,0 @@
-hello.sh

--- a/unittests/test_pipeline.py
+++ b/unittests/test_pipeline.py
@@ -240,26 +240,6 @@ def test_run_only_no_srcdir(local_exec_ctx):
     _run(test, *local_exec_ctx)
 
 
-def test_run_only_preserve_symlinks(local_exec_ctx):
-    @fixtures.custom_prefix('unittests/resources/checks')
-    class MyTest(rfm.RunOnlyRegressionTest):
-        def __init__(self):
-            self.executable = './hello.sh.link'
-            self.executable_opts = ['Hello, World!']
-            self.local = True
-            self.valid_prog_environs = ['*']
-            self.valid_systems = ['*']
-            self.sanity_patterns = sn.assert_found(
-                r'Hello, World\!', self.stdout
-            )
-
-        @rfm.run_after('run')
-        def check_symlinks(self):
-            assert os.path.islink(os.path.join(self.stagedir, 'hello.sh.link'))
-
-    _run(MyTest(), *local_exec_ctx)
-
-
 def test_compile_only_failure(local_exec_ctx):
     @fixtures.custom_prefix('unittests/resources/checks')
     class MyTest(rfm.CompileOnlyRegressionTest):


### PR DESCRIPTION
This PR reverts #1580.

* Remove temporary workarounds from affected regression tests.

Fixes #1639 