### PR TITLE
[bugfix] Set stdin to null when launching processes from ReFrame, so that processes do no think they are on a tty

### DIFF
--- a/reframe/utility/osext.py
+++ b/reframe/utility/osext.py
@@ -77,6 +77,7 @@ def run_command(cmd, check=False, timeout=None, shell=False, log=True):
 def run_command_async(cmd,
                       stdout=subprocess.PIPE,
                       stderr=subprocess.PIPE,
+                      stdin=subprocess.PIPE,
                       shell=False,
                       log=True,
                       **popen_args):
@@ -112,6 +113,7 @@ def run_command_async(cmd,
     return subprocess.Popen(args=cmd,
                             stdout=stdout,
                             stderr=stderr,
+                            stdin=stdin,
                             universal_newlines=True,
                             shell=shell,
                             **popen_args)

--- a/reframe/utility/osext.py
+++ b/reframe/utility/osext.py
@@ -77,7 +77,6 @@ def run_command(cmd, check=False, timeout=None, shell=False, log=True):
 def run_command_async(cmd,
                       stdout=subprocess.PIPE,
                       stderr=subprocess.PIPE,
-                      stdin=subprocess.PIPE,
                       shell=False,
                       log=True,
                       **popen_args):
@@ -113,7 +112,7 @@ def run_command_async(cmd,
     return subprocess.Popen(args=cmd,
                             stdout=stdout,
                             stderr=stderr,
-                            stdin=stdin,
+                            stdin=subprocess.DEVNULL,
                             universal_newlines=True,
                             shell=shell,
                             **popen_args)

--- a/unittests/test_utility.py
+++ b/unittests/test_utility.py
@@ -29,13 +29,6 @@ def test_command_success():
     assert completed.stdout == 'foobar\n'
 
 
-def test_command_stdin_isatty():
-    completed = osext.run_command(
-        "python -c 'import sys; print(sys.stdin.isatty())'")
-    assert completed.returncode == 0
-    assert completed.stdout == 'False\n'
-
-
 def test_command_success_cmd_seq():
     completed = osext.run_command(['echo', 'foobar'])
     assert completed.returncode == 0

--- a/unittests/test_utility.py
+++ b/unittests/test_utility.py
@@ -29,6 +29,13 @@ def test_command_success():
     assert completed.stdout == 'foobar\n'
 
 
+def test_command_stdin_isatty():
+    completed = osext.run_command(
+        "python -c 'import sys; print(sys.stdin.isatty())'")
+    assert completed.returncode == 0
+    assert completed.stdout == 'False\n'
+
+
 def test_command_success_cmd_seq():
     completed = osext.run_command(['echo', 'foobar'])
     assert completed.returncode == 0


### PR DESCRIPTION
Close #1877 