### PR TITLE
[feat] Allow deprecation of fields in a future version and issue deprecation warnings also in prereleases

### DIFF
--- a/reframe/core/fields.py
+++ b/reframe/core/fields.py
@@ -136,19 +136,20 @@ class DeprecatedField(Field):
     def __set_name__(self, owner, name):
         self._target_field.__set_name__(owner, name)
 
-    def __init__(self, target_field, message, op=OP_ALL):
+    def __init__(self, target_field, message, op=OP_ALL, from_version='0.0.0'):
         self._target_field = target_field
         self._message = message
         self._op = op
+        self._from_version = from_version
 
     def __set__(self, obj, value):
         if self._op & DeprecatedField.OP_SET:
-            user_deprecation_warning(self._message)
+            user_deprecation_warning(self._message, self._from_version)
 
         self._target_field.__set__(obj, value)
 
     def __get__(self, obj, objtype):
         if self._op & DeprecatedField.OP_GET:
-            user_deprecation_warning(self._message)
+            user_deprecation_warning(self._message, self._from_version)
 
         return self._target_field.__get__(obj, objtype)

--- a/reframe/core/warnings.py
+++ b/reframe/core/warnings.py
@@ -74,7 +74,14 @@ def user_deprecation_warning(message, from_version='0.0.0'):
         stack_level += 1
 
     min_version = semver.VersionInfo.parse(from_version)
+
     version = semver.VersionInfo.parse(reframe.VERSION)
+    if version.prerelease:
+        # Promote prereleases, so that we issue the warning also in this case
+        version = semver.VersionInfo(
+            version.major, version.minor, version.patch
+        )
+
     if _RAISE_DEPRECATION_ALWAYS or version >= min_version:
         warnings.warn(message, ReframeDeprecationWarning,
                       stacklevel=stack_level)

--- a/unittests/resources/checks_unlisted/good.py
+++ b/unittests/resources/checks_unlisted/good.py
@@ -57,7 +57,7 @@ class AnotherBaseTest(_Base):
         return 'AnotherBaseTest(%s, %s)' % (self.a, self.b)
 
 
-@rfm.required_version('>=2.13-dev1')
+@rfm.required_version('>=2.13.0-dev.1')
 @rfm.simple_test
 class MyTest(MyBaseTest):
     def __init__(self):
@@ -67,6 +67,6 @@ class MyTest(MyBaseTest):
 # We intentionally have swapped the order of the two decorators here.
 # The order should not play any role.
 @rfm.simple_test
-@rfm.required_version('<=2.12')
+@rfm.required_version('<=2.12.0')
 class InvalidTest(MyBaseTest):
     pass

--- a/unittests/test_policies.py
+++ b/unittests/test_policies.py
@@ -211,7 +211,7 @@ def test_runall(make_runner, make_cases, common_exec_ctx, tmp_path):
         runreport.load_report(tmp_path / 'invalid.json')
 
     # Generate a report with an incorrect data version
-    report['session_info']['data_version'] = '10.0'
+    report['session_info']['data_version'] = '10.0.0'
     with open(tmp_path / 'invalid-version.json', 'w') as fp:
         jsonext.dump(report, fp)
 

--- a/unittests/test_warnings.py
+++ b/unittests/test_warnings.py
@@ -23,7 +23,9 @@ def test_deprecation_warning():
 
 def test_deprecation_warning_from_version():
     next_version = semver.VersionInfo.parse(reframe.VERSION).bump_minor()
-    warn.user_deprecation_warning('deprecated', str(next_version))
+    with warnings.catch_warnings(record=True) as w:
+        warn.user_deprecation_warning('deprecated', str(next_version))
+        assert len(w) == 0
 
 
 def test_deprecation_warning_formatting(with_colors):

--- a/unittests/test_warnings.py
+++ b/unittests/test_warnings.py
@@ -22,10 +22,16 @@ def test_deprecation_warning():
 
 
 def test_deprecation_warning_from_version():
-    next_version = semver.VersionInfo.parse(reframe.VERSION).bump_minor()
+    version = semver.VersionInfo.parse(reframe.VERSION).bump_minor()
     with warnings.catch_warnings(record=True) as w:
-        warn.user_deprecation_warning('deprecated', str(next_version))
+        warn.user_deprecation_warning('deprecated', str(version))
         assert len(w) == 0
+
+
+def test_deprecation_warning_from_prerelease_version(monkeypatch):
+    monkeypatch.setattr(reframe, 'VERSION', '1.0.0-dev.0')
+    with pytest.warns(warn.ReframeDeprecationWarning):
+        warn.user_deprecation_warning('deprecated', '1.0.0')
 
 
 def test_deprecation_warning_formatting(with_colors):


### PR DESCRIPTION
Also:

- Make unit tests for deprecation warnings more robust
-  Ignore prereleases when filtering deprecation warnings. For example, if we are on 3.5.0-dev.0 and a feature is set to deprecate in 3.5.0, then we issue the deprecation warning also for the prerelease.
- Fix deprecation warnings introduced by #1761.

This is a follow up of #1761.