### PR TITLE
[bugfix] Skip test cases recursively in case of dangling dependencies

### DIFF
--- a/reframe/frontend/dependencies.py
+++ b/reframe/frontend/dependencies.py
@@ -61,7 +61,6 @@ def build_deps(cases, default_cases=None):
     # c stands for check or case depending on the context
     # p stands for partition
     # e stands for environment
-    # t stands for target
 
     # We use an ordered dict here, because we need to keep the order of
     # partitions and environments
@@ -79,8 +78,23 @@ def build_deps(cases, default_cases=None):
                     if when((psrc, esrc), (pdst, edst)):
                         c.deps.append(d)
         except DependencyError as e:
-            getlogger().warning(f'{e}; skipping test case...')
-            skipped_cases.append(c)
+            getlogger().warning(f'{e}; skipping dependent test cases:')
+
+            # FIXME: we need to unit test this properly
+            skip_nodes = {c}
+            while skip_nodes:
+                v = skip_nodes.pop()
+                skipped_cases.append(v)
+                getlogger().warning(f'  - {v}')
+                pruned_nodes = []
+                for u, adj in graph.items():
+                    if v in adj:
+                        skip_nodes.add(u)
+                        pruned_nodes.append(u)
+
+                for u in pruned_nodes:
+                    del graph[u]
+
             continue
 
         graph[c] = util.OrderedSet(c.deps)


### PR DESCRIPTION
When `A -> B -> C -> D`, if `D` is missing, we should skip all of `A`, `B` and `C`, i.e., we need to recursively skip all the test cases that depend on the missing one. This currently leads to a crash. Since this urgent, because it breaks the tutorials in #1692 I suggest merging this asap for 3.4. We will add proper unit tests for it in 3.5.