### PR TITLE
bump to latest importlib-metadata, only use with Python < 3.8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 argcomplete==1.12.2
 coverage==5.3
-importlib_metadata==2.0.0
+importlib_metadata==3.10.0; python_version < '3.8'
 jsonschema==3.2.0
 pytest==6.2.0
 pytest-forked==1.3.0


### PR DESCRIPTION
Relying on an older `importlib-metadata` is a problem when other Python packages are installed that require a newer version (see https://github.com/EESSI/software-layer/issues/81 for example).

In addition, `importlib-metadata` is part of the Python standard library since 3.8, so then you don't need a separate installation at all (cfr. https://github.com/python/importlib_metadata#readme).