### PR TITLE
[bugfix] Color `bootstrap.sh` only if stdout is a terminal

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -9,10 +9,12 @@
 # Bootstrap script for running ReFrame from source
 #
 
-BLUE='\033[0;34m'
-GREEN='\033[0;32m'
-YELLOW='\033[0;33m'
-NC='\033[0m'
+if [ -t 1 ]; then
+    BLUE='\033[0;34m'
+    GREEN='\033[0;32m'
+    YELLOW='\033[0;33m'
+    NC='\033[0m'
+fi
 
 CMD()
 {


### PR DESCRIPTION
Fixes #1855 