### PR TITLE
[bugfix] Fix sanity function `print` to accept a single object only

### DIFF
--- a/reframe/utility/sanity.py
+++ b/reframe/utility/sanity.py
@@ -135,7 +135,8 @@ def print(obj, *, sep=' ', end='\n', file=None, flush=False):
 
     .. versionchanged:: 3.4
        This function accepts now a single object argument in contrast to the
-       built-in :func:`print() <python:print>` function, which accepts multiple.
+       built-in :func:`print() <python:print>` function, which accepts
+       multiple.
 
     '''
 

--- a/reframe/utility/sanity.py
+++ b/reframe/utility/sanity.py
@@ -112,13 +112,13 @@ def min(*args):
 
 
 @deferrable
-def print(*objects, sep=' ', end='\n', file=None, flush=False):
+def print(obj, *, sep=' ', end='\n', file=None, flush=False):
     '''Replacement for the built-in :func:`print() <python:print>` function.
 
-    The only difference is that this function returns the ``objects``, so that
-    you can use it transparently inside a complex sanity expression. For
-    example, you could write the following to print the matches returned from
-    the :func:`extractall()` function:
+    The only difference is that this function takes a *single* object argument
+    and it returns that, so that you can use it transparently inside a complex
+    sanity expression. For example, you could write the following to print the
+    matches returned from the :func:`extractall()` function:
 
     .. code:: python
 
@@ -132,13 +132,18 @@ def print(*objects, sep=' ', end='\n', file=None, flush=False):
     default. This would capture :attr:`sys.stdout` at the time this function
     is defined and would prevent it from seeing changes to :attr:`sys.stdout`,
     such as redirects, in the future.
+
+    .. versionchanged:: 3.4
+       This function accepts now a single object argument in contrast to the
+       built-in :func:`print() <python:print>` function, which accepts multiple.
+
     '''
 
     if file is None:
         file = sys.stdout
 
-    builtins.print(*objects, sep=sep, end=end, file=file, flush=flush)
-    return objects
+    builtins.print(obj, sep=sep, end=end, file=file, flush=flush)
+    return obj
 
 
 @deferrable

--- a/unittests/test_sanity_functions.py
+++ b/unittests/test_sanity_functions.py
@@ -148,41 +148,37 @@ def test_min():
 def test_print_stdout():
     stdout = io.StringIO()
     with contextlib.redirect_stdout(stdout):
-        x, y = sn.evaluate(sn.print(1, sn.defer(2)))
+        x = sn.evaluate(sn.print(sn.defer(2)))
 
-    assert stdout.getvalue() == '1 2\n'
-    assert x == 1
-    assert y == 2
+    assert stdout.getvalue() == '2\n'
+    assert x == 2
 
 
 def test_print_stderr():
     stderr = io.StringIO()
     with contextlib.redirect_stderr(stderr):
-        x, y = sn.evaluate(sn.print(1, sn.defer(2), file=sys.stderr))
+        x = sn.evaluate(sn.print(sn.defer(2), file=sys.stderr))
 
-    assert stderr.getvalue() == '1 2\n'
-    assert x == 1
-    assert y == 2
+    assert stderr.getvalue() == '2\n'
+    assert x == 2
 
 
 def test_print_separator():
     stdout = io.StringIO()
     with contextlib.redirect_stdout(stdout):
-        x, y = sn.evaluate(sn.print(1, sn.defer(2), sep='|'))
+        x = sn.evaluate(sn.print(sn.defer(2), sep='|'))
 
-    assert stdout.getvalue() == '1|2\n'
-    assert x == 1
-    assert y == 2
+    assert stdout.getvalue() == '2\n'
+    assert x == 2
 
 
 def test_print_end():
     stdout = io.StringIO()
     with contextlib.redirect_stdout(stdout):
-        x, y = sn.evaluate(sn.print(1, sn.defer(2), end=''))
+        x = sn.evaluate(sn.print(sn.defer(2), end=''))
 
-    assert stdout.getvalue() == '1 2'
-    assert x == 1
-    assert y == 2
+    assert stdout.getvalue() == '2'
+    assert x == 2
 
 
 def test_reversed():


### PR DESCRIPTION
I came up to this when preparing the tutorials. Currently you can't write `sn.assert_found('r'something', sn.print(self.stdout))`, because `sn.print()` would return you a tuple, which you would need to unpack. But if you try to unpack, you trigger the evaluation of the deferred expression, which you don't want. So the sanity version of the `print` is restricted to getting a single object only.