### PR TITLE
[bugfix] Fix crash when `sourcesdir` is set to `None` in class body

### DIFF
--- a/reframe/core/pipeline.py
+++ b/reframe/core/pipeline.py
@@ -845,8 +845,8 @@ class RegressionTest(RegressionMixin, jsonext.JSONSerializable):
 
         # Static directories of the regression check
         self._prefix = os.path.abspath(prefix)
-        if (not os.path.isdir(os.path.join(self._prefix, self.sourcesdir)) and
-            not osext.is_url(self.sourcesdir)):
+        if (self.sourcesdir == 'src' and
+            not os.path.isdir(os.path.join(self._prefix, self.sourcesdir))):
             self.sourcesdir = None
 
         # Runtime information of the test

--- a/unittests/test_pipeline.py
+++ b/unittests/test_pipeline.py
@@ -272,6 +272,20 @@ def test_run_only_no_srcdir(local_exec_ctx):
     _run(test, *local_exec_ctx)
 
 
+def test_run_only_srcdir_set_to_none(local_exec_ctx):
+    @fixtures.custom_prefix('foo/bar/')
+    class MyTest(rfm.RunOnlyRegressionTest):
+        executable = 'echo'
+        valid_prog_environs = ['*']
+        valid_systems = ['*']
+        sourcesdir = None
+        sanity_patterns = sn.assert_true(1)
+
+    test = MyTest()
+    assert test.sourcesdir is None
+    _run(test, *local_exec_ctx)
+
+
 def test_compile_only_failure(local_exec_ctx):
     @fixtures.custom_prefix('unittests/resources/checks')
     class MyTest(rfm.CompileOnlyRegressionTest):


### PR DESCRIPTION
I've also changed the automatic assignment of `sourcesdir` to `None` so as to avoid setting it so, in cases that the user has explicitly passed a directory that does not exist. For this one, I'm taking advantage of the default value that is being set by the variables.

Fixes #1869.