### PR TITLE
[bugfix] Fix bootstrap script for `pip`-less Python installations

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -70,15 +70,16 @@ fi
 # Check if ensurepip is installed
 $python -m ensurepip --version &> /dev/null
 
+export PATH=$(pwd)/external/usr/bin:$PATH
+
 # Install pip for Python 3
 if [ $? -eq 0 ]; then
-    CMD $python -m ensurepip --root external/ --default-pip
+    CMD $python -m ensurepip --root $(pwd)/external/ --default-pip
 fi
 
 # ensurepip installs pip in `external/usr/` whereas the --target option installs
 # everything under `external/`. That's why we include both in the PYTHONPATH
 
-export PATH=$(pwd)/external/usr/bin:$PATH
 export PYTHONPATH=$(pwd)/external:$(pwd)/external/usr/lib/python$pyver/site-packages:$PYTHONPATH
 
 CMD $python -m pip install --no-cache-dir -q --upgrade pip --target=external/

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -77,7 +77,7 @@ if [ $? -eq 0 ]; then
     CMD $python -m ensurepip --root $(pwd)/external/ --default-pip
 fi
 
-# ensurepip installs pip in `external/usr/` whereas the --target option installs
+# ensurepip installs pip in `external/usr/` whereas the `--root` option installs
 # everything under `external/`. That's why we include both in the PYTHONPATH
 
 export PYTHONPATH=$(pwd)/external:$(pwd)/external/usr/lib/python$pyver/site-packages:$PYTHONPATH


### PR DESCRIPTION
Jumping from Python 3.6.10 to 3.6.12 on Dom has caused the bootstrap script to fail.