### PR TITLE
[dom] Temporary fix for GridTools build on dom

### DIFF
--- a/cscs-checks/libraries/gridtools/gridtools_tests.py
+++ b/cscs-checks/libraries/gridtools/gridtools_tests.py
@@ -28,7 +28,7 @@ class GridToolsBuildCheck(rfm.CompileOnlyRegressionTest):
         ]
         self.build_system.flags_from_environ = False
         self.build_system.make_opts = ['perftests']
-        self.build_system.max_concurrency = 2
+        self.build_system.max_concurrency = 8
         self.postbuild_cmds = ['ls tests/regression/']
         self.sanity_patterns = sn.assert_found(r'perftest',
                                                self.stdout)
@@ -53,12 +53,14 @@ class GridToolsGPUBuildCheck(GridToolsBuildCheck):
         super().__init__()
         self.descr = 'GridTools GPU build test'
         if self.current_system.name == 'dom':
-            self.modules.append(
-                'cudatoolkit/10.2.89_3.29-7.0.2.1_3.5__g67354b4')
-            self.modules.append('cdt-cuda/20.10')
-            self.modules.append('gcc/8.3.0')
+            self.modules += [
+                'cudatoolkit/10.2.89_3.29-7.0.2.1_3.5__g67354b4',
+                'cdt-cuda/20.10',
+                'gcc/8.3.0'
+            ]
         else:
             self.modules.append('cudatoolkit')
+
         self.build_system.config_opts += [
             '-DGT_CUDA_ARCH=sm_60',
             '-DGT_TESTS_REQUIRE_GPU="ON"'

--- a/cscs-checks/libraries/gridtools/gridtools_tests.py
+++ b/cscs-checks/libraries/gridtools/gridtools_tests.py
@@ -52,7 +52,13 @@ class GridToolsGPUBuildCheck(GridToolsBuildCheck):
     def __init__(self):
         super().__init__()
         self.descr = 'GridTools GPU build test'
-        self.modules.append('cudatoolkit')
+        if self.current_system.name == 'dom':
+            self.modules.append(
+                'cudatoolkit/10.2.89_3.29-7.0.2.1_3.5__g67354b4')
+            self.modules.append('cdt-cuda/20.10')
+            self.modules.append('gcc/8.3.0')
+        else:
+            self.modules.append('cudatoolkit')
         self.build_system.config_opts += [
             '-DGT_CUDA_ARCH=sm_60',
             '-DGT_TESTS_REQUIRE_GPU="ON"'


### PR DESCRIPTION
This is a temporary fix for the GridTools build issue on Dom reported here: https://jira.cscs.ch/browse/UES-1382