### PR TITLE
[feat] Comply with the semantic versioning specification

### DIFF
--- a/reframe/__init__.py
+++ b/reframe/__init__.py
@@ -6,8 +6,7 @@
 import os
 import sys
 
-
-VERSION = '3.5-dev1'
+VERSION = '3.5.0-dev.1'
 INSTALL_PREFIX = os.path.normpath(
     os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 )

--- a/reframe/core/decorators.py
+++ b/reframe/core/decorators.py
@@ -19,7 +19,6 @@ import inspect
 import sys
 import traceback
 
-import reframe
 import reframe.utility.osext as osext
 from reframe.core.exceptions import ReframeSyntaxError, user_frame
 from reframe.core.logging import getlogger

--- a/reframe/core/decorators.py
+++ b/reframe/core/decorators.py
@@ -20,6 +20,7 @@ import sys
 import traceback
 
 import reframe
+import reframe.utility.osext as osext
 from reframe.core.exceptions import ReframeSyntaxError, user_frame
 from reframe.core.logging import getlogger
 from reframe.core.pipeline import RegressionTest
@@ -168,7 +169,7 @@ def required_version(*versions):
         if not hasattr(mod, '__rfm_skip_tests'):
             mod.__rfm_skip_tests = set()
 
-        if not any(c.validate(reframe.VERSION) for c in conditions):
+        if not any(c.validate(osext.reframe_version()) for c in conditions):
             getlogger().info('skipping incompatible test defined'
                              ' in class: %s' % cls.__name__)
             mod.__rfm_skip_tests.add(cls)

--- a/reframe/core/decorators.py
+++ b/reframe/core/decorators.py
@@ -139,8 +139,6 @@ def required_version(*versions):
     If the test is not compatible with the current ReFrame version it will be
     skipped.
 
-    .. versionadded:: 2.13
-
     :arg versions: A list of ReFrame version specifications that this test is
       allowed to run. A version specification string can have one of the
       following formats:
@@ -148,15 +146,25 @@ def required_version(*versions):
       1. ``VERSION``: Specifies a single version.
       2. ``{OP}VERSION``, where ``{OP}`` can be any of ``>``, ``>=``, ``<``,
          ``<=``, ``==`` and ``!=``. For example, the version specification
-         string ``'>=2.15'`` will allow the following test to be loaded only
-         by ReFrame 2.15 and higher. The ``==VERSION`` specification is the
+         string ``'>=3.5.0'`` will allow the following test to be loaded only
+         by ReFrame 3.5.0 and higher. The ``==VERSION`` specification is the
          equivalent of ``VERSION``.
       3. ``V1..V2``: Specifies a range of versions.
 
       You can specify multiple versions with this decorator, such as
-      ``@required_version('2.13', '>=2.16')``, in which case the test will be
+      ``@required_version('3.5.1', '>=3.5.6')``, in which case the test will be
       selected if *any* of the versions is satisfied, even if the versions
       specifications are conflicting.
+
+    .. versionadded:: 2.13
+
+    .. versionchanged:: 3.5.0
+
+       Passing ReFrame version numbers that do not comply with the `semantic
+       versioning <https://semver.org/>`__ specification is deprecated.
+       Examples of non-compliant version numbers are ``3.5`` and ``3.5-dev0``.
+       These should be written as ``3.5.0`` and ``3.5.0-dev.0``.
+
     '''
     if not versions:
         raise ValueError('no versions specified')

--- a/reframe/frontend/runreport.py
+++ b/reframe/frontend/runreport.py
@@ -11,10 +11,10 @@ import re
 import reframe as rfm
 import reframe.core.exceptions as errors
 import reframe.utility.jsonext as jsonext
-from reframe.utility.versioning import Version
+import reframe.utility.versioning as versioning
 
 
-DATA_VERSION = '1.3'
+DATA_VERSION = '1.3.0'
 _SCHEMA = os.path.join(rfm.INSTALL_PREFIX, 'reframe/schemas/runreport.json')
 
 
@@ -141,8 +141,10 @@ def load_report(filename):
         raise errors.ReframeError(f'invalid report {filename!r}') from e
 
     # Check if the report data is compatible
-    found_ver = Version(report['session_info']['data_version'])
-    required_ver = Version(DATA_VERSION)
+    found_ver = versioning.parse(
+        report['session_info']['data_version']
+    )
+    required_ver = versioning.parse(DATA_VERSION)
     if found_ver.major != required_ver.major or found_ver < required_ver:
         raise errors.ReframeError(
             f'incompatible report data versions: '

--- a/reframe/utility/osext.py
+++ b/reframe/utility/osext.py
@@ -13,6 +13,7 @@ import getpass
 import grp
 import os
 import re
+import semver
 import shlex
 import shutil
 import signal
@@ -481,15 +482,16 @@ def git_repo_hash(commit='HEAD', short=True, wd=None):
 def reframe_version():
     '''Return ReFrame version.
 
-    If ReFrame's installation contains the repository metadata, the
-    repository's hash will be appended to the actual version.
+    If ReFrame's installation contains the repository metadata and the current
+    version is a pre-release version, the repository's hash will be appended
+    to the actual version.
+
     '''
-    version = reframe.VERSION
     repo_hash = git_repo_hash()
-    if repo_hash:
-        return '%s (rev: %s)' % (version, repo_hash)
+    if repo_hash and semver.VersionInfo.parse(reframe.VERSION).prerelease:
+        return f'{reframe.VERSION}+{repo_hash}'
     else:
-        return version
+        return reframe.VERSION
 
 
 def expandvars(s):

--- a/reframe/utility/versioning.py
+++ b/reframe/utility/versioning.py
@@ -4,11 +4,9 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 import abc
-import semver
-import sys
 import re
+import semver
 
-import reframe
 from reframe.core.warnings import user_deprecation_warning
 
 
@@ -18,8 +16,6 @@ def parse(version_str):
 
     :returns: a :class:`semver.VersionInfo` object.
     '''
-
-    import re
 
     compat = False
     old_style_stable = re.search(r'^(\d+)\.(\d+)$', version_str)

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ pytest-forked==1.3.0
 pytest-parallel==0.1.0
 PyYAML==5.3.1
 requests==2.25.1
+semver==2.13.0
 setuptools==50.3.0
 wcwidth==0.2.5
 #+pygelf%pygelf==0.3.6

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setuptools.setup(
     ),
     package_data={'reframe': ['schemas/*']},
     include_package_data=True,
-    install_requires=['argcomplete', 'jsonschema', 'PyYAML'],
+    install_requires=['argcomplete', 'jsonschema', 'PyYAML', 'semver'],
     python_requires='>=3.6',
     scripts=['bin/reframe'],
     classifiers=(

--- a/unittests/test_versioning.py
+++ b/unittests/test_versioning.py
@@ -4,8 +4,6 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 import pytest
-import semver
-
 import reframe.core.warnings as warnings
 import reframe.utility.versioning as versioning
 

--- a/unittests/test_warnings.py
+++ b/unittests/test_warnings.py
@@ -1,6 +1,8 @@
 import pytest
+import semver
 import warnings
 
+import reframe
 import reframe.core.runtime as rt
 import reframe.core.warnings as warn
 import reframe.utility.color as color
@@ -17,6 +19,11 @@ def with_colors(request):
 def test_deprecation_warning():
     with pytest.warns(warn.ReframeDeprecationWarning):
         warn.user_deprecation_warning('deprecated')
+
+
+def test_deprecation_warning_from_version():
+    next_version = semver.VersionInfo.parse(reframe.VERSION).bump_minor()
+    warn.user_deprecation_warning('deprecated', str(next_version))
 
 
 def test_deprecation_warning_formatting(with_colors):


### PR DESCRIPTION
This PR also adds the following:

- Expand deprecation message function to issue deprecation warnings in future releases.
- Old style of version specification is set to deprecate in 3.5.0

TODO:

- [x] Update documentation of the `@required_version` decorator.

~~NOTE: The CI will fail due to an irrelevant reason. A separate PR will fix that (it's Gitlab CI lint failure)~~