### PR TITLE
[feat] Support multiple job submissions when slurm's job submit limit is reached

### DIFF
--- a/docs/config_reference.rst
+++ b/docs/config_reference.rst
@@ -1006,7 +1006,7 @@ Common scheduler options
    In such cases, you may set this parameter to ``true`` to avoid this.
 
 
-.. js:attribute:: .schedulers[].resubmit_on_qos_errors
+.. js:attribute:: .schedulers[].resubmit_on_errors
 
    :required: No
    :default: ``[]``
@@ -1014,10 +1014,11 @@ Common scheduler options
    This option is relevant to the Slurm backends only.
 
    When a job is submitted certain errors can be ignored and the framework will try to submit again the job after some seconds.
-   ReFrame is checking with a regular expression if any of the given expressions is contained in the ``stderr`` of the submission command.
-   Keep in mind that the submission is blocking and ReFrame will not continue until the submission is successful or has a different error.
+   An example of this could be QOS errors like ``QOSMaxSubmitJobPerUserLimit``, in which case you would have to set the option to ``["QOSMaxSubmitJobPerUserLimit"]``. You can ignore multiple errors at the same time if you include all the error strings in the list.
+   Job submission is a synchronous operation in ReFrame.
+   If this option is set, it will block the whole execution until the error conditions specified in this list are raised.
 
-   .. versionadded:: 3.4
+   .. versionadded:: 3.5
 
 
 Execution Mode Configuration

--- a/docs/config_reference.rst
+++ b/docs/config_reference.rst
@@ -1006,6 +1006,20 @@ Common scheduler options
    In such cases, you may set this parameter to ``true`` to avoid this.
 
 
+.. js:attribute:: .schedulers[].resubmit_on_qos_errors
+
+   :required: No
+   :default: ``[]``
+
+   This option is relevant to the Slurm backends only.
+
+   When a job is submitted certain errors can be ignored and the framework will try to submit again the job after some seconds.
+   ReFrame is checking with a regular expression if any of the given expressions is contained in the ``stderr`` of the submission command.
+   Keep in mind that the submission is blocking and ReFrame will not continue until the submission is successful or has a different error.
+
+   .. versionadded:: 3.4
+
+
 Execution Mode Configuration
 ----------------------------
 

--- a/docs/config_reference.rst
+++ b/docs/config_reference.rst
@@ -1013,12 +1013,16 @@ Common scheduler options
 
    This option is relevant to the Slurm backends only.
 
-   When a job is submitted certain errors can be ignored and the framework will try to submit again the job after some seconds.
-   An example of this could be QOS errors like ``QOSMaxSubmitJobPerUserLimit``, in which case you would have to set the option to ``["QOSMaxSubmitJobPerUserLimit"]``. You can ignore multiple errors at the same time if you include all the error strings in the list.
-   Job submission is a synchronous operation in ReFrame.
-   If this option is set, it will block the whole execution until the error conditions specified in this list are raised.
+   If any of the listed errors occur, ReFrame will try to resubmit the job after some seconds.
+   As an example, you could have ReFrame trying to resubmit a job in case that the maximum submission limit per user is reached by setting this field to ``["QOSMaxSubmitJobPerUserLimit"]``.
+   You can ignore multiple errors at the same time if you add more error strings in the list.
 
    .. versionadded:: 3.5
+
+   .. warning::
+      Job submission is a synchronous operation in ReFrame.
+      If this option is set, ReFrame's execution will block until the error conditions specified in this list are resolved.
+      No other test would be able to proceed.
 
 
 Execution Mode Configuration

--- a/reframe/core/schedulers/slurm.py
+++ b/reframe/core/schedulers/slurm.py
@@ -244,7 +244,7 @@ class SlurmJobScheduler(sched.JobScheduler):
 
                 t = next(intervals)
                 self.log(
-                    f'encountered a job submission error: {sbatch_error.group(1)}'
+                    f'encountered a job submission error: {error_match.group(1)}'
                     f'will resubmit after {t}s'
                 )
                 time.sleep(t)

--- a/reframe/core/schedulers/slurm.py
+++ b/reframe/core/schedulers/slurm.py
@@ -244,8 +244,8 @@ class SlurmJobScheduler(sched.JobScheduler):
 
                 t = next(intervals)
                 self.log(
-                    f'encountered a job submission error: {error_match.group(1)}'
-                    f'will resubmit after {t}s'
+                    f'encountered a job submission error: '
+                    f'{error_match.group(1)}: will resubmit after {t}s'
                 )
                 time.sleep(t)
 

--- a/reframe/core/schedulers/slurm.py
+++ b/reframe/core/schedulers/slurm.py
@@ -125,8 +125,8 @@ class SlurmJobScheduler(sched.JobScheduler):
         self._use_nodes_opt = rt.runtime().get_option(
             f'schedulers/@{self.registered_name}/use_nodes_option'
         )
-        self._block_submission = rt.runtime().get_option(
-            f'schedulers/@{self.registered_name}/block_submission'
+        self._resubmit_on_qos_errors = rt.runtime().get_option(
+            f'schedulers/@{self.registered_name}/resubmit_on_qos_errors'
         )
 
     def make_job(self, *args, **kwargs):
@@ -236,11 +236,10 @@ class SlurmJobScheduler(sched.JobScheduler):
                 completed = _run_strict(cmd, timeout=self._submit_timeout)
                 break
             except SpawnedProcessError as e:
-                sbatch_error = 'sbatch: error: QOSMaxSubmitJobPerUserLimit'
+                sbatch_error = '|'.join(self._resubmit_on_qos_errors)
                 if (
-                    not self._block_submission or
-                    e.exitcode != 1 or
-                    sbatch_error not in e.stderr
+                    not self._resubmit_on_qos_errors or
+                    not re.search(sbatch_error, e.stderr)
                 ):
                     raise e
 

--- a/reframe/core/schedulers/slurm.py
+++ b/reframe/core/schedulers/slurm.py
@@ -236,9 +236,10 @@ class SlurmJobScheduler(sched.JobScheduler):
                 completed = _run_strict(cmd, timeout=self._submit_timeout)
                 break
             except SpawnedProcessError as e:
-                sbatch_error = rf'({"|".join(self._resubmit_on_errors)})'
-                if (not self._resubmit_on_errors or
-                    not re.search(sbatch_error, e.stderr)):
+                error_match = re.search(
+                    rf'({"|".join(self._resubmit_on_errors)})', e.stderr
+                )
+                if not self._resubmit_on_errors or not error_match:
                     raise
 
                 t = next(intervals)

--- a/reframe/core/schedulers/slurm.py
+++ b/reframe/core/schedulers/slurm.py
@@ -236,9 +236,11 @@ class SlurmJobScheduler(sched.JobScheduler):
                 completed = _run_strict(cmd, timeout=self._submit_timeout)
                 break
             except SpawnedProcessError as e:
-                if (not self._block_submission or
+                sbatch_error = 'sbatch: error: QOSMaxSubmitJobPerUserLimit'
+                if (
+                    not self._block_submission or
                     e.exitcode != 1 or
-                    'sbatch: error: QOSMaxSubmitJobPerUserLimit' not in e.stderr
+                    sbatch_error not in e.stderr
                 ):
                     raise e
 

--- a/reframe/core/schedulers/slurm.py
+++ b/reframe/core/schedulers/slurm.py
@@ -125,8 +125,8 @@ class SlurmJobScheduler(sched.JobScheduler):
         self._use_nodes_opt = rt.runtime().get_option(
             f'schedulers/@{self.registered_name}/use_nodes_option'
         )
-        self._resubmit_on_qos_errors = rt.runtime().get_option(
-            f'schedulers/@{self.registered_name}/resubmit_on_qos_errors'
+        self._resubmit_on_errors = rt.runtime().get_option(
+            f'schedulers/@{self.registered_name}/resubmit_on_errors'
         )
 
     def make_job(self, *args, **kwargs):
@@ -236,11 +236,9 @@ class SlurmJobScheduler(sched.JobScheduler):
                 completed = _run_strict(cmd, timeout=self._submit_timeout)
                 break
             except SpawnedProcessError as e:
-                sbatch_error = '|'.join(self._resubmit_on_qos_errors)
-                if (
-                    not self._resubmit_on_qos_errors or
-                    not re.search(sbatch_error, e.stderr)
-                ):
+                sbatch_error = '|'.join(self._resubmit_on_errors)
+                if (not self._resubmit_on_errors or
+                    not re.search(sbatch_error, e.stderr)):
                     raise e
 
             time.sleep(next(intervals))

--- a/reframe/schemas/config.json
+++ b/reframe/schemas/config.json
@@ -293,7 +293,7 @@
                         "enum": ["local", "pbs", "slurm", "squeue", "torque"]
                     },
                     "ignore_reqnodenotavail": {"type": "boolean"},
-                    "resubmit_on_qos_errors": {
+                    "resubmit_on_errors": {
                         "type": "array",
                         "items": {"type": "string"}
                     },
@@ -449,7 +449,7 @@
         "modes/options": [],
         "modes/target_systems": ["*"],
         "schedulers/ignore_reqnodenotavail": false,
-        "resubmit_on_qos_errors": [],
+        "schedulers/resubmit_on_errors": [],
         "schedulers/job_submit_timeout": 60,
         "schedulers/target_systems": ["*"],
         "schedulers/use_nodes_option": false,

--- a/reframe/schemas/config.json
+++ b/reframe/schemas/config.json
@@ -293,7 +293,10 @@
                         "enum": ["local", "pbs", "slurm", "squeue", "torque"]
                     },
                     "ignore_reqnodenotavail": {"type": "boolean"},
-                    "block_submission": {"type": "boolean"},
+                    "resubmit_on_qos_errors": {
+                        "type": "array",
+                        "items": {"type": "string"}
+                    },
                     "job_submit_timeout": {"type": "number"},
                     "target_systems": {"$ref": "#/defs/system_ref"},
                     "use_nodes_option": {"type": "boolean"}
@@ -446,7 +449,7 @@
         "modes/options": [],
         "modes/target_systems": ["*"],
         "schedulers/ignore_reqnodenotavail": false,
-        "schedulers/block_submission": false,
+        "resubmit_on_qos_errors": [],
         "schedulers/job_submit_timeout": 60,
         "schedulers/target_systems": ["*"],
         "schedulers/use_nodes_option": false,

--- a/reframe/schemas/config.json
+++ b/reframe/schemas/config.json
@@ -293,6 +293,7 @@
                         "enum": ["local", "pbs", "slurm", "squeue", "torque"]
                     },
                     "ignore_reqnodenotavail": {"type": "boolean"},
+                    "block_submission": {"type": "boolean"},
                     "job_submit_timeout": {"type": "number"},
                     "target_systems": {"$ref": "#/defs/system_ref"},
                     "use_nodes_option": {"type": "boolean"}
@@ -445,6 +446,7 @@
         "modes/options": [],
         "modes/target_systems": ["*"],
         "schedulers/ignore_reqnodenotavail": false,
+        "schedulers/block_submission": false,
         "schedulers/job_submit_timeout": 60,
         "schedulers/target_systems": ["*"],
         "schedulers/use_nodes_option": false,


### PR DESCRIPTION
Second, much simpler implementation of #1672. In this PR the submission blocks until slurm stops giving the `QOSMaxSubmitJobPerUserLimit` error. This could cause significant slowdown of the jobs.
Closes #1595.