### PR TITLE
[feat] Support test retries in the JUnit report

### DIFF
--- a/docs/manpage.rst
+++ b/docs/manpage.rst
@@ -277,11 +277,14 @@ Options controlling ReFrame output
 .. option:: --report-junit=FILE
 
    Instruct ReFrame to generate a JUnit XML report in ``FILE``.
-   The generated report adheres to the XSD schema `here <https://github.com/windyroad/JUnit-Schema/blob/master/JUnit.xsd>`__ and it takes into account only the first run, ignoring retries of failed tests.
+   The generated report adheres to the XSD schema `here <https://github.com/windyroad/JUnit-Schema/blob/master/JUnit.xsd>`__ where each retry is treated as an individual testsuite.
 
    This option can also be set using the :envvar:`RFM_REPORT_JUNIT` environment variable or the :js:attr:`report_junit` general configuration parameter.
 
    .. versionadded:: 3.6.0
+
+   .. versionchanged:: 3.6.1
+      Added support for retries in the JUnit XML report.
 
 
 -------------------------------------

--- a/reframe/frontend/runreport.py
+++ b/reframe/frontend/runreport.py
@@ -167,7 +167,7 @@ def junit_xml_report(json_report):
                 'failures': str(rfm_run['num_failures']),
                 'hostname': json_report['session_info']['hostname'],
                 'id': str(run_id),
-                'name': f'ReFrame run {run_id + 1}',
+                'name': f'ReFrame run {run_id}',
                 'package': 'reframe',
                 'tests': str(rfm_run['num_cases']),
                 'time': str(json_report['session_info']['time_elapsed']),

--- a/reframe/frontend/runreport.py
+++ b/reframe/frontend/runreport.py
@@ -159,51 +159,52 @@ def junit_xml_report(json_report):
     '''Generate a JUnit report from a standard ReFrame JSON report.'''
 
     xml_testsuites = etree.Element('testsuites')
-    xml_testsuite = etree.SubElement(
-        xml_testsuites, 'testsuite',
-        attrib={
-            'errors': '0',
-            'failures': str(json_report['session_info']['num_failures']),
-            'hostname': json_report['session_info']['hostname'],
-            'id': '0',
-            'name': 'reframe',
-            'package': 'reframe',
-            'tests': str(json_report['session_info']['num_cases']),
-            'time': str(json_report['session_info']['time_elapsed']),
-
-            # XSD schema does not like the timezone format, so we remove it
-            'timestamp': json_report['session_info']['time_start'][:-5],
-        }
-    )
-    testsuite_properties = etree.SubElement(xml_testsuite, 'properties')
-    for testid in range(len(json_report['runs'][0]['testcases'])):
-        tid = json_report['runs'][0]['testcases'][testid]
-        casename = (
-            f"{tid['name']}[{tid['system']}, {tid['environment']}]"
-        )
-        testcase = etree.SubElement(
-            xml_testsuite, 'testcase',
+    for run_id, rfm_run in enumerate(json_report['runs']):
+        xml_testsuite = etree.SubElement(
+            xml_testsuites, 'testsuite',
             attrib={
-                'classname': tid['filename'],
-                'name': casename,
+                'errors': '0',
+                'failures': str(rfm_run['num_failures']),
+                'hostname': json_report['session_info']['hostname'],
+                'id': str(run_id),
+                'name': f'ReFrame run {run_id + 1}',
+                'package': 'reframe',
+                'tests': str(rfm_run['num_cases']),
+                'time': str(json_report['session_info']['time_elapsed']),
 
-                # XSD schema does not like the exponential format and since we
-                # do not want to impose a fixed width, we pass it to `Decimal`
-                # to format it automatically.
-                'time': str(decimal.Decimal(tid['time_total'])),
+                # XSD schema does not like the timezone format, so we remove it
+                'timestamp': json_report['session_info']['time_start'][:-5],
             }
         )
-        if tid['result'] == 'failure':
-            testcase_msg = etree.SubElement(
-                testcase, 'failure', attrib={'type': 'failure',
-                                             'message': tid['fail_phase']}
+        testsuite_properties = etree.SubElement(xml_testsuite, 'properties')
+        for tc in rfm_run['testcases']:
+            casename = (
+                f"{tc['name']}[{tc['system']}, {tc['environment']}]"
             )
-            testcase_msg.text = f"{tid['fail_phase']}: {tid['fail_reason']}"
+            testcase = etree.SubElement(
+                xml_testsuite, 'testcase',
+                attrib={
+                    'classname': tc['filename'],
+                    'name': casename,
 
-    testsuite_stdout = etree.SubElement(xml_testsuite, 'system-out')
-    testsuite_stdout.text = ''
-    testsuite_stderr = etree.SubElement(xml_testsuite, 'system-err')
-    testsuite_stderr.text = ''
+                    # XSD schema does not like the exponential format and since
+                    # we do not want to impose a fixed width, we pass it to
+                    # `Decimal` to format it automatically.
+                    'time': str(decimal.Decimal(tc['time_total'])),
+                }
+            )
+            if tc['result'] == 'failure':
+                testcase_msg = etree.SubElement(
+                    testcase, 'failure', attrib={'type': 'failure',
+                                                 'message': tc['fail_phase']}
+                )
+                testcase_msg.text = f"{tc['fail_phase']}: {tc['fail_reason']}"
+
+        testsuite_stdout = etree.SubElement(xml_testsuite, 'system-out')
+        testsuite_stdout.text = ''
+        testsuite_stderr = etree.SubElement(xml_testsuite, 'system-err')
+        testsuite_stderr.text = ''
+
     return xml_testsuites
 
 


### PR DESCRIPTION
* Each retry(run) is passed as an individual testsuite to the junit report.

Fixes #1963 