### PR TITLE
[feat] Issue a warning if a module operation is attempted on the `nomod` modules system

### DIFF
--- a/reframe/core/modules.py
+++ b/reframe/core/modules.py
@@ -1008,6 +1008,14 @@ class LModImpl(TMod4Impl):
 class NoModImpl(ModulesSystemImpl):
     '''A convenience class that implements a no-op a modules system.'''
 
+    def _warn(self, msg):
+        getlogger().warning(
+            f"no modules system is set: {msg}: "
+            f"check the 'modules_system' configuration "
+            f"parameter for your system",
+            cache=True
+        )
+
     def available_modules(self, substr):
         return []
 
@@ -1021,10 +1029,10 @@ class NoModImpl(ModulesSystemImpl):
         return ''
 
     def load_module(self, module):
-        pass
+        self._warn(f'module {module.name!r} will not be loaded')
 
     def unload_module(self, module):
-        pass
+        self._warn(f'module {module.name!r} will not be unloaded')
 
     def is_module_loaded(self, module):
         #
@@ -1043,21 +1051,23 @@ class NoModImpl(ModulesSystemImpl):
         return ''
 
     def unload_all(self):
-        pass
+        self._warn('no module will be purged')
 
     def searchpath(self):
         return []
 
     def searchpath_add(self, *dirs):
-        pass
+        self._warn('MODULEPATH will not be modified')
 
     def searchpath_remove(self, *dirs):
-        pass
+        self._warn('MODULEPATH will not be modified')
 
     def emit_load_instr(self, module):
+        self._warn(f'module {module.name!r} will not be loaded')
         return []
 
     def emit_unload_instr(self, module):
+        self._warn(f'module {module.name!r} will not be unloaded')
         return []
 
 

--- a/unittests/test_logging.py
+++ b/unittests/test_logging.py
@@ -328,6 +328,18 @@ def test_handler_noappend(make_exec_ctx, config_file, logfile):
     assert _found_in_logfile('bar', logfile)
 
 
+def test_warn_once(default_exec_ctx, logfile):
+    rlog.configure_logging(rt.runtime().site_config)
+    rlog.getlogger().warning('foo', cache=True)
+    rlog.getlogger().warning('foo', cache=True)
+    rlog.getlogger().warning('foo', cache=True)
+    _flush_handlers()
+    _close_handlers()
+
+    with open(logfile, 'rt') as fp:
+        assert len(re.findall('foo', fp.read())) == 1
+
+
 def test_date_format(default_exec_ctx, logfile):
     rlog.configure_logging(rt.runtime().site_config)
     rlog.getlogger().warning('foo')


### PR DESCRIPTION
In order to avoid multiple warnings, this PR introduces also a caching mechanism for warnings. Warnings that are intended to be cached, must be issued with `cache=True`. Currently, only warnings from `nomod` are issued in such a way.

Fixes #1892.