### PR TITLE
[test] Fix energy reference value and difference of QE small

### DIFF
--- a/cscs-checks/apps/quantumespresso/quantumespresso_check.py
+++ b/cscs-checks/apps/quantumespresso/quantumespresso_check.py
@@ -3,7 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-import os
 import reframe as rfm
 import reframe.utility.sanity as sn
 

--- a/cscs-checks/apps/quantumespresso/quantumespresso_check.py
+++ b/cscs-checks/apps/quantumespresso/quantumespresso_check.py
@@ -98,7 +98,7 @@ class QuantumESPRESSOGpuCheck(QuantumESPRESSOCheck):
         if scale == 'small':
             self.valid_systems += ['dom:gpu']
             self.num_tasks = 6
-            energy_reference = -11427.09017176
+            energy_reference = -11427.09017168
         else:
             self.num_tasks = 16
             energy_reference = -11427.09017179

--- a/cscs-checks/apps/quantumespresso/quantumespresso_check.py
+++ b/cscs-checks/apps/quantumespresso/quantumespresso_check.py
@@ -56,7 +56,8 @@ class QuantumESPRESSOCpuCheck(QuantumESPRESSOCheck):
         energy_diff = sn.abs(energy-energy_reference)
         self.sanity_patterns = sn.all([
             self.sanity_patterns,
-# FIXME temporarily increase energy difference (different QE default on Dom and Daint)
+            # FIXME temporarily increase energy difference 
+            # (different QE default on Dom and Daint)
             sn.assert_lt(energy_diff, 1e-6)
         ])
 
@@ -111,7 +112,8 @@ class QuantumESPRESSOGpuCheck(QuantumESPRESSOCheck):
         energy_diff = sn.abs(energy-energy_reference)
         self.sanity_patterns = sn.all([
             self.sanity_patterns,
-# FIXME temporarily increase energy difference (different default CUDA on Dom and Daint)
+            # FIXME temporarily increase energy difference
+            # (different CUDA default on Dom and Daint)
             sn.assert_lt(energy_diff, 1e-7)
         ])
 

--- a/cscs-checks/apps/quantumespresso/quantumespresso_check.py
+++ b/cscs-checks/apps/quantumespresso/quantumespresso_check.py
@@ -44,7 +44,7 @@ class QuantumESPRESSOCpuCheck(QuantumESPRESSOCheck):
         if scale == 'small':
             self.valid_systems += ['dom:mc']
             self.num_tasks = 216
-            energy_reference = -11427.09017162
+            energy_reference = -11427.09017218
         else:
             self.num_tasks = 576
             energy_reference = -11427.09017152
@@ -56,7 +56,9 @@ class QuantumESPRESSOCpuCheck(QuantumESPRESSOCheck):
         energy_diff = sn.abs(energy-energy_reference)
         self.sanity_patterns = sn.all([
             self.sanity_patterns,
-            sn.assert_lt(energy_diff, 1e-7)
+# FIXME temporarily increase energy difference allowed by the sanity check
+# until we have different default QE versions on Dom and Piz Daint (mc)
+            sn.assert_lt(energy_diff, 1e-6)
         ])
 
         references = {
@@ -110,7 +112,9 @@ class QuantumESPRESSOGpuCheck(QuantumESPRESSOCheck):
         energy_diff = sn.abs(energy-energy_reference)
         self.sanity_patterns = sn.all([
             self.sanity_patterns,
-            sn.assert_lt(energy_diff, 1e-8)
+# FIXME temporarily increase energy difference allowed by the sanity check
+# until we have different default CUDA versions on Dom and Piz Daint (gpu)
+            sn.assert_lt(energy_diff, 1e-7)
         ])
 
         references = {

--- a/cscs-checks/apps/quantumespresso/quantumespresso_check.py
+++ b/cscs-checks/apps/quantumespresso/quantumespresso_check.py
@@ -56,8 +56,7 @@ class QuantumESPRESSOCpuCheck(QuantumESPRESSOCheck):
         energy_diff = sn.abs(energy-energy_reference)
         self.sanity_patterns = sn.all([
             self.sanity_patterns,
-# FIXME temporarily increase energy difference allowed by the sanity check
-# until we have different default QE versions on Dom and Piz Daint (mc)
+# FIXME temporarily increase energy difference (different QE default on Dom and Daint)
             sn.assert_lt(energy_diff, 1e-6)
         ])
 
@@ -112,8 +111,7 @@ class QuantumESPRESSOGpuCheck(QuantumESPRESSOCheck):
         energy_diff = sn.abs(energy-energy_reference)
         self.sanity_patterns = sn.all([
             self.sanity_patterns,
-# FIXME temporarily increase energy difference allowed by the sanity check
-# until we have different default CUDA versions on Dom and Piz Daint (gpu)
+# FIXME temporarily increase energy difference (different default CUDA on Dom and Daint)
             sn.assert_lt(energy_diff, 1e-7)
         ])
 

--- a/cscs-checks/apps/quantumespresso/quantumespresso_check.py
+++ b/cscs-checks/apps/quantumespresso/quantumespresso_check.py
@@ -56,7 +56,7 @@ class QuantumESPRESSOCpuCheck(QuantumESPRESSOCheck):
         energy_diff = sn.abs(energy-energy_reference)
         self.sanity_patterns = sn.all([
             self.sanity_patterns,
-            # FIXME temporarily increase energy difference 
+            # FIXME temporarily increase energy difference
             # (different QE default on Dom and Daint)
             sn.assert_lt(energy_diff, 1e-6)
         ])

--- a/cscs-checks/apps/quantumespresso/quantumespresso_check.py
+++ b/cscs-checks/apps/quantumespresso/quantumespresso_check.py
@@ -56,7 +56,7 @@ class QuantumESPRESSOCpuCheck(QuantumESPRESSOCheck):
         energy_diff = sn.abs(energy-energy_reference)
         self.sanity_patterns = sn.all([
             self.sanity_patterns,
-            sn.assert_lt(energy_diff, 1e-8)
+            sn.assert_lt(energy_diff, 1e-7)
         ])
 
         references = {


### PR DESCRIPTION
The fix applies to the modulefile `QuantumESPRESSO/6.6a2-CrayPGI-20.10-cuda`: the total energy of the small test case changed with the new Cray Programming Environment 20.10 and the new cudatoolkit 11.0. 