### PR TITLE
[test] Load cdt-cuda in dom for GPU checks

### DIFF
--- a/cscs-checks/microbenchmarks/gpu/gpu_burn/gpu_burn_test.py
+++ b/cscs-checks/microbenchmarks/gpu/gpu_burn/gpu_burn_test.py
@@ -83,7 +83,10 @@ class GpuBurnTest(rfm.RegressionTest):
         # Nvidia options
         if cs in {'dom', 'daint'}:
             gpu_arch = '60'
-            self.modules = ['craype-accel-nvidia60']
+            self.modules = ['cudatoolkit']
+            if cs == 'dom':
+                self.modules += ['cdt-cuda']
+
         elif cs in {'arola', 'tsa'}:
             gpu_arch = '70'
             self.modules = ['cuda/10.1.243']

--- a/cscs-checks/microbenchmarks/gpu/gpu_burn/gpu_burn_test.py
+++ b/cscs-checks/microbenchmarks/gpu/gpu_burn/gpu_burn_test.py
@@ -83,7 +83,7 @@ class GpuBurnTest(rfm.RegressionTest):
         # Nvidia options
         if cs in {'dom', 'daint'}:
             gpu_arch = '60'
-            self.modules = ['cudatoolkit']
+            self.modules = ['craype-accel-nvidia60']
             if cs == 'dom':
                 self.modules += ['cdt-cuda']
 

--- a/cscs-checks/microbenchmarks/gpu/kernel_latency/kernel_latency.py
+++ b/cscs-checks/microbenchmarks/gpu/kernel_latency/kernel_latency.py
@@ -117,7 +117,7 @@ class KernelLatencyTest(rfm.RegressionTest):
         if nvidia_sm:
             self.build_system.cxxflags += [f'-arch=sm_{nvidia_sm}']
             if cp in {'dom:gpu', 'daint:gpu'}:
-                self.modules += ['cudatoolkit']
+                self.modules = ['craype-accel-nvidia60']
                 if cp == 'dom:gpu':
                     self.modules += ['cdt-cuda']
 

--- a/cscs-checks/microbenchmarks/gpu/kernel_latency/kernel_latency.py
+++ b/cscs-checks/microbenchmarks/gpu/kernel_latency/kernel_latency.py
@@ -118,6 +118,9 @@ class KernelLatencyTest(rfm.RegressionTest):
             self.build_system.cxxflags += [f'-arch=sm_{nvidia_sm}']
             if cp in {'dom:gpu', 'daint:gpu'}:
                 self.modules += ['cudatoolkit']
+                if cp == 'dom:gpu':
+                    self.modules += ['cdt-cuda']
+
             else:
                 self.modules += ['cuda']
 

--- a/cscs-checks/microbenchmarks/gpu/memory_bandwidth/memory_bandwidth.py
+++ b/cscs-checks/microbenchmarks/gpu/memory_bandwidth/memory_bandwidth.py
@@ -103,7 +103,7 @@ class GpuBandwidthCheck(rfm.RegressionTest):
         if nvidia_sm:
             self.build_system.cxxflags += [f'-arch=sm_{nvidia_sm}']
             if cp in {'dom:gpu', 'daint:gpu'}:
-                self.modules += ['cudatoolkit']
+                self.modules += ['craype-accel-nvidia60']
                 if cp == 'dom:gpu':
                     self.modules += ['cdt-cuda']
 

--- a/cscs-checks/microbenchmarks/gpu/memory_bandwidth/memory_bandwidth.py
+++ b/cscs-checks/microbenchmarks/gpu/memory_bandwidth/memory_bandwidth.py
@@ -104,6 +104,9 @@ class GpuBandwidthCheck(rfm.RegressionTest):
             self.build_system.cxxflags += [f'-arch=sm_{nvidia_sm}']
             if cp in {'dom:gpu', 'daint:gpu'}:
                 self.modules += ['cudatoolkit']
+                if cp == 'dom:gpu':
+                    self.modules += ['cdt-cuda']
+
             else:
                 self.modules += ['cuda']
 

--- a/cscs-checks/microbenchmarks/gpu/shmem/shmem.py
+++ b/cscs-checks/microbenchmarks/gpu/shmem/shmem.py
@@ -87,7 +87,10 @@ class GPUShmemTest(rfm.RegressionTest):
         if nvidia_sm:
             self.build_system.cxxflags += [f'-arch=sm_{nvidia_sm}']
             if cp in {'dom:gpu', 'daint:gpu'}:
-                self.modules += ['craype-accel-nvidia60']
+                self.modules += ['cudatoolkit']
+                if cp == 'dom:gpu':
+                    self.modules += ['cdt-cuda']
+
             else:
                 self.modules += ['cuda']
 

--- a/cscs-checks/microbenchmarks/gpu/shmem/shmem.py
+++ b/cscs-checks/microbenchmarks/gpu/shmem/shmem.py
@@ -87,7 +87,7 @@ class GPUShmemTest(rfm.RegressionTest):
         if nvidia_sm:
             self.build_system.cxxflags += [f'-arch=sm_{nvidia_sm}']
             if cp in {'dom:gpu', 'daint:gpu'}:
-                self.modules += ['cudatoolkit']
+                self.modules += ['craype-accel-nvidia60']
                 if cp == 'dom:gpu':
                     self.modules += ['cdt-cuda']
 


### PR DESCRIPTION
Extended hook for `dom:gpu` so that the tests under `microbenchmarks/gpu` load the `cdt-cuda` module.