### PR TITLE
[bugfix] Fix the call order on the `__set_name__` hook for built-in variables

### DIFF
--- a/reframe/core/meta.py
+++ b/reframe/core/meta.py
@@ -82,9 +82,8 @@ class RegressionTestMeta(type):
                             if key in b._rfm_var_space:
                                 # Store a deep-copy of the variable's
                                 # value and return.
-                                self._namespace[key] = (
-                                    b._rfm_var_space[key].default_value
-                                )
+                                v = b._rfm_var_space[key].default_value
+                                self._namespace[key] = v
                                 return self._namespace[key]
 
                         # If 'key' is neither a variable nor a parameter,

--- a/reframe/core/meta.py
+++ b/reframe/core/meta.py
@@ -32,6 +32,7 @@ class RegressionTestMeta(type):
             if isinstance(value, variables.TestVar):
                 # Insert the attribute in the variable namespace
                 self['_rfm_local_var_space'][key] = value
+                value.__set_name__(self, key)
 
                 # Override the regular class attribute (if present)
                 self._namespace.pop(key, None)
@@ -64,9 +65,7 @@ class RegressionTestMeta(type):
             except KeyError as err:
                 try:
                     # Handle variable access
-                    v = self['_rfm_local_var_space'][key]
-                    v.__set_name__(self, key)
-                    return v
+                    return self['_rfm_local_var_space'][key]
 
                 except KeyError:
                     # Handle parameter access
@@ -81,12 +80,11 @@ class RegressionTestMeta(type):
                         # available in the current class' namespace.
                         for b in self['_rfm_bases']:
                             if key in b._rfm_var_space:
-                                v = b._rfm_var_space[key]
-                                v.__set_name__(self, key)
-
                                 # Store a deep-copy of the variable's
                                 # value and return.
-                                self._namespace[key] = v.default_value
+                                self._namespace[key] = (
+                                    b._rfm_var_space[key].default_value
+                                )
                                 return self._namespace[key]
 
                         # If 'key' is neither a variable nor a parameter,

--- a/reframe/core/parameters.py
+++ b/reframe/core/parameters.py
@@ -46,9 +46,6 @@ class TestParam:
         self.values = tuple(values)
         self.filter_params = filter_params
 
-    def __set_name__(self, owner, name):
-        self.name = name
-
 
 class ParamSpace(namespaces.Namespace):
     ''' Regression test parameter space

--- a/unittests/test_variables.py
+++ b/unittests/test_variables.py
@@ -211,6 +211,13 @@ def test_override_regular_attribute():
     assert Foo.v == 40
 
 
+def test_var_name_is_set():
+    class MyTest (rfm.RegressionTest):
+        v = variable(int)
+
+    assert MyTest.v.name == 'v'
+
+
 def test_variable_with_attribute():
     class Foo:
         pass


### PR DESCRIPTION
When declaring a variable with the `variable` built-in, the corresponding `__set_name__` hook was only called if needed by the `__getitem__` method of the metaclass. This is because the variables are temporarily hidden away in their own namespace, and the `__set_name__` hooks from these variables don't get called by the base metaclass `type`.

Hence, it is a bit counterintuitive (if not just plainly wrong) that things get set when calling the `__getitem__` method; so now the `__set_name__` hook is called unconditionally for all variables in the `__setitem__` method of the metaclass.