### PR TITLE
[feat] Support parameter and variable access directly from the class body

### DIFF
--- a/docs/regression_test_api.rst
+++ b/docs/regression_test_api.rst
@@ -59,6 +59,7 @@ In essence, these builtins exert control over the test creation, and they allow 
 
     class Foo(rfm.RegressionTest):
         variant = parameter(['A', 'B'])
+        # print(variant) # Error: a parameter may only be accessed from the class instance.
 
         def __init__(self):
             if self.variant == 'A':
@@ -67,8 +68,9 @@ In essence, these builtins exert control over the test creation, and they allow 
                 do_other()
 
   One of the most powerful features about these built-in functions is that they store their input information at the class level. 
-  This means if one were to extend or specialize an existing regression test, the test attribute additions and modifications made through built-in functions in the parent class will be automatically inherited by the child test.
-  For instance, continuing with the example above, one could override the :func:`__init__` method in the :class:`MyTest` regression test as follows:
+  However, a parameter may only be accessed from the class instance and accessing it directly from the class body is disallowed.
+  With this approach, extending or specializing an existing parametrized regression test becomes straightforward, since the test attribute additions and modifications made through built-in functions in the parent class are automatically inherited by the child test.
+  For instance, continuing with the example above, one could override the :func:`__init__` method in the :class:`Foo` regression test as follows:
 
   .. code:: python
 
@@ -124,7 +126,7 @@ In essence, these builtins exert control over the test creation, and they allow 
 
     class Foo(rfm.RegressionTest):
         my_var = variable(int, value=8)
-        not_a_var = 4
+        not_a_var = my_var - 4
 
         def __init__(self):
             print(self.my_var) # prints 8.
@@ -133,13 +135,15 @@ In essence, these builtins exert control over the test creation, and they allow 
             self.my_var = 10 # tests may also assign values the standard way
 
   The argument ``value`` in the :func:`variable` built-in sets the default value for the variable.
-  As mentioned above, a variable may not be declared more than once, but its default value can be updated by simply assigning it a new value directly in the class body.
+  Note that a variable may be accesed directly from the class body as long as its value was previously assigned in the same class body.
+  As mentioned above, a variable may not be declared more than once, but its default value can be updated by simply assigning it a new value directly in the class body. However, a variable may only be acted upon once in the same class body.
 
   .. code:: python
 
     class Bar(Foo):
         my_var = 4
         # my_var = 'override' # Error again!
+        # my_var = 8 # Error: Double action on `my_var` is not allowed.
 
         def __init__(self):
             print(self.my_var) # prints 4.

--- a/reframe/core/meta.py
+++ b/reframe/core/meta.py
@@ -37,7 +37,7 @@ class RegressionTestMeta(type):
             '''
             try:
                 return super().__getitem__(key)
-            except Exception as err:
+            except KeyError as err:
                 try:
                     # Handle variable access
                     var = self['_rfm_local_var_space'][key]
@@ -45,7 +45,7 @@ class RegressionTestMeta(type):
                         return var.default_value
                     else:
                         raise ValueError(
-                            f'variable {key!r} does not have an assigned value'
+                            f'variable {key!r} is not assigned a value'
                         )
 
                 except KeyError:
@@ -58,7 +58,7 @@ class RegressionTestMeta(type):
                     else:
                         # If 'key' is neither a variable nor a parameter,
                         # raise the exception from the base __getitem__.
-                        raise err
+                        raise err from None
 
     @classmethod
     def __prepare__(metacls, name, bases, **kwargs):

--- a/reframe/core/pipeline.py
+++ b/reframe/core/pipeline.py
@@ -138,9 +138,22 @@ class RegressionMixin(metaclass=RegressionTestMeta):
 
     .. versionadded:: 3.4.2
     '''
+    def __getattribute__(self, name):
+        try:
+            return super().__getattribute__(name)
+        except AttributeError:
+            # Intercept the AttributeError if the name corresponds to a
+            # required variable.
+            if (name in self._rfm_var_space.vars and
+                not self._rfm_var_space.vars[name].is_defined()):
+                raise AttributeError(
+                    f'required variable {name!r} has not been set'
+                ) from None
+            else:
+                super().__getattr__(name)
 
 
-class RegressionTest(jsonext.JSONSerializable, metaclass=RegressionTestMeta):
+class RegressionTest(jsonext.JSONSerializable, RegressionMixin):
     '''Base class for regression tests.
 
     All regression tests must eventually inherit from this class.
@@ -763,20 +776,6 @@ class RegressionTest(jsonext.JSONSerializable, metaclass=RegressionTestMeta):
 
     def __init__(self):
         pass
-
-    def __getattribute__(self, name):
-        try:
-            return super().__getattribute__(name)
-        except AttributeError:
-            # Intercept the AttributeError if the name corresponds to a
-            # required variable.
-            if (name in self._rfm_var_space.vars and
-                not self._rfm_var_space.vars[name].is_defined()):
-                raise AttributeError(
-                    f'required variable {name!r} has not been set'
-                ) from None
-            else:
-                super().__getattr__(name)
 
     def _append_parameters_to_name(self):
         if self._rfm_param_space.params:

--- a/reframe/core/pipeline.py
+++ b/reframe/core/pipeline.py
@@ -153,7 +153,7 @@ class RegressionMixin(metaclass=RegressionTestMeta):
                 super().__getattr__(name)
 
 
-class RegressionTest(jsonext.JSONSerializable, RegressionMixin):
+class RegressionTest(RegressionMixin, jsonext.JSONSerializable):
     '''Base class for regression tests.
 
     All regression tests must eventually inherit from this class.

--- a/unittests/test_parameters.py
+++ b/unittests/test_parameters.py
@@ -228,3 +228,10 @@ def test_param_deepcopy():
     assert Foo(_rfm_use_params=True).p0.val == -20
     assert Bar(_rfm_use_params=True).p0.val == 1
     assert Bar(_rfm_use_params=True).p0.val == 2
+
+
+def test_param_access():
+    with pytest.raises(ValueError):
+        class Foo(rfm.RegressionTest):
+            p = parameter([1, 2, 3])
+            x = f'accessing {p!r} in the class body is disallowed.'

--- a/unittests/test_variables.py
+++ b/unittests/test_variables.py
@@ -180,3 +180,15 @@ def test_var_deepcopy():
 
     assert Foo().my_var == [1, 2, 3]
     assert Bar().my_var == [1, 2]
+
+
+def test_variable_access():
+    class Foo(rfm.RegressionMixin):
+        my_var = variable(str, value='bananas')
+        x = f'accessing {my_var!r} works because it has a default value.'
+
+    assert 'bananas' in getattr(Foo, 'x')
+    with pytest.raises(ValueError):
+        class Foo(rfm.RegressionMixin):
+            my_var = variable(int)
+            x = f'accessing {my_var!r} fails because its value is not set.'


### PR DESCRIPTION
This PR implements the attribute access to variables and parameters directly from the class body. Prior to this PR, an attempt to access either variables or parameters from the class body resulted in a `NameError` since none of these built-ins are stored in the public namespace from the class. This PR not only implements the access to these items, but also provides a more robust error handling in case of erroneous user input:

- Accessing a required (undefined) variable in the class body will raise a `ValueError`:
```python
class Foo(rfm.RegressionMixin):
    v = variable(str)
    x = f'{v}' # This will raise an error because `v` has no value
```
- Accessing a defined variable will return its default value:
```python
class Foo(rfm.RegressionMixin):
    v = variable(int, value=4)
    x = v + 1 # this sets x to 5
```
- Accessing a parameter directly from the class body is disallowed.
```python
class Foo(rfm.RegressionMixin):
    p = parameter([1, 2, 3])
    x = f'{p}' # This raises an error. Here `P` is a TestParam object, not a test parameter.
```