### PR TITLE
[bugfix] Ensure that job options passed from the command-line are always the last in the generated job script

### DIFF
--- a/reframe/core/launchers/mpi.py
+++ b/reframe/core/launchers/mpi.py
@@ -117,7 +117,7 @@ class SrunAllocationLauncher(JobLauncher):
             hint = 'multithread' if job.use_smt else 'nomultithread'
             ret += ['--hint=%s' % hint]
 
-        for opt in job.options + job.sched_options:
+        for opt in job.options + job.cli_options:
             if opt.startswith('#'):
                 continue
 

--- a/reframe/core/launchers/mpi.py
+++ b/reframe/core/launchers/mpi.py
@@ -117,7 +117,7 @@ class SrunAllocationLauncher(JobLauncher):
             hint = 'multithread' if job.use_smt else 'nomultithread'
             ret += ['--hint=%s' % hint]
 
-        for opt in job.options:
+        for opt in job.options + job.sched_options:
             if opt.startswith('#'):
                 continue
 

--- a/reframe/core/schedulers/__init__.py
+++ b/reframe/core/schedulers/__init__.py
@@ -180,7 +180,7 @@ class Job(jsonext.JSONSerializable):
         self.num_cpus_per_task = None
         self.use_smt = None
         self.time_limit = None
-        self.sched_options = list(sched_options) if sched_options else []
+        self.cli_options = list(sched_options) if sched_options else []
         self.options = []
 
         self._name = name

--- a/reframe/core/schedulers/__init__.py
+++ b/reframe/core/schedulers/__init__.py
@@ -180,7 +180,8 @@ class Job(jsonext.JSONSerializable):
         self.num_cpus_per_task = None
         self.use_smt = None
         self.time_limit = None
-        self.options = list(sched_options) if sched_options else []
+        self.sched_options = list(sched_options) if sched_options else []
+        self.options = []
 
         self._name = name
         self._workdir = workdir

--- a/reframe/core/schedulers/pbs.py
+++ b/reframe/core/schedulers/pbs.py
@@ -91,7 +91,7 @@ class PbsJobScheduler(sched.JobScheduler):
         # Options starting with `-` are emitted in separate lines
         rem_opts = []
         verb_opts = []
-        for opt in (*job.sched_access, *job.options):
+        for opt in (*job.sched_access, *job.options, *job.sched_options):
             if opt.startswith('-'):
                 rem_opts.append(opt)
             elif opt.startswith('#'):

--- a/reframe/core/schedulers/pbs.py
+++ b/reframe/core/schedulers/pbs.py
@@ -91,7 +91,7 @@ class PbsJobScheduler(sched.JobScheduler):
         # Options starting with `-` are emitted in separate lines
         rem_opts = []
         verb_opts = []
-        for opt in (*job.sched_access, *job.options, *job.sched_options):
+        for opt in (*job.sched_access, *job.options, *job.cli_options):
             if opt.startswith('-'):
                 rem_opts.append(opt)
             elif opt.startswith('#'):

--- a/reframe/core/schedulers/slurm.py
+++ b/reframe/core/schedulers/slurm.py
@@ -149,11 +149,11 @@ class SlurmJobScheduler(sched.JobScheduler):
         ]
 
         # Determine if job refers to a Slurm job array, by looking into the
-        # job.options and job.sched_options
+        # job.options and job.cli_options
         jobarr_parser = ArgumentParser()
         jobarr_parser.add_argument('-a', '--array')
         parsed_args, _ = jobarr_parser.parse_known_args(
-            job.options + job.sched_options
+            job.options + job.cli_options
         )
         if parsed_args.array:
             job._is_array = True
@@ -200,7 +200,7 @@ class SlurmJobScheduler(sched.JobScheduler):
         # NOTE: Here last of the passed --constraint job options is taken
         # into account in order to respect the behavior of slurm.
         parsed_options, _ = constraint_parser.parse_known_args(
-            job.options + job.sched_options
+            job.options + job.cli_options
         )
         if parsed_options.constraint:
             constraints.append(parsed_options.constraint.strip())
@@ -212,7 +212,7 @@ class SlurmJobScheduler(sched.JobScheduler):
 
         preamble.append(self._format_option(hint, '--hint={0}'))
         prefix_patt = re.compile(r'(#\w+)')
-        for opt in job.options + job.sched_options:
+        for opt in job.options + job.cli_options:
             if opt.strip().startswith(('-C', '--constraint')):
                 # Constraints are already processed
                 continue
@@ -271,7 +271,7 @@ class SlurmJobScheduler(sched.JobScheduler):
         # Collect options that restrict node selection, but we need to first
         # create a mutable list out of the immutable SequenceView that
         # sched_access is
-        options = list(job.sched_access + job.options + job.sched_options)
+        options = list(job.sched_access + job.options + job.cli_options)
         option_parser = ArgumentParser()
         option_parser.add_argument('--reservation')
         option_parser.add_argument('-p', '--partition')

--- a/reframe/core/schedulers/slurm.py
+++ b/reframe/core/schedulers/slurm.py
@@ -149,10 +149,12 @@ class SlurmJobScheduler(sched.JobScheduler):
         ]
 
         # Determine if job refers to a Slurm job array, by looking into the
-        # job.options
+        # job.options and job.sched_options
         jobarr_parser = ArgumentParser()
         jobarr_parser.add_argument('-a', '--array')
-        parsed_args, _ = jobarr_parser.parse_known_args(job.options)
+        parsed_args, _ = jobarr_parser.parse_known_args(
+            job.options + job.sched_options
+        )
         if parsed_args.array:
             job._is_array = True
             self.log('Slurm job is a job array')
@@ -197,7 +199,9 @@ class SlurmJobScheduler(sched.JobScheduler):
 
         # NOTE: Here last of the passed --constraint job options is taken
         # into account in order to respect the behavior of slurm.
-        parsed_options, _ = constraint_parser.parse_known_args(job.options)
+        parsed_options, _ = constraint_parser.parse_known_args(
+            job.options + job.sched_options
+        )
         if parsed_options.constraint:
             constraints.append(parsed_options.constraint.strip())
 
@@ -208,7 +212,7 @@ class SlurmJobScheduler(sched.JobScheduler):
 
         preamble.append(self._format_option(hint, '--hint={0}'))
         prefix_patt = re.compile(r'(#\w+)')
-        for opt in job.options:
+        for opt in job.options + job.sched_options:
             if opt.strip().startswith(('-C', '--constraint')):
                 # Constraints are already processed
                 continue
@@ -267,7 +271,7 @@ class SlurmJobScheduler(sched.JobScheduler):
         # Collect options that restrict node selection, but we need to first
         # create a mutable list out of the immutable SequenceView that
         # sched_access is
-        options = list(job.sched_access + job.options)
+        options = list(job.sched_access + job.options + job.sched_options)
         option_parser = ArgumentParser()
         option_parser.add_argument('--reservation')
         option_parser.add_argument('-p', '--partition')

--- a/unittests/test_launchers.py
+++ b/unittests/test_launchers.py
@@ -85,7 +85,7 @@ def job(make_job, launcher):
     job.num_cpus_per_task = 2
     job.use_smt = True
     job.time_limit = '10m'
-    job.options += ['--gres=gpu:4', '#DW jobdw anything']
+    job.options = ['--gres=gpu:4', '#DW jobdw anything']
     job.launcher.options = ['--foo']
     return job
 
@@ -130,8 +130,8 @@ def test_run_command(job):
                            '--cpus-per-task=2 '
                            '--exclusive '
                            '--hint=multithread '
-                           '--fake '
                            '--gres=gpu:4 '
+                           '--fake '
                            '--foo')
     elif launcher_name == 'ssh':
         assert command == 'ssh -o BatchMode=yes -l user -p 22222 --foo host'


### PR DESCRIPTION
Closes #1700 