### PR TITLE
[test] Fix minor bug in sanity pattern for GPU burn test

### DIFF
--- a/cscs-checks/microbenchmarks/gpu/gpu_burn/gpu_burn_test.py
+++ b/cscs-checks/microbenchmarks/gpu/gpu_burn/gpu_burn_test.py
@@ -25,8 +25,8 @@ class GpuBurnTest(rfm.RegressionTest):
         self.num_tasks = 0
         self.num_tasks_per_node = 1
         self.sanity_patterns = self.assert_num_tasks()
-        patt = (r'^\s*\[[^\]]*\]\s*GPU\s+\d+\(\S*\): (?P<perf>\S*) GF\/s  '
-                r'(?P<temp>\S*) Celsius')
+        patt = (r'^\s*\[[^\]]*\]\s*GPU\s+\d+\(\S*\):\s+(?P<perf>\S*)\s+GF\/s\s+'
+                r'(?P<temp>\S*)\s+Celsius')
         self.perf_patterns = {
             'perf': sn.min(sn.extractall(patt, self.stdout, 'perf', float)),
             'temp': sn.max(sn.extractall(patt, self.stdout, 'temp', float)),
@@ -71,7 +71,7 @@ class GpuBurnTest(rfm.RegressionTest):
     @sn.sanity_function
     def assert_num_tasks(self):
         return sn.assert_eq(sn.count(sn.findall(
-            r'^\s*\[[^\]]*\]\s*GPU\s*\d+\s*\(OK\)', self.stdout)
+            r'^\s*\[[^\]]*\]\s*GPU\s*\d+\(OK\)', self.stdout)
         ), self.num_tasks_assigned)
 
     @rfm.run_before('compile')

--- a/cscs-checks/microbenchmarks/gpu/gpu_burn/gpu_burn_test.py
+++ b/cscs-checks/microbenchmarks/gpu/gpu_burn/gpu_burn_test.py
@@ -25,8 +25,8 @@ class GpuBurnTest(rfm.RegressionTest):
         self.num_tasks = 0
         self.num_tasks_per_node = 1
         self.sanity_patterns = self.assert_num_tasks()
-        patt = (r'^\s*\[[^\]]*\]\s*GPU\s+\d+\(\S*\):\s+(?P<perf>\S*)\s+GF\/s\s+'
-                r'(?P<temp>\S*)\s+Celsius')
+        patt = (r'^\s*\[[^\]]*\]\s*GPU\s+\d+\(\S*\):\s+(?P<perf>\S*)\s+GF\/s'
+                r'\s+(?P<temp>\S*)\s+Celsius')
         self.perf_patterns = {
             'perf': sn.min(sn.extractall(patt, self.stdout, 'perf', float)),
             'temp': sn.max(sn.extractall(patt, self.stdout, 'temp', float)),


### PR DESCRIPTION
The perf value may have two space in front of it if <1000.
There is never a space between the GPU number and the (OK) value.