### PR TITLE
[feat] Improve naming scheme of tests

### DIFF
--- a/reframe/core/decorators.py
+++ b/reframe/core/decorators.py
@@ -22,7 +22,6 @@ import traceback
 import reframe.utility.osext as osext
 from reframe.core.exceptions import ReframeSyntaxError, user_frame
 from reframe.core.logging import getlogger
-from reframe.core.parameters import TestParam
 from reframe.core.pipeline import RegressionTest
 from reframe.utility.versioning import VersionValidator
 

--- a/reframe/core/meta.py
+++ b/reframe/core/meta.py
@@ -18,6 +18,7 @@ class RegressionTestMeta(type):
 
     class MetaNamespace(namespaces.LocalNamespace):
         '''Custom namespace to control the cls attribute assignment.'''
+
         def __setitem__(self, key, value):
             if isinstance(value, variables.VarDirective):
                 # Insert the attribute in the variable namespace
@@ -159,7 +160,7 @@ class RegressionTestMeta(type):
         to perform specific reframe-internal actions. This gives extra control
         over the class instantiation process, allowing reframe to instantiate
         the regression test class differently if this class was registered or
-        not (e.g. when deep-copying a regression test object). These interal
+        not (e.g. when deep-copying a regression test object). These internal
         arguments must be intercepted before the object initialization, since
         these would otherwise affect the __init__ method's signature, and these
         internal mechanisms must be fully transparent to the user.

--- a/reframe/core/namespaces.py
+++ b/reframe/core/namespaces.py
@@ -135,11 +135,21 @@ class Namespace(metaclass=abc.ABCMeta):
         assert isinstance(getattr(cls, self.local_namespace_name),
                           LocalNamespace)
 
+    def allow_inheritance(self, cls, base):
+        '''Return true if cls is allowed to inherit the namespace of base.
+
+        Subclasses may override that to customize the behavior.
+        '''
+        return True
+
     def inherit(self, cls):
         '''Inherit the Namespaces from the bases.'''
 
         for base in filter(lambda x: hasattr(x, self.namespace_name),
                            cls.__bases__):
+            if not self.allow_inheritance(cls, base):
+                continue
+
             assert isinstance(getattr(base, self.namespace_name), type(self))
             self.join(getattr(base, self.namespace_name), cls)
 

--- a/reframe/core/parameters.py
+++ b/reframe/core/parameters.py
@@ -178,10 +178,10 @@ class ParamSpace(namespaces.Namespace):
         '''
 
         # Set the values of the test parameters (if any)
+        injected = []
         if use_params and self.params:
             try:
                 # Consume the parameter space iterator
-                injected = []
                 param_values = next(self.unique_iter)
                 for index, key in enumerate(self.params):
                     setattr(obj, key, param_values[index])
@@ -201,6 +201,8 @@ class ParamSpace(namespaces.Namespace):
             # Otherwise init the params as None
             for key in self.params:
                 setattr(obj, key, None)
+
+        obj.params_inserted(injected)
 
     def __iter__(self):
         '''Create a generator object to iterate over the parameter space

--- a/reframe/core/pipeline.py
+++ b/reframe/core/pipeline.py
@@ -830,10 +830,18 @@ class RegressionTest(RegressionMixin, jsonext.JSONSerializable):
             self._cdt_environ = env.Environment('__rfm_cdt_environ')
 
     @property
+    def param_hash(self):
+        return self._param_hash
+
+    @property
+    def param_hash_short(self):
+        return self._param_hash[:8] if self.param_hash else None
+
+    @property
     def unique_id(self):
         ret = type(self).__qualname__
-        if self._param_hash:
-            ret += '_' + self._param_hash[:8]
+        if self.param_hash:
+            ret += '_' + self.param_hash_short
 
         return ret
 
@@ -1018,11 +1026,14 @@ class RegressionTest(RegressionMixin, jsonext.JSONSerializable):
            method may be called at any point of the test's lifetime.
         '''
         ret = self.name
+        if self.param_hash:
+            ret += f' (/{self.param_hash_short})'
+
         if self.current_partition:
-            ret += ' on %s' % self.current_partition.fullname
+            ret += f' on {self.current_partition.fullname}'
 
         if self.current_environ:
-            ret += ' using %s' % self.current_environ.name
+            ret += f' using {self.current_environ.name}'
 
         return ret
 

--- a/reframe/core/pipeline.py
+++ b/reframe/core/pipeline.py
@@ -846,10 +846,10 @@ class RegressionTest(RegressionMixin, jsonext.JSONSerializable):
         return ret
 
     def _set_param_hash(self, params):
-        obj = {}
-        for name, value, _ in params:
-            obj[name] = value
-
+        obj = {
+            'test': type(self).__qualname__,
+            'params': {name: value for name, value, _ in params}
+        }
         h = hashlib.sha256()
         h.update(bytes(jsonext.dumps(obj), encoding='utf-8'))
         self._param_hash = h.hexdigest()

--- a/reframe/core/pipeline.py
+++ b/reframe/core/pipeline.py
@@ -138,6 +138,7 @@ class RegressionMixin(metaclass=RegressionTestMeta):
 
     .. versionadded:: 3.4.2
     '''
+
     def __getattribute__(self, name):
         try:
             return super().__getattribute__(name)
@@ -771,7 +772,7 @@ class RegressionTest(RegressionMixin, jsonext.JSONSerializable):
                         os.path.dirname(inspect.getfile(cls))
                     )
 
-        obj._rfm_init(name, prefix)
+        obj.__rfm_init__(name, prefix)
         return obj
 
     def __init__(self):
@@ -796,7 +797,7 @@ class RegressionTest(RegressionMixin, jsonext.JSONSerializable):
                 os.path.dirname(inspect.getfile(cls))
             )
 
-    def _rfm_init(self, name=None, prefix=None):
+    def __rfm_init__(self, name=None, prefix=None):
         if name is not None:
             self.name = name
 

--- a/reframe/core/pipeline.py
+++ b/reframe/core/pipeline.py
@@ -785,7 +785,7 @@ class RegressionTest(RegressionMixin, jsonext.JSONSerializable):
 
     def __rfm_init__(self):
         self.descr = self.name
-        self.executable = os.path.join('.', self.name)
+        self.executable = os.path.join('.', self.unique_id)
         self._perfvalues = {}
 
         # Static directories of the regression check

--- a/reframe/core/schedulers/__init__.py
+++ b/reframe/core/schedulers/__init__.py
@@ -8,6 +8,7 @@
 #
 
 import abc
+import os
 import time
 
 import reframe.core.fields as fields
@@ -168,7 +169,7 @@ class Job(jsonext.JSONSerializable):
                  stderr=None,
                  max_pending_time=None,
                  sched_flex_alloc_nodes=None,
-                 sched_access=[],
+                 sched_access=None,
                  sched_exclusive_access=None,
                  sched_options=None):
 
@@ -185,14 +186,16 @@ class Job(jsonext.JSONSerializable):
 
         self._name = name
         self._workdir = workdir
-        self._script_filename = script_filename or '%s.sh' % name
-        self._stdout = stdout or '%s.out' % name
-        self._stderr = stderr or '%s.err' % name
+        self._script_filename = script_filename or f'{name}.sh'
+
+        basename = os.path.splitext(self._script_filename)[0]
+        self._stdout = stdout or f'{basename}.out'
+        self._stderr = stderr or f'{basename}.err'
         self._max_pending_time = max_pending_time
 
         # Backend scheduler related information
         self._sched_flex_alloc_nodes = sched_flex_alloc_nodes
-        self._sched_access = sched_access
+        self._sched_access = list(sched_access) if sched_access else []
         self._sched_exclusive_access = sched_exclusive_access
 
         # Live job information; to be filled during job's lifetime by the

--- a/reframe/frontend/cli.py
+++ b/reframe/frontend/cli.py
@@ -72,6 +72,7 @@ def format_check(check, check_deps, detailed=False):
 
     check_info = {
         'Description': check.descr,
+        'Hash': check.hash_long,
         'Environment modules': fmt_list(check.modules),
         'Location': location,
         'Maintainers': fmt_list(check.maintainers),
@@ -722,7 +723,9 @@ def main():
                 testcases = filter(filters.have_not_hash(h), testcases)
 
         if hashes:
-            testcases = filter(filters.have_hash(hashes), testcases)
+            testcases = filter(
+                filters.have_hash('|'.join(f'^{h}' for h in hashes)), testcases
+            )
 
         # Filter test cases by name
         if exclude_names:

--- a/reframe/frontend/cli.py
+++ b/reframe/frontend/cli.py
@@ -56,11 +56,7 @@ def format_check(check, check_deps, detailed=False):
             return '<none>'
 
     def fmt_name(check):
-        ret = f'- {check.name}'
-        if check.param_hash:
-            ret += f' (test hash: {check.param_hash_short})'
-
-        return ret
+        return f'- {check.name} (/{check.hash_short})'
 
     location = inspect.getfile(type(check))
     if not detailed:
@@ -726,8 +722,7 @@ def main():
                 testcases = filter(filters.have_not_hash(h), testcases)
 
         if hashes:
-            for h in hashes:
-                testcases = filter(filters.have_hash(h), testcases)
+            testcases = filter(filters.have_hash(hashes), testcases)
 
         # Filter test cases by name
         if exclude_names:

--- a/reframe/frontend/cli.py
+++ b/reframe/frontend/cli.py
@@ -55,9 +55,16 @@ def format_check(check, check_deps, detailed=False):
         else:
             return '<none>'
 
+    def fmt_name(check):
+        ret = f'- {check.name}'
+        if check.param_hash:
+            ret += f' (parameter hash: {check.param_hash_short})'
+
+        return ret
+
     location = inspect.getfile(type(check))
     if not detailed:
-        return f'- {check.name} (found in {location!r})'
+        return fmt_name(check)
 
     if check.num_tasks > 0:
         node_alloc_scheme = (f'standard ({check.num_tasks} task(s) -- '
@@ -85,7 +92,8 @@ def format_check(check, check_deps, detailed=False):
         ),
         'Dependencies (actual)': fmt_deps()
     }
-    lines = [f'- {check.name}:']
+
+    lines = [fmt_name(check) + ':']
     for prop, val in check_info.items():
         lines.append(f'    {prop}:')
         if isinstance(val, dict):

--- a/reframe/frontend/filters.py
+++ b/reframe/frontend/filters.py
@@ -15,6 +15,10 @@ def re_compile(patt):
         raise ReframeError(f'invalid regex: {patt!r}')
 
 
+def have_hash(hashes):
+    pass
+
+
 def have_name(patt):
     regex = re_compile(patt)
 

--- a/reframe/frontend/filters.py
+++ b/reframe/frontend/filters.py
@@ -15,8 +15,13 @@ def re_compile(patt):
         raise ReframeError(f'invalid regex: {patt!r}')
 
 
-def have_hash(hashes):
-    pass
+def have_hash(patt):
+    regex = re_compile(patt)
+
+    def _fn(case):
+        return regex.match(case.check.hash_long)
+
+    return _fn
 
 
 def have_name(patt):

--- a/reframe/frontend/filters.py
+++ b/reframe/frontend/filters.py
@@ -19,7 +19,10 @@ def have_name(patt):
     regex = re_compile(patt)
 
     def _fn(case):
-        return regex.match(case.check.name)
+        if case.check.unique_id == patt:
+            return True
+        else:
+            return regex.match(case.check.name)
 
     return _fn
 

--- a/reframe/frontend/filters.py
+++ b/reframe/frontend/filters.py
@@ -19,10 +19,7 @@ def have_name(patt):
     regex = re_compile(patt)
 
     def _fn(case):
-        if case.check.unique_id == patt:
-            return True
-        else:
-            return regex.match(case.check.name)
+        return regex.match(case.check.name)
 
     return _fn
 

--- a/reframe/utility/__init__.py
+++ b/reframe/utility/__init__.py
@@ -67,10 +67,11 @@ def _do_import_module_from_file(filename, module_name=None):
     return module
 
 
-def import_module_from_file(filename):
+def import_module_from_file(filename, force=False):
     '''Import module from file.
 
     :arg filename: The path to the filename of a Python module.
+    :arg force: Force reload of module in case it is already loaded
     :returns: The loaded Python module.
     '''
 
@@ -93,6 +94,9 @@ def import_module_from_file(filename):
     match = site_packages.search(filename)
     if match:
         module_name = _get_module_name(match['rel_filename'])
+
+    if force:
+        sys.modules.pop(module_name, None)
 
     return importlib.import_module(module_name)
 

--- a/unittests/resources/checks/frontend_checks.py
+++ b/unittests/resources/checks/frontend_checks.py
@@ -161,7 +161,11 @@ class SleepCheck(BaseFrontendCheck):
 
     def __init__(self, sleep_time):
         super().__init__()
-        self.name = '%s_%s' % (self.name, SleepCheck._next_id)
+
+        # Simulate a parameterized test, so as to get a proper unique test id
+        self.params_inserted([('id', self._next_id, None),
+                              ('sleep_time', sleep_time, None)])
+        print(self.name, self.unique_id)
         self.sourcesdir = None
         self.sleep_time = sleep_time
         self.executable = 'python3'

--- a/unittests/resources/checks/frontend_checks.py
+++ b/unittests/resources/checks/frontend_checks.py
@@ -157,20 +157,14 @@ class CleanupFailTest(rfm.RunOnlyRegressionTest):
 
 
 class SleepCheck(BaseFrontendCheck):
-    _next_id = 0
+    sleep_time = parameter()
 
-    def __init__(self, sleep_time):
+    def __init__(self):
         super().__init__()
-
-        # Simulate a parameterized test, so as to get a proper unique test id
-        self.params_inserted([('id', self._next_id, None),
-                              ('sleep_time', sleep_time, None)])
-        print(self.name, self.unique_id)
         self.sourcesdir = None
-        self.sleep_time = sleep_time
         self.executable = 'python3'
         self.executable_opts = [
-            '-c "from time import sleep; sleep(%s)"' % sleep_time
+            '-c "from time import sleep; sleep(%s)"' % self.sleep_time
         ]
         print_timestamp = (
             "python3 -c \"from datetime import datetime; "
@@ -180,7 +174,6 @@ class SleepCheck(BaseFrontendCheck):
         self.sanity_patterns = sn.assert_found(r'.*', self.stdout)
         self.valid_systems = ['*']
         self.valid_prog_environs = ['*']
-        SleepCheck._next_id += 1
 
 
 class SleepCheckPollFail(SleepCheck, special=True):

--- a/unittests/resources/checks/hellocheck.py
+++ b/unittests/resources/checks/hellocheck.py
@@ -10,7 +10,6 @@ import reframe.utility.sanity as sn
 @rfm.simple_test
 class HelloTest(rfm.RegressionTest):
     def __init__(self):
-        self.name = 'hellocheck'
         self.descr = 'C Hello World test'
 
         # All available systems are supported

--- a/unittests/test_cli.py
+++ b/unittests/test_cli.py
@@ -553,8 +553,20 @@ def test_filtering_multiple_criteria(run_reframe):
     returncode, stdout, stderr = run_reframe(
         checkpath=['unittests/resources/checks'],
         action='list',
-        more_options=['-t', 'foo', '-n', 'hellocheck',
+        more_options=['-t', 'foo', '-n', 'HelloTest',
                       '--ignore-check-conflicts']
+    )
+    assert 'Traceback' not in stdout
+    assert 'Traceback' not in stderr
+    assert 'Found 1 check(s)' in stdout
+    assert returncode == 0
+
+
+def test_filtering_by_hash(run_reframe):
+    returncode, stdout, stderr = run_reframe(
+        checkpath=['unittests/resources/checks'],
+        action='list',
+        more_options=['-n', '/fc3f678d']
     )
     assert 'Traceback' not in stdout
     assert 'Traceback' not in stderr

--- a/unittests/test_loader.py
+++ b/unittests/test_loader.py
@@ -50,7 +50,7 @@ def test_load_all(loader_with_path):
 
 def test_load_new_syntax(loader):
     checks = loader.load_from_file(
-        'unittests/resources/checks_unlisted/good.py'
+        'unittests/resources/checks_unlisted/good.py', force=True
     )
     assert 13 == len(checks)
 

--- a/unittests/test_pipeline.py
+++ b/unittests/test_pipeline.py
@@ -6,7 +6,6 @@
 import os
 import pytest
 import re
-import sys
 
 import reframe as rfm
 import reframe.core.runtime as rt


### PR DESCRIPTION
This PR enhances the naming scheme of tests by introducing the following concepts:

1. Each test is now associated with a unique id, which is a SHA256 hash. This hash is calculated based on the test name and its parameters, if it is a parameterized test.
2. The unique hash is available through the `hash_long` and `hash_short` properties.
3. A test gets a `unique_name`, which is essentially the test class name with the test hash appended, if the test is parameterized, i.e., `ParamTest_<hash_short>`. We could always append the test hash, but we choose not to do so, in order to maintain compatibility with the current naming scheme of non-parameterized tests.
4. The test's `name` becomes a human-readable version of the test's name. If the test is not parameterized, this is simply the qualified class name of the test. If it is parameterized, the parameter names and their values are appended as follows: `MyTest%param1=value1%param2=value2`
5. Modifying the test's `name` is now deprecated.
6. Test listings have been updated to include the test hashes.
7. Tests can also be selected by hash using the `-n` option as follows: `-n /<hash>`.
8. The test's `name` is no more used in paths. The `unique_name`, which is read-only and has no special characters, is used instead.
9. The test's default `executable` uses the `unique_name` instead of `name`.
10. The name of the generated job and build scripts do not contain the test name any more. They are simply `_rfm_build.{sh,out,err}`and `_rfm_run.{sh,out,err}`. The test name was superfluous here, since it is already part of the path.

### Implementation details

The parameterized tests defined using the `@parameterized_test` decorator are now implemented using the `parameter` built-in machinery. We essentially extend the test's parameter space with the parameters passed in the decorators. By inspecting the test's `__init__()` function we can also assign the right names to the parameters. However, one of the key differences of the `@parameterized_test` decorator compared to the `parameter` built-in is the way multiple parameters are treated.  The `parameter()` directive uses the external product of the parameters to create new tests, whereas the `@parameterized_test` decorator simply zips the parameters and passes them to the test's `__init__()` function. Supporting this requires to add the possibility to change the iteration scheme of the parameterization space. Another difference between the built-in and the decorator is that the parameterization space is inherited in the case of the built-in, such that a `@simple_test` that derives from a parameterized test is also parameterized. This is not the case, however, when using the decorator. To be able to support this using the built-in machinery, we had to mark a test that is parameterized in the old way, and do not allow inheritance of the parameterization space in this case. In the future, we should consider deprecating the `@parameterized_test` decorator, since it does not offer anything compared to the more powerful `parameter` built-in.

Other implementation changes:

- The `_rfm_init()` function is renamed to `__rfm_init__()` so as to be in sync with other special framework functions.
- The hacks in the series of sleep checks used in `test_policies` are now removed and a parameterized test is used.
- The framework's module import logic is extended so as to allow force reloading of a module. This is quite useful in unit tests, where we load multiple times the same tests and we would like every time to start fresh with the creation of its variable and parameter spaces. The addition of this logic to the basic module load utility functions allowed us to simplify the logic of some test loading unit test fixtures.

### Todos:

- [ ] Update documentation.
- [ ] Actually deprecate setting the test's `name`.
- [ ] Remove stale comments.
- [ ] Implement and test the `have_not_hash()` filter.

Fixes #1794.