### PR TITLE
[test] Remove HPCG test workaround for unsupported OpenMP pragma

### DIFF
--- a/cscs-checks/microbenchmarks/hpcg/hpcg_benchmark.py
+++ b/cscs-checks/microbenchmarks/hpcg/hpcg_benchmark.py
@@ -21,11 +21,6 @@ class HPCGCheckRef(rfm.RegressionTest):
         self.build_system = 'Make'
         self.build_system.options = ['arch=MPI_GCC_OMP']
         self.sourcesdir = 'https://github.com/hpcg-benchmark/hpcg.git'
-
-        # FIXME: Remove this after the OpenMP pragma gets fixed in hpcg master
-        self.prebuild_cmds = [
-            'git checkout 9484cd7f2c4744c783abbdcfd4f5cc34807b42b1'
-        ]
         self.executable = 'bin/xhpcg'
         self.executable_opts = ['--nx=104', '--ny=104', '--nz=104', '-t2']
         # use glob to catch the output file suffix dependent on execution time
@@ -202,7 +197,7 @@ class HPCG_GPUCheck(rfm.RunOnlyRegressionTest):
         self.num_tasks = 0
         self.num_tasks_per_node = 1
         self.num_cpus_per_task = 12
-        self.variables  = {
+        self.variables = {
             'PMI_NO_FORK': '1',
             'MPICH_USE_DMAPP_COLL': '1',
             'OMP_SCHEDULE': 'static',


### PR DESCRIPTION
Removed no longer needed workaround for an issue with OMP.