### PR TITLE
[bugfix] Deepcopy inherited variables from the parent classes

### DIFF
--- a/reframe/core/variables.py
+++ b/reframe/core/variables.py
@@ -17,6 +17,9 @@ class _UndefinedType:
     '''Custom type to flag a variable as undefined.'''
     __slots__ = ()
 
+    def __deepcopy__(self, memo):
+        return self
+
 
 _Undefined = _UndefinedType()
 
@@ -116,7 +119,7 @@ class VarSpace(namespaces.Namespace):
                     f'parent classes of class {cls.__qualname__!r}'
                 )
 
-            self.vars[key] = var
+            self.vars[key] = copy.deepcopy(var)
 
         # Carry over the set of injected variables
         self._injected_vars.update(other._injected_vars)

--- a/unittests/test_variables.py
+++ b/unittests/test_variables.py
@@ -178,8 +178,13 @@ def test_var_deepcopy():
     class Bar(Base):
         pass
 
+    class Baz(Base):
+        my_var = []
+
+    assert Base().my_var == [1, 2]
     assert Foo().my_var == [1, 2, 3]
     assert Bar().my_var == [1, 2]
+    assert Baz().my_var == []
 
 
 def test_variable_access():


### PR DESCRIPTION
This PR fixes the upstream propagation of changes to variables done by the child classes. Reproducer:
```python
class Foo(rfm.RegressionMixin):
    v = variable(int, value=3)

class Bar(Foo):
    v = 4

Foo().v # Erroneously printed 4 instead of 3
Bar().v # Prints 4
```
A unit tests has been extended to catch this.