### PR TITLE
[test] Constrain flexible node allocation on the HPCG check

### DIFF
--- a/cscs-checks/microbenchmarks/hpcg/hpcg_benchmark.py
+++ b/cscs-checks/microbenchmarks/hpcg/hpcg_benchmark.py
@@ -17,12 +17,13 @@ class HPCGHookMixin(rfm.RegressionTest):
         ntasks_per_node = self.num_tasks_per_node or 1
         self.job.num_tasks_per_node = ntasks_per_node
         n = int(self.job.guess_num_tasks()/ntasks_per_node)
+
         def first_factor(x):
             if x <= 1:
                 return 1
 
             for i in range(2, x+1):
-                if x%i == 0:
+                if x % i == 0:
                     return i
 
         def is_prime(x):

--- a/cscs-checks/microbenchmarks/hpcg/hpcg_benchmark.py
+++ b/cscs-checks/microbenchmarks/hpcg/hpcg_benchmark.py
@@ -8,7 +8,7 @@ import reframe as rfm
 import reframe.utility.sanity as sn
 
 
-class HPCGHookMixin(rfm.RegressionTest):
+class HPCGHookMixin:
     @rfm.run_before('run')
     def guide_node_guess(self):
         '''Guide the node guess based on the test's needs.'''
@@ -36,7 +36,7 @@ class HPCGHookMixin(rfm.RegressionTest):
 
             # If x==1, n is prime
             # if x > 8 and prime, it would also not meet HPCG's aspect ratio
-            if x == 1 or is_prime(x) and x > 8:
+            if x == 1 or (is_prime(x) and x > 8):
                 n -= 1
             else:
                 break
@@ -45,9 +45,8 @@ class HPCGHookMixin(rfm.RegressionTest):
         self.num_tasks_per_node = ntasks_per_node
 
 
-@rfm.required_version('>=2.16-dev0')
 @rfm.simple_test
-class HPCGCheckRef(HPCGHookMixin):
+class HPCGCheckRef(rfm.RegressionTest, HPCGHookMixin):
     def __init__(self):
         self.descr = 'HPCG reference benchmark'
         self.valid_systems = ['daint:mc', 'daint:gpu', 'dom:gpu', 'dom:mc']
@@ -120,9 +119,8 @@ class HPCGCheckRef(HPCGHookMixin):
         ])
 
 
-@rfm.required_version('>=2.16-dev0')
 @rfm.simple_test
-class HPCGCheckMKL(HPCGHookMixin):
+class HPCGCheckMKL(rfm.RegressionTest, HPCGHookMixin):
     def __init__(self):
         self.descr = 'HPCG benchmark Intel MKL implementation'
         self.valid_systems = ['daint:mc', 'dom:mc', 'daint:gpu', 'dom:gpu']


### PR DESCRIPTION
The HPCG test requires the number of nodes to be factored into `N=nx*ny*nx`, where `max(nx, ny, nz)/min(nx, ny, nz) >= 8`.
Thus, since this case is a flexible test, some guidance is needed to have the 'raw' slurm node guess educated into something the HPCG tests can work with (for example, if the number of available nodes in the system is a prime number, the above factorisation is impossible).
 
This PR solves this issue by adding a hook into the `pre_run` stage of these tests. The hook simply does the node guess in advance and makes sure that the number of nodes is a sensible one. With this 'constrained' number of nodes we set `self.num_tasks` in the test, which avoids reframe to query for the available number of nodes again at a later stage.