### PR TITLE
[doc] Make basic configuration example more intuitive w.r.t. to modules systems

### DIFF
--- a/docs/configure.rst
+++ b/docs/configure.rst
@@ -68,7 +68,7 @@ Each system is a different object inside the ``systems`` section.
 In our example we define three systems, a Mac laptop, Piz Daint and a generic fallback system:
 
 .. literalinclude:: ../tutorials/config/settings.py
-   :lines: 11-89
+   :lines: 11-90
 
 Each system is associated with a set of properties, which in this case are the following:
 
@@ -90,7 +90,7 @@ The ``login`` partition refers to the login nodes of the system, whereas the ``g
 Let's pick the ``gpu`` partition and look into it in more detail:
 
 .. literalinclude:: ../tutorials/config/settings.py
-   :lines: 38-58
+   :lines: 39-59
 
 The basic properties of a partition are the following:
 
@@ -132,7 +132,7 @@ In our example, we define environments for all the basic compilers as well as a 
 In certain contexts, it is useful to see a ReFrame environment as a wrapper of a programming toolchain (MPI + compiler combination):
 
 .. literalinclude:: ../tutorials/config/settings.py
-   :lines: 90-148
+   :lines: 91-149
 
 Each environment is associated with a name.
 This name will be used to reference this environment in different contexts, as for example in the ``environs`` property of the system partitions.
@@ -154,7 +154,7 @@ Additionally, it allows for logging performance data from performance tests into
 Let's see how logging is defined in our example configuration, which also represents a typical one for logging:
 
 .. literalinclude:: ../tutorials/config/settings.py
-   :lines: 149-184
+   :lines: 150-185
 
 Logging is configured under the ``logging`` section of the configuration, which is a list of logger objects.
 Unless you want to configure logging differently for different systems, a single logger object is enough.

--- a/docs/tutorial_advanced.rst
+++ b/docs/tutorial_advanced.rst
@@ -499,7 +499,7 @@ You can then use those resources transparently from within your test.
 To achieve this in our case, we first need to define a ``memory`` resource in the configuration:
 
 .. literalinclude:: ../tutorials/config/settings.py
-   :lines: 30-51,58-74
+   :lines: 31-52,59-75
    :emphasize-lines: 17-22,32-38
 
 Notice that we do not define the resource for all the partitions, but only for those that it makes sense.
@@ -707,7 +707,7 @@ ReFrame can be used also to test applications that run inside a container.
 First, we need to enable the container platform support in ReFrame's configuration and, specifically, at the partition configuration level:
 
 .. literalinclude:: ../tutorials/config/settings.py
-   :lines: 38-62
+   :lines: 39-63
    :emphasize-lines: 15-24
 
 For each partition, users can define a list of container platforms supported using the :js:attr:`container_platforms` `configuration parameter <config_reference.html#.systems[].partitions[].container_platforms>`__.

--- a/docs/tutorial_basics.rst
+++ b/docs/tutorial_basics.rst
@@ -325,8 +325,8 @@ Note that you should *not* edit this configuration file in place.
 Here is how the new configuration file looks like with the needed additions highlighted:
 
 .. literalinclude:: ../tutorials/config/settings.py
-   :lines: 10-24,80-101,134-
-   :emphasize-lines: 3-15,31-42
+   :lines: 10-25,81-102,135-
+   :emphasize-lines: 3-16,32-43
 
 Here we define a system named ``catalina`` that has one partition named ``default``.
 This partition makes no use of any `workload manager <config_reference.html#.systems[].partitions[].scheduler>`__, but instead launches any jobs locally as OS processes.
@@ -809,8 +809,8 @@ Let's extend our configuration file for Piz Daint.
 
 
 .. literalinclude:: ../tutorials/config/settings.py
-   :lines: 10-45,62-70,77-
-   :emphasize-lines: 16-48,70-101,114-120
+   :lines: 10-46,63-71,78-
+   :emphasize-lines: 17-49,71-102,115-121
 
 
 First of all, we need to define a new system and set the list of hostnames that will help ReFrame identify it.

--- a/tutorials/config/settings.py
+++ b/tutorials/config/settings.py
@@ -13,6 +13,7 @@ site_configuration = {
             'name': 'catalina',
             'descr': 'My Mac',
             'hostnames': ['tresa'],
+            'modules_system': 'nomod',
             'partitions': [
                 {
                     'name': 'default',


### PR DESCRIPTION
A laptop would generally not have modules, so saying that explicitly
will help highlight to new users that a module setting can be
useful. There is a modules setting below for daint, but at least one
user skimmed over the more complex case.

The line numbers for the literal includes need to be bumped if they
are greater than 15, and a range including 15 is shown, then the
highlighting can need a bump. Note that the latter index within the
range shown, so don't always need a bump.

Fixes #1887