### PR TITLE
[bugfix] Fix error checking of module commands in the class Tmod backends

### DIFF
--- a/reframe/core/modules.py
+++ b/reframe/core/modules.py
@@ -637,7 +637,7 @@ class TModImpl(ModulesSystemImpl):
     def _execute(self, cmd, *args):
         modulecmd = self.modulecmd(cmd, *args)
         completed = osext.run_command(modulecmd)
-        if re.search(r'ERROR', completed.stderr) is not None:
+        if re.search(r'\bERROR\b', completed.stderr) is not None:
             raise SpawnedProcessError(modulecmd,
                                       completed.stdout,
                                       completed.stderr,
@@ -769,7 +769,7 @@ class TMod31Impl(TModImpl):
     def _execute(self, cmd, *args):
         modulecmd = self.modulecmd(cmd, *args)
         completed = osext.run_command(modulecmd)
-        if re.search(r'ERROR', completed.stderr) is not None:
+        if re.search(r'\bERROR\b', completed.stderr) is not None:
             raise SpawnedProcessError(modulecmd,
                                       completed.stdout,
                                       completed.stderr,

--- a/unittests/modules/testmod_bar
+++ b/unittests/modules/testmod_bar
@@ -10,3 +10,4 @@ conflict testmod_foo
 conflict testmod_boo
 
 setenv TESTMOD_BAR "BAR"
+setenv TESTMOD_ERROR "BARERROR"


### PR DESCRIPTION
- Test for `ERROR` word when checking success of module command

Fixes #1967 