### PR TITLE
[feat] Support multiple job submissions when slurm's job submit limit is reached

### DIFF
--- a/reframe/core/exceptions.py
+++ b/reframe/core/exceptions.py
@@ -270,6 +270,10 @@ class JobNotStartedError(JobError):
     '''Raised when trying an operation on a unstarted job.'''
 
 
+class JobQOSMaxSubmitJobPerUserLimitError(ReframeError):
+    '''Raised when a slurm gives QOSMaxSubmitJobPerUserLimit.'''
+
+
 class DependencyError(ReframeError):
     '''Raised when a dependency problem is encountered.'''
 

--- a/unittests/test_policies.py
+++ b/unittests/test_policies.py
@@ -458,6 +458,11 @@ class _TaskEventMonitor(executors.TaskEventListener):
     def on_task_setup(self, task):
         pass
 
+    def on_task_compile(self, task):
+        pass
+
+    def on_task_compiled(self, task):
+        pass
 
 @pytest.fixture
 def make_async_exec_ctx(temp_runtime):


### PR DESCRIPTION
Will fix #1595 .

This PR still has several issues:
- It should work with remote building but this complicates the PR a bit.
- Currently it works only in the asynchronous policy. In the serial policy I would have to create another loop with some sleep interval to be able to submit the compilation job multiple times.
- There are no unittests since it is a bit hard to test. Maybe one way would be to overload the slurm submission to return the exception and see how the policies handle it?
- I think the logic of the policies file is getting a bit too complicated and we should rethink how to name the buckets of the tasks (now called "ready", "running", "compiled" etc) and how we move the tasks through them. I think it's reasonable to also have a simpler `runcase` which puts jobs just in the "waiting" list and handle everything in `exit`. This would require a bigger restructure and more thorough testing, but I made this draft PR anyway, mostly to get some feedback.
- It also needs documentation and some configuration parameter, so that the users can decide whether to treat `QOSMaxSubmitJobPerUserLimit` as an error or submit the job later.