### PR TITLE
[test] Fix DGEMM performance in Eiger

### DIFF
--- a/cscs-checks/microbenchmarks/cpu/dgemm/dgemm.py
+++ b/cscs-checks/microbenchmarks/cpu/dgemm/dgemm.py
@@ -36,12 +36,10 @@ class DGEMMTest(rfm.RegressionTest):
         self.build_system.cflags = ['-O3']
         self.sys_reference = {
             'daint:gpu': (300.0, -0.15, None, 'Gflop/s'),
-            'daint:mc': (860.0, -0.15, None, 'Gflop/s'),
+            'daint:mc': (1040.0, -0.15, None, 'Gflop/s'),
             'dom:gpu': (300.0, -0.15, None, 'Gflop/s'),
-            'dom:mc': (860.0, -0.15, None, 'Gflop/s'),
-
-            # FIXME: This needs further investigation (see SD-51352)
-            'eiger:mc': (650.0, -0.15, None, 'Gflop/s'),
+            'dom:mc': (1040.0, -0.15, None, 'Gflop/s'),
+            'eiger:mc': (3200.0, -0.15, None, 'Gflop/s'),
         }
         self.maintainers = ['AJ', 'VH']
         self.tags = {'benchmark', 'diagnostic', 'craype'}
@@ -80,7 +78,10 @@ class DGEMMTest(rfm.RegressionTest):
 
         if self.num_cpus_per_task:
             self.variables = {
-                'OMP_NUM_THREADS': str(self.num_cpus_per_task)
+                'OMP_NUM_THREADS': str(self.num_cpus_per_task),
+                'OMP_BIND': 'cores',
+                'OMP_PROC_BIND': 'spread',
+                'OMP_SCHEDULE': 'static'
             }
 
     @sn.sanity_function

--- a/cscs-checks/microbenchmarks/cpu/dgemm/src/dgemm.c
+++ b/cscs-checks/microbenchmarks/cpu/dgemm/src/dgemm.c
@@ -49,8 +49,11 @@ int main(int argc, char* argv[])
     printf("%s: LOOP COUNT\t\t\t:\t%d \n", hostname, LOOP_COUNT);
     printf("\n");
 
+#pragma omp parallel for
     for (i=0; i<m*k ; ++i) A[i] = i%3+1;
+#pragma omp parallel for
     for (i=0; i<k*n ; ++i) B[i] = i%3+1;
+#pragma omp parallel for
     for (i=0; i<m*n ; ++i) C[i] = i%3+1;
 
     gflop = (2.0 * m * n * k + 3.0 * m * n) * 1E-9;


### PR DESCRIPTION
The initialisation of the arrays is now done in parallel. The appropriate OMP env variables have been added to the test.