### PR TITLE
[test] Adjust regex patterns for CP2K 8.1

### DIFF
--- a/cscs-checks/apps/cp2k/cp2k_check.py
+++ b/cscs-checks/apps/cp2k/cp2k_check.py
@@ -15,14 +15,14 @@ class Cp2kCheck(rfm.RunOnlyRegressionTest):
         self.executable_opts = ['H2O-256.inp']
 
         energy = sn.extractsingle(r'\s+ENERGY\| Total FORCE_EVAL \( QS \) '
-                                  r'energy \(a\.u\.\):\s+(?P<energy>\S+)',
+                                  r'energy [\[\(]a\.u\.[\]\)]:\s+(?P<energy>\S+)',
                                   self.stdout, 'energy', float, item=-1)
         energy_reference = -4404.2323
         energy_diff = sn.abs(energy-energy_reference)
         self.sanity_patterns = sn.all([
             sn.assert_found(r'PROGRAM STOPPED IN', self.stdout),
             sn.assert_eq(sn.count(sn.extractall(
-                r'(?P<step_count>STEP NUM)',
+                r'(?i)(?P<step_count>STEP NUMBER)',
                 self.stdout, 'step_count')), 10),
             sn.assert_lt(energy_diff, 1e-4)
         ])


### PR DESCRIPTION
The pull request addresses minor changes in the output of CP2K 8.1 with respect to previous releases:
- the step keyword `STEP NUMBER` now becomes `MD| Step number`
- the energy units `(a.u.)` are now enclosed in square branckets `[a.u.]`