### PR TITLE
[bugfix] Print a FAILURE result if not all test cases have completed

### DIFF
--- a/reframe/frontend/executors/__init__.py
+++ b/reframe/frontend/executors/__init__.py
@@ -415,7 +415,7 @@ class Runner:
             # Print the summary line
             num_failures = len(self._stats.failed())
             num_completed = len(self._stats.completed())
-            if num_failures:
+            if num_failures > 0 or num_completed < len(testcases):
                 status = 'FAILED'
             else:
                 status = 'PASSED'


### PR DESCRIPTION
ReFrame will now also print `FAILURE` as the final result in cases where not all test cases have been run. This covers cases such as #1740, where errors occur during polling.

Fixes #1740.