### PR TITLE
[test] Put back import that registers magic command

### DIFF
--- a/cscs-checks/apps/jupyter/src/tf-hvd-sgd-ipc-tf2.py
+++ b/cscs-checks/apps/jupyter/src/tf-hvd-sgd-ipc-tf2.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
+import ipcmagic
 import ipyparallel as ipp
 
 

--- a/cscs-checks/apps/jupyter/src/tf-hvd-sgd-ipc-tf2.py
+++ b/cscs-checks/apps/jupyter/src/tf-hvd-sgd-ipc-tf2.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-import ipcmagic
+import ipcmagic  # noqa: F401
 import ipyparallel as ipp
 
 


### PR DESCRIPTION
`import ipcmagic` registers the magic command `%ipcluster`. The module is not used on the rest the code but without it script crashes.