### PR TITLE
[test] Update checks of supported applications on Pilatus

### DIFF
--- a/cscs-checks/apps/cp2k/cp2k_check.py
+++ b/cscs-checks/apps/cp2k/cp2k_check.py
@@ -9,7 +9,11 @@ import reframe.utility.sanity as sn
 
 class Cp2kCheck(rfm.RunOnlyRegressionTest):
     def __init__(self):
-        self.valid_prog_environs = ['builtin']
+        if self.current_system.name == 'pilatus':
+            self.valid_prog_environs = ['cpeGNU']
+        else:
+            self.valid_prog_environs = ['builtin']
+
         self.modules = ['CP2K']
         self.executable = 'cp2k.psmp'
         self.executable_opts = ['H2O-256.inp']
@@ -51,13 +55,13 @@ class Cp2kCpuCheck(Cp2kCheck):
     def __init__(self, scale, variant):
         super().__init__()
         self.descr = 'CP2K CPU check (version: %s, %s)' % (scale, variant)
-        self.valid_systems = ['daint:mc', 'eiger:mc']
+        self.valid_systems = ['daint:mc', 'eiger:mc', 'pilatus:mc']
         if scale == 'small':
             self.valid_systems += ['dom:mc']
             if self.current_system.name in ['daint', 'dom']:
                 self.num_tasks = 216
                 self.num_tasks_per_node = 36
-            elif self.current_system.name == 'eiger':
+            elif self.current_system.name in ['eiger', 'pilatus']:
                 self.num_tasks = 96
                 self.num_tasks_per_node = 16
                 self.num_cpus_per_task = 16
@@ -74,7 +78,7 @@ class Cp2kCpuCheck(Cp2kCheck):
             if self.current_system.name in ['daint', 'dom']:
                 self.num_tasks = 576
                 self.num_tasks_per_node = 36
-            elif self.current_system.name in ['eiger']:
+            elif self.current_system.name in ['eiger', 'pilatus']:
                 self.num_tasks = 256
                 self.num_tasks_per_node = 16
                 self.num_cpus_per_task = 16
@@ -92,22 +96,26 @@ class Cp2kCpuCheck(Cp2kCheck):
                 'small': {
                     'dom:mc': {'time': (202.2, None, 0.05, 's')},
                     'daint:mc': {'time': (180.9, None, 0.08, 's')},
-                    'eiger:mc': {'time': (70.0, None, 0.08, 's')}
+                    'eiger:mc': {'time': (70.0, None, 0.08, 's')},
+                    'pilatus:mc': {'time': (70.0, None, 0.08, 's')}
                 },
                 'large': {
                     'daint:mc': {'time': (141.0, None, 0.05, 's')},
-                    'eiger:mc': {'time': (46.0, None, 0.05, 's')}
+                    'eiger:mc': {'time': (46.0, None, 0.05, 's')},
+                    'pilatus:mc': {'time': (46.0, None, 0.05, 's')}
                 }
             },
             'prod': {
                 'small': {
                     'dom:mc': {'time': (202.2, None, 0.05, 's')},
                     'daint:mc': {'time': (180.9, None, 0.08, 's')},
-                    'eiger:mc': {'time': (70.0, None, 0.08, 's')}
+                    'eiger:mc': {'time': (70.0, None, 0.08, 's')},
+                    'pilatus:mc': {'time': (70.0, None, 0.08, 's')}
                 },
                 'large': {
                     'daint:mc': {'time': (113.0, None, 0.05, 's')},
-                    'eiger:mc': {'time': (46.0, None, 0.05, 's')}
+                    'eiger:mc': {'time': (46.0, None, 0.05, 's')},
+                    'pilatus:mc': {'time': (46.0, None, 0.05, 's')}
                 }
             }
         }

--- a/cscs-checks/apps/gromacs/gromacs_check.py
+++ b/cscs-checks/apps/gromacs/gromacs_check.py
@@ -16,6 +16,7 @@ class GromacsBaseCheck(rfm.RunOnlyRegressionTest):
             self.valid_prog_environs = ['cpeGNU']
         else:
             self.valid_prog_environs = ['builtin']
+
         self.executable = 'gmx_mpi'
 
         # Reset sources dir relative to the SCS apps prefix

--- a/cscs-checks/apps/gromacs/gromacs_check.py
+++ b/cscs-checks/apps/gromacs/gromacs_check.py
@@ -12,7 +12,10 @@ import reframe.utility.sanity as sn
 
 class GromacsBaseCheck(rfm.RunOnlyRegressionTest):
     def __init__(self, output_file):
-        self.valid_prog_environs = ['builtin']
+        if self.current_system.name == 'pilatus':
+            self.valid_prog_environs = ['cpeGNU']
+        else:
+            self.valid_prog_environs = ['builtin']
         self.executable = 'gmx_mpi'
 
         # Reset sources dir relative to the SCS apps prefix
@@ -99,7 +102,7 @@ class GromacsGPUCheck(GromacsBaseCheck):
 class GromacsCPUCheck(GromacsBaseCheck):
     def __init__(self, scale, variant):
         super().__init__('md.log')
-        self.valid_systems = ['daint:mc', 'eiger:mc']
+        self.valid_systems = ['daint:mc', 'eiger:mc', 'pilatus:mc']
         self.descr = 'GROMACS CPU check'
         self.executable_opts = ['mdrun', '-dlb yes', '-ntomp 1', '-npme -1',
                                 '-nb cpu', '-s herflat.tpr']
@@ -109,14 +112,14 @@ class GromacsCPUCheck(GromacsBaseCheck):
             if (self.current_system.name in ['daint', 'dom']):
                 self.num_tasks = 216
                 self.num_tasks_per_node = 36
-            elif (self.current_system.name in ['eiger']):
+            elif (self.current_system.name in ['eiger', 'pilatus']):
                 self.num_tasks = 768
                 self.num_tasks_per_node = 128
         else:
             if (self.current_system.name in ['daint', 'dom']):
                 self.num_tasks = 576
                 self.num_tasks_per_node = 36
-            elif (self.current_system.name in ['eiger']):
+            elif (self.current_system.name in ['eiger', 'pilatus']):
                 self.num_tasks = 2048
                 self.num_tasks_per_node = 128
 
@@ -125,11 +128,13 @@ class GromacsCPUCheck(GromacsBaseCheck):
                 'small': {
                     'dom:mc': {'perf': (40.0, -0.05, None, 'ns/day')},
                     'daint:mc': {'perf': (38.8, -0.10, None, 'ns/day')},
-                    'eiger:mc': {'perf': (103.00, -0.10, None, 'ns/day')}
+                    'eiger:mc': {'perf': (103.00, -0.10, None, 'ns/day')},
+                    'pilatus:mc': {'perf': (103.00, -0.10, None, 'ns/day')}
                 },
                 'large': {
                     'daint:mc': {'perf': (68.0, -0.20, None, 'ns/day')},
-                    'eiger:mc': {'perf': (146.00, -0.20, None, 'ns/day')}
+                    'eiger:mc': {'perf': (146.00, -0.20, None, 'ns/day')},
+                    'pilatus:mc': {'perf': (146.00, -0.20, None, 'ns/day')}
                 }
             },
         }

--- a/cscs-checks/apps/lammps/lammps_check.py
+++ b/cscs-checks/apps/lammps/lammps_check.py
@@ -99,7 +99,7 @@ class LAMMPSCPUCheck(LAMMPSBaseCheck):
         if self.current_system.name in ['eiger', 'pilatus']:
             self.executable = 'lmp_mpi'
             self.executable_opts = ['-in in.lj.cpu']
-        else: 
+        else:
             self.executable = 'lmp_omp'
             self.executable_opts = ['-sf omp', '-pk omp 1', '-in in.lj.cpu']
 

--- a/cscs-checks/apps/lammps/lammps_check.py
+++ b/cscs-checks/apps/lammps/lammps_check.py
@@ -11,7 +11,10 @@ import reframe.utility.sanity as sn
 
 class LAMMPSBaseCheck(rfm.RunOnlyRegressionTest):
     def __init__(self):
-        self.valid_prog_environs = ['builtin']
+        if self.current_system.name == 'pilatus':
+            self.valid_prog_environs = ['cpeGNU']
+        else:
+            self.valid_prog_environs = ['builtin']
         self.modules = ['LAMMPS']
 
         # Reset sources dir relative to the SCS apps prefix
@@ -92,9 +95,14 @@ class LAMMPSGPUCheck(LAMMPSBaseCheck):
 class LAMMPSCPUCheck(LAMMPSBaseCheck):
     def __init__(self, scale, variant):
         super().__init__()
-        self.valid_systems = ['daint:mc', 'eiger:mc']
-        self.executable = 'lmp_omp'
-        self.executable_opts = ['-sf omp', '-pk omp 1', '-in in.lj.cpu']
+        self.valid_systems = ['daint:mc', 'eiger:mc', 'pilatus:mc']
+        if self.current_system.name == 'pilatus':
+            self.executable = 'lmp_mpi'
+            self.executable_opts = ['-in in.lj.cpu']
+        else: 
+            self.executable = 'lmp_omp'
+            self.executable_opts = ['-sf omp', '-pk omp 1', '-in in.lj.cpu']
+
         self.scale = scale
         if scale == 'small':
             self.valid_systems += ['dom:mc']
@@ -113,11 +121,13 @@ class LAMMPSCPUCheck(LAMMPSBaseCheck):
                 'small': {
                     'dom:mc': {'perf': (4394, -0.05, None, 'timesteps/s')},
                     'daint:mc': {'perf': (3824, -0.10, None, 'timesteps/s')},
-                    'eiger:mc': {'perf': (5300, -0.05, None, 'timesteps/s')}
+                    'eiger:mc': {'perf': (5300, -0.05, None, 'timesteps/s')},
+                    'pilatus:mc': {'perf': (5300, -0.05, None, 'timesteps/s')}
                 },
                 'large': {
                     'daint:mc': {'perf': (5310, -0.65, None, 'timesteps/s')},
-                    'eiger:mc': {'perf': (7100, -0.05, None, 'timesteps/s')}
+                    'eiger:mc': {'perf': (7100, -0.05, None, 'timesteps/s')},
+                    'pilatus:mc': {'perf': (7100, -0.05, None, 'timesteps/s')}
                 }
             },
         }

--- a/cscs-checks/apps/lammps/lammps_check.py
+++ b/cscs-checks/apps/lammps/lammps_check.py
@@ -96,7 +96,7 @@ class LAMMPSCPUCheck(LAMMPSBaseCheck):
     def __init__(self, scale, variant):
         super().__init__()
         self.valid_systems = ['daint:mc', 'eiger:mc', 'pilatus:mc']
-        if self.current_system.name == 'pilatus':
+        if self.current_system.name in ['eiger', 'pilatus']:
             self.executable = 'lmp_mpi'
             self.executable_opts = ['-in in.lj.cpu']
         else: 
@@ -121,13 +121,13 @@ class LAMMPSCPUCheck(LAMMPSBaseCheck):
                 'small': {
                     'dom:mc': {'perf': (4394, -0.05, None, 'timesteps/s')},
                     'daint:mc': {'perf': (3824, -0.10, None, 'timesteps/s')},
-                    'eiger:mc': {'perf': (5300, -0.05, None, 'timesteps/s')},
-                    'pilatus:mc': {'perf': (5300, -0.05, None, 'timesteps/s')}
+                    'eiger:mc': {'perf': (4500, -0.10, None, 'timesteps/s')},
+                    'pilatus:mc': {'perf': (5000, -0.10, None, 'timesteps/s')}
                 },
                 'large': {
                     'daint:mc': {'perf': (5310, -0.65, None, 'timesteps/s')},
-                    'eiger:mc': {'perf': (7100, -0.05, None, 'timesteps/s')},
-                    'pilatus:mc': {'perf': (7100, -0.05, None, 'timesteps/s')}
+                    'eiger:mc': {'perf': (6500, -0.10, None, 'timesteps/s')},
+                    'pilatus:mc': {'perf': (7500, -0.10, None, 'timesteps/s')}
                 }
             },
         }

--- a/cscs-checks/apps/namd/namd_check.py
+++ b/cscs-checks/apps/namd/namd_check.py
@@ -12,7 +12,10 @@ import reframe.utility.sanity as sn
 class NamdBaseCheck(rfm.RunOnlyRegressionTest):
     def __init__(self, arch, scale, variant):
         self.descr = 'NAMD check (%s, %s)' % (arch, variant)
-        self.valid_prog_environs = ['builtin']
+        if self.current_system.name == 'pilatus':
+            self.valid_prog_environs = ['cpeIntel']
+        else:
+            self.valid_prog_environs = ['builtin']
         self.modules = ['NAMD']
 
         # Reset sources dir relative to the SCS apps prefix

--- a/cscs-checks/apps/quantumespresso/quantumespresso_check.py
+++ b/cscs-checks/apps/quantumespresso/quantumespresso_check.py
@@ -9,7 +9,11 @@ import reframe.utility.sanity as sn
 
 class QuantumESPRESSOCheck(rfm.RunOnlyRegressionTest):
     def __init__(self):
-        self.valid_prog_environs = ['builtin']
+        if self.current_system.name == 'pilatus':
+            self.valid_prog_environs = ['cpeGNU']
+        else:
+            self.valid_prog_environs = ['builtin']
+
         self.modules = ['QuantumESPRESSO']
         self.executable = 'pw.x'
         self.executable_opts = ['-in', 'ausurf.in']
@@ -40,14 +44,14 @@ class QuantumESPRESSOCpuCheck(QuantumESPRESSOCheck):
     def __init__(self, scale, variant):
         super().__init__()
         self.descr = f'QuantumESPRESSO CPU check (version: {scale}, {variant})'
-        self.valid_systems = ['daint:mc', 'eiger:mc']
+        self.valid_systems = ['daint:mc', 'eiger:mc', 'pilatus:mc']
         if scale == 'small':
             self.valid_systems += ['dom:mc']
             energy_reference = -11427.09017218
             if self.current_system.name in ['daint', 'dom']:
                 self.num_tasks = 216
                 self.num_tasks_per_node = 36
-            elif self.current_system.name == 'eiger':
+            elif self.current_system.name in ['eiger', 'pilatus']:
                 self.num_tasks = 96
                 self.num_tasks_per_node = 16
                 self.num_cpus_per_task = 16
@@ -64,7 +68,7 @@ class QuantumESPRESSOCpuCheck(QuantumESPRESSOCheck):
             if self.current_system.name in ['daint']:
                 self.num_tasks = 576
                 self.num_tasks_per_node = 36
-            elif self.current_system.name in ['eiger']:
+            elif self.current_system.name in ['eiger', 'pilatus']:
                 self.num_tasks = 256
                 self.num_tasks_per_node = 16
                 self.num_cpus_per_task = 16
@@ -92,22 +96,26 @@ class QuantumESPRESSOCpuCheck(QuantumESPRESSOCheck):
                 'small': {
                     'dom:mc': {'time': (115.0, None, 0.05, 's')},
                     'daint:mc': {'time': (115.0, None, 0.10, 's')},
-                    'eiger:mc': {'time': (66.0, None, 0.10, 's')}
+                    'eiger:mc': {'time': (66.0, None, 0.10, 's')},
+                    'pilatus:mc': {'time': (66.0, None, 0.10, 's')}
                 },
                 'large': {
                     'daint:mc': {'time': (115.0, None, 0.10, 's')},
-                    'eiger:mc': {'time': (53.0, None, 0.10, 's')}
+                    'eiger:mc': {'time': (53.0, None, 0.10, 's')},
+                    'pilatus:mc': {'time': (53.0, None, 0.10, 's')}
                 }
             },
             'prod': {
                 'small': {
                     'dom:mc': {'time': (115.0, None, 0.05, 's')},
                     'daint:mc': {'time': (115.0, None, 0.10, 's')},
-                    'eiger:mc': {'time': (66.0, None, 0.10, 's')}
+                    'eiger:mc': {'time': (66.0, None, 0.10, 's')},
+                    'pilatus:mc': {'time': (66.0, None, 0.10, 's')}
                 },
                 'large': {
                     'daint:mc': {'time': (115.0, None, 0.10, 's')},
-                    'eiger:mc': {'time': (53.0, None, 0.10, 's')}
+                    'eiger:mc': {'time': (53.0, None, 0.10, 's')},
+                    'pilatus:mc': {'time': (53.0, None, 0.10, 's')}
                 }
             }
         }


### PR DESCRIPTION
Existing checks of supported applications valid on Eiger can be easily adapted to Pilatus with the following lines (e.g.: `NAMD`):
```
        if self.current_system.name == 'pilatus':
            self.valid_prog_environs = ['cpeIntel']
        else:
            self.valid_prog_environs = ['builtin']
```