### PR TITLE
[bugfix] Fix parameter value specification in the `parameter()` directive

### DIFF
--- a/docs/regression_test_api.rst
+++ b/docs/regression_test_api.rst
@@ -48,7 +48,7 @@ For example, a test can be parameterized using the :func:`parameter` directive a
 .. code:: python
 
     class MyTest(rfm.RegressionTest):
-        parameter('variant', 'A', 'B')
+        parameter('variant', ['A', 'B'])
  
         def __init__(self):
             if self.variant == 'A':
@@ -71,14 +71,14 @@ For instance, continuing with the example above, one could override the :func:`_
                 override_other()
 
 
-.. py:function:: reframe.core.pipeline.RegressionTest.parameter(name, *values, inherit_params=False, filter_params=None)
+.. py:function:: reframe.core.pipeline.RegressionTest.parameter(name, values=None, inherit_params=False, filter_params=None)
 
    Inserts or modifies a regression test parameter.
    If a parameter with a matching name is already present in the parameter space of a parent class, the existing parameter values will be combined with those provided by this method following the inheritance behaviour set by the arguments ``inherit_params`` and ``filter_params``.
    Instead, if no parameter with a matching name exists in any of the parent parameter spaces, a new regression test parameter is created.
 
-   :param name: the parameter name.
-   :param values: the parameter values.
+   :param name: The parameter name.
+   :param values: A list containing the parameter values.
        If no values are passed when creating a new parameter, the parameter is considered as *declared* but not *defined* (i.e. an abstract parameter).
        Instead, for an existing parameter, this depends on the parameter's inheritance behaviour and on whether any values where provided in any of the parent parameter spaces.
    :param inherit_params: If :obj:`False`, no parameter values that may have been defined in any of the parent parameter spaces will be inherited.

--- a/reframe/core/parameters.py
+++ b/reframe/core/parameters.py
@@ -23,8 +23,11 @@ class _TestParameter:
     parameter space is built.
     '''
 
-    def __init__(self, name, *values,
+    def __init__(self, name, values=None,
                  inherit_params=False, filter_params=None):
+        if values is None:
+            values = []
+
         # By default, filter out all the parameter values defined in the
         # base classes.
         if not inherit_params:
@@ -38,7 +41,7 @@ class _TestParameter:
                 return x
 
         self.name = name
-        self.values = values
+        self.values = tuple(values)
         self.filter_params = filter_params
 
 
@@ -81,7 +84,7 @@ class LocalParamSpace:
                 f'parameter {name!r} already defined in this class'
             )
 
-    def add_param(self, name, *values, **kwargs):
+    def add_param(self, name, values=None, **kwargs):
         '''Insert or modify a regression test parameter.
 
         This method must be called directly in the class body. For each
@@ -94,7 +97,7 @@ class LocalParamSpace:
            :ref:`directives`
 
         '''
-        self[name] = _TestParameter(name, *values, **kwargs)
+        self[name] = _TestParameter(name, values, **kwargs)
 
     @property
     def params(self):

--- a/unittests/test_parameters.py
+++ b/unittests/test_parameters.py
@@ -15,8 +15,8 @@ class NoParams(rfm.RunOnlyRegressionTest):
 
 
 class TwoParams(NoParams):
-    parameter('P0', 'a')
-    parameter('P1', 'b')
+    parameter('P0', ['a'])
+    parameter('P1', ['b'])
 
 
 class Abstract(TwoParams):
@@ -24,8 +24,8 @@ class Abstract(TwoParams):
 
 
 class ExtendParams(TwoParams):
-    parameter('P1', 'c', 'd', 'e', inherit_params=True)
-    parameter('P2', 'f', 'g')
+    parameter('P1', ['c', 'd', 'e'], inherit_params=True)
+    parameter('P2', ['f', 'g'])
 
 
 def test_param_space_is_empty():
@@ -53,7 +53,7 @@ def test_abstract_param():
 
 def test_param_override():
     class MyTest(TwoParams):
-        parameter('P1', '-')
+        parameter('P1', ['-'])
 
     assert MyTest.param_space['P0'] == ('a',)
     assert MyTest.param_space['P1'] == ('-',)
@@ -61,7 +61,7 @@ def test_param_override():
 
 def test_param_inheritance():
     class MyTest(TwoParams):
-        parameter('P1', 'c', inherit_params=True)
+        parameter('P1', ['c'], inherit_params=True)
 
     assert MyTest.param_space['P0'] == ('a',)
     assert MyTest.param_space['P1'] == ('b', 'c',)


### PR DESCRIPTION
On its current state, the parameters are specified in a class as
```python
class Test(rfm.RegressionTest):
    parameter('P0', 1, 2, 3 , 4, 5)
```
This PR will change the parameter definition to
```python
class Test(rfm.RegressionTest):
    parameter('P0', [1, 2, 3 , 4, 5])
```
