### PR TITLE
[feat] Skip test if `sanity_patterns` is undefined

### DIFF
--- a/reframe/core/pipeline.py
+++ b/reframe/core/pipeline.py
@@ -603,7 +603,7 @@ class RegressionTest(RegressionMixin, jsonext.JSONSerializable):
     #:
     #:       ::
     #:
-    #:           self.sanity_patterns = sn.assert_found(r'.*', self.stdout)
+    #:           self.sanity_patterns = sn.assert_true(1)
     sanity_patterns = variable(_DeferredExpression, type(None), value=None)
 
     #: Patterns for verifying the performance of this test.

--- a/reframe/frontend/loader.py
+++ b/reframe/frontend/loader.py
@@ -81,7 +81,8 @@ class RegressionCheckLoader:
 
         name = type(check).__name__
         checkfile = os.path.relpath(inspect.getfile(type(check)))
-        required_attrs = ['valid_systems', 'valid_prog_environs']
+        required_attrs = ['sanity_patterns',
+                          'valid_systems', 'valid_prog_environs']
         for attr in required_attrs:
             if getattr(check, attr) is None:
                 getlogger().warning(

--- a/unittests/resources/checks/bad/invalid_check.py
+++ b/unittests/resources/checks/bad/invalid_check.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 import reframe as rfm
+import reframe.utility.sanity as sn
 
 
 @rfm.simple_test
@@ -11,6 +12,7 @@ class SomeTest(rfm.RegressionTest):
     def __init__(self):
         self.valid_systems = []
         self.valid_prog_environs = []
+        self.sanity_patterns = sn.assert_true(1)
 
 
 class NotATest:

--- a/unittests/resources/checks/emptycheck.py
+++ b/unittests/resources/checks/emptycheck.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 import reframe as rfm
+import reframe.utility.sanity as sn
 
 
 @rfm.simple_test
@@ -11,3 +12,4 @@ class EmptyTest(rfm.RegressionTest):
     def __init__(self):
         self.valid_systems = []
         self.valid_prog_environs = []
+        self.sanity_patterns = sn.assert_true(1)

--- a/unittests/resources/checks/frontend_checks.py
+++ b/unittests/resources/checks/frontend_checks.py
@@ -243,6 +243,7 @@ class TestWithGenerator(rfm.RunOnlyRegressionTest):
     def __init__(self):
         self.valid_systems = ['*']
         self.valid_prog_environs = ['*']
+        self.sanity_patterns = sn.assert_true(1)
 
         def foo():
             yield True
@@ -257,6 +258,7 @@ class TestWithFileObject(rfm.RunOnlyRegressionTest):
     def __init__(self):
         self.valid_systems = ['*']
         self.valid_prog_environs = ['*']
+        self.sanity_patterns = sn.assert_true(1)
         with open(__file__) as fp:
             pass
 

--- a/unittests/resources/checks_unlisted/good.py
+++ b/unittests/resources/checks_unlisted/good.py
@@ -8,6 +8,7 @@
 #
 
 import reframe as rfm
+import reframe.utility.sanity as sn
 
 # We just import this individually for testing purposes
 from reframe.core.pipeline import RegressionTest
@@ -17,6 +18,7 @@ class _Base(RegressionTest):
     def __init__(self):
         self.valid_systems = ['*']
         self.valid_prog_environs = ['*']
+        self.sanity_patterns = sn.assert_true(1)
 
 
 @rfm.parameterized_test(*((x, y) for x in range(3) for y in range(2)))

--- a/unittests/resources/checks_unlisted/kbd_interrupt.py
+++ b/unittests/resources/checks_unlisted/kbd_interrupt.py
@@ -11,6 +11,7 @@
 #
 
 import reframe as rfm
+import reframe.utility.sanity as sn
 
 
 @rfm.simple_test
@@ -21,6 +22,7 @@ class KeyboardInterruptCheck(rfm.RunOnlyRegressionTest):
         self.valid_systems = ['*']
         self.valid_prog_environs = ['*']
         self.tags = {self.name}
+        self.sanity_patterns = sn.assert_true(1)
 
     @rfm.run_before('setup')
     def raise_keyboard_interrupt(self):


### PR DESCRIPTION
It is a common mistake to forget to define the `sanity_patterns`. Now tests not defining them, will be skipped and a warning message will be issued, similarly to `valid_systems` and `valid_prog_environs`.