### PR TITLE
[test] Add configuration for Pilatus and VASP check

### DIFF
--- a/config/cscs.py
+++ b/config/cscs.py
@@ -660,10 +660,10 @@ site_configuration = {
             ]
         },
         {
-            'name': 'pilatus',
-            'descr': 'Alps Cray EX Supercomputer (TDS)',
+            'name': 'eiger',
+            'descr': 'Alps Cray EX Supercomputer',
             'hostnames': [
-                'pilatus'
+                'eiger'
             ],
             'modules_system': 'lmod',
             'resourcesdir': '/apps/common/UES/reframe/resources',
@@ -711,10 +711,10 @@ site_configuration = {
             ]
         },
         {
-            'name': 'eiger',
+            'name': 'pilatus',
             'descr': 'Alps Cray EX Supercomputer',
             'hostnames': [
-                'eiger'
+                'pilatus'
             ],
             'modules_system': 'lmod',
             'resourcesdir': '/apps/common/UES/reframe/resources',
@@ -724,9 +724,14 @@ site_configuration = {
                     'scheduler': 'local',
                     'environs': [
                         'builtin',
+                        'PrgEnv-aocc',
                         'PrgEnv-cray',
                         'PrgEnv-gnu',
-                        'PrgEnv-aocc'
+                        'PrgEnv-intel',
+                        'cpeAMD',
+                        'cpeCray',
+                        'cpeGNU',
+                        'cpeIntel'
                     ],
                     'descr': 'Login nodes',
                     'max_jobs': 4,
@@ -738,9 +743,14 @@ site_configuration = {
                     'scheduler': 'slurm',
                     'environs': [
                         'builtin',
+                        'PrgEnv-aocc',
                         'PrgEnv-cray',
                         'PrgEnv-gnu',
-                        'PrgEnv-aocc'
+                        'PrgEnv-intel',
+                        'cpeAMD',
+                        'cpeCray',
+                        'cpeGNU',
+                        'cpeIntel'
                     ],
                     'max_jobs': 100,
                     'resources': [
@@ -906,6 +916,15 @@ site_configuration = {
             'ftn': 'gfortran'
         },
         {
+            'name': 'PrgEnv-aocc',
+            'target_systems': [
+                'eiger', 'pilatus'
+            ],
+            'modules': [
+                {'name': 'PrgEnv-aocc', 'collection': True}
+            ]
+        },
+        {
             'name': 'PrgEnv-cray',
             'target_systems': [
                 'eiger', 'pilatus'
@@ -924,12 +943,48 @@ site_configuration = {
             ]
         },
         {
-            'name': 'PrgEnv-aocc',
+            'name': 'PrgEnv-intel',
+            'target_systems': [
+                'pilatus'
+            ],
+            'modules': [
+                {'name': 'PrgEnv-intel', 'collection': True}
+            ]
+        },
+        {
+            'name': 'cpeAMD',
             'target_systems': [
                 'eiger', 'pilatus'
             ],
             'modules': [
-                {'name': 'PrgEnv-aocc', 'collection': True}
+                {'name': 'cpeAMD', 'collection': False}
+            ]
+        },
+        {
+            'name': 'cpeCray',
+            'target_systems': [
+                'eiger', 'pilatus'
+            ],
+            'modules': [
+                {'name': 'cpeCray', 'collection': False}
+            ]
+        },
+        {
+            'name': 'cpeGNU',
+            'target_systems': [
+                'eiger', 'pilatus'
+            ],
+            'modules': [
+                {'name': 'cpeGNU', 'collection': False}
+            ]
+        },
+        {
+            'name': 'cpeIntel',
+            'target_systems': [
+                'pilatus'
+            ],
+            'modules': [
+                {'name': 'cpeIntel', 'collection': False}
             ]
         },
         {

--- a/config/cscs.py
+++ b/config/cscs.py
@@ -712,7 +712,7 @@ site_configuration = {
         },
         {
             'name': 'pilatus',
-            'descr': 'Alps Cray EX Supercomputer',
+            'descr': 'Alps Cray EX Supercomputer TDS',
             'hostnames': [
                 'pilatus'
             ],
@@ -957,8 +957,8 @@ site_configuration = {
                 'eiger', 'pilatus'
             ],
             'modules': [
-                {'name': 'cpeAMD', 'collection': False}
-            ]
+                'cpeAMD'
+            ],
         },
         {
             'name': 'cpeCray',
@@ -966,8 +966,8 @@ site_configuration = {
                 'eiger', 'pilatus'
             ],
             'modules': [
-                {'name': 'cpeCray', 'collection': False}
-            ]
+                'cpeCray'
+            ],
         },
         {
             'name': 'cpeGNU',
@@ -975,8 +975,8 @@ site_configuration = {
                 'eiger', 'pilatus'
             ],
             'modules': [
-                {'name': 'cpeGNU', 'collection': False}
-            ]
+                'cpeGNU'
+            ],
         },
         {
             'name': 'cpeIntel',
@@ -984,8 +984,8 @@ site_configuration = {
                 'pilatus'
             ],
             'modules': [
-                {'name': 'cpeIntel', 'collection': False}
-            ]
+                'cpeIntel'
+            ],
         },
         {
             'name': 'PrgEnv-cray',

--- a/cscs-checks/apps/vasp/vasp_check.py
+++ b/cscs-checks/apps/vasp/vasp_check.py
@@ -13,7 +13,7 @@ class VASPCheck(rfm.RunOnlyRegressionTest):
             self.valid_prog_environs = ['cpeIntel']
         else:
             self.valid_prog_environs = ['builtin']
-            
+
         self.modules = ['VASP']
         force = sn.extractsingle(r'1 F=\s+(?P<result>\S+)',
                                  self.stdout, 'result', float)

--- a/cscs-checks/apps/vasp/vasp_check.py
+++ b/cscs-checks/apps/vasp/vasp_check.py
@@ -9,6 +9,10 @@ import reframe.utility.sanity as sn
 
 class VASPCheck(rfm.RunOnlyRegressionTest):
     def __init__(self):
+        if self.current_system.name == 'pilatus':
+            self.valid_prog_environs = ['cpeIntel']
+        else:
+            self.valid_prog_environs = ['builtin']
         self.modules = ['VASP']
         force = sn.extractsingle(r'1 F=\s+(?P<result>\S+)',
                                  self.stdout, 'result', float)
@@ -37,10 +41,6 @@ class VASPCpuCheck(VASPCheck):
         super().__init__()
         self.descr = f'VASP CPU check (variant: {variant})'
         self.valid_systems = ['daint:mc', 'dom:mc', 'eiger:mc', 'pilatus:mc']
-        if self.current_system.name in ['daint', 'dom', 'eiger']:
-            self.valid_prog_environs = ['builtin']
-        elif self.current_system.name == 'pilatus':
-            self.valid_prog_environs = ['cpeIntel']
 
         self.executable = 'vasp_std'
         if self.current_system.name == 'dom':
@@ -96,7 +96,6 @@ class VASPGpuCheck(VASPCheck):
         super().__init__()
         self.descr = f'VASP GPU check (variant: {variant})'
         self.valid_systems = ['daint:gpu', 'dom:gpu']
-        self.valid_prog_environs = ['builtin']
         self.executable = 'vasp_gpu'
         self.variables = {'CRAY_CUDA_MPS': '1'}
         self.num_gpus_per_node = 1

--- a/cscs-checks/apps/vasp/vasp_check.py
+++ b/cscs-checks/apps/vasp/vasp_check.py
@@ -9,7 +9,6 @@ import reframe.utility.sanity as sn
 
 class VASPCheck(rfm.RunOnlyRegressionTest):
     def __init__(self):
-        self.valid_prog_environs = ['builtin']
         self.modules = ['VASP']
         force = sn.extractsingle(r'1 F=\s+(?P<result>\S+)',
                                  self.stdout, 'result', float)
@@ -37,13 +36,18 @@ class VASPCpuCheck(VASPCheck):
     def __init__(self, variant):
         super().__init__()
         self.descr = f'VASP CPU check (variant: {variant})'
-        self.valid_systems = ['daint:mc', 'dom:mc', 'eiger:mc']
+        self.valid_systems = ['daint:mc', 'dom:mc', 'eiger:mc', 'pilatus:mc']
+        if self.current_system.name in ['daint', 'dom', 'eiger']:
+            self.valid_prog_environs = ['builtin']
+        elif self.current_system.name == 'pilatus':
+            self.valid_prog_environs = ['cpeIntel']
+
         self.executable = 'vasp_std'
         if self.current_system.name == 'dom':
             self.num_tasks = 72
             self.num_tasks_per_node = 12
             self.use_multithreading = True
-        elif self.current_system.name == 'eiger':
+        elif self.current_system.name in ['eiger', 'pilatus']:
             self.num_tasks = 64
             self.num_tasks_per_node = 4
             self.num_cpus_per_task = 8
@@ -64,12 +68,14 @@ class VASPCpuCheck(VASPCheck):
             'maint': {
                 'dom:mc': {'time': (148.7, None, 0.05, 's')},
                 'daint:mc': {'time': (105.3, None, 0.20, 's')},
-                'eiger:mc': {'time': (100.0, None, 0.10, 's')}
+                'eiger:mc': {'time': (100.0, None, 0.10, 's')},
+                'pilatus:mc': {'time': (100.0, None, 0.10, 's')}
             },
             'prod': {
                 'dom:mc': {'time': (148.7, None, 0.05, 's')},
                 'daint:mc': {'time': (105.3, None, 0.20, 's')},
-                'eiger:mc': {'time': (100.0, None, 0.10, 's')}
+                'eiger:mc': {'time': (100.0, None, 0.10, 's')},
+                'pilatus:mc': {'time': (100.0, None, 0.10, 's')}
             }
         }
         self.reference = references[variant]
@@ -90,6 +96,7 @@ class VASPGpuCheck(VASPCheck):
         super().__init__()
         self.descr = f'VASP GPU check (variant: {variant})'
         self.valid_systems = ['daint:gpu', 'dom:gpu']
+        self.valid_prog_environs = ['builtin']
         self.executable = 'vasp_gpu'
         self.variables = {'CRAY_CUDA_MPS': '1'}
         self.num_gpus_per_node = 1

--- a/cscs-checks/apps/vasp/vasp_check.py
+++ b/cscs-checks/apps/vasp/vasp_check.py
@@ -13,6 +13,7 @@ class VASPCheck(rfm.RunOnlyRegressionTest):
             self.valid_prog_environs = ['cpeIntel']
         else:
             self.valid_prog_environs = ['builtin']
+            
         self.modules = ['VASP']
         force = sn.extractsingle(r'1 F=\s+(?P<result>\S+)',
                                  self.stdout, 'result', float)


### PR DESCRIPTION
I propose a configuration of ReFrame on Pilatus with the Hierarchical module naming scheme, introducing the environments `cpeAMD`, `cpeCray`, `cpeGNU` and `cpeIntel` that correspond to the toolchain modules to be loaded before the apps. 
I also provide a modified check for VASP that works on Pilatus: we might use this configuration temporarily.