### PR TITLE
[bugfix] Fix variable and parameter access as class attributes

### DIFF
--- a/reframe/core/meta.py
+++ b/reframe/core/meta.py
@@ -197,14 +197,15 @@ class RegressionTestMeta(type):
         return obj
 
     def __getattr__(cls, name):
-        ''' Attribute lookup method for the MetaNamespace.
+        '''Attribute lookup method for the MetaNamespace.
 
         This metaclass uses a custom namespace, where ``variable`` built-in
         and ``parameter`` types are stored in their own sub-namespaces (see
-        :class:`reframe.core.meta.RegressionTestMeta.MetaNamespace`).
-        This method will perform an attribute lookup on these sub-namespaces if
-        a call to the default ``__getattribute__`` method fails to retrieve the
-        requested class attribute.
+        :class:`reframe.core.meta.RegressionTestMeta.MetaNamespace`). This
+        method will perform an attribute lookup on these sub-namespaces if a
+        call to the default :func:`__getattribute__` method fails to retrieve
+        the requested class attribute.
+
         '''
 
         try:
@@ -218,7 +219,7 @@ class RegressionTestMeta(type):
                 ) from None
 
     def __setattr__(cls, name, value):
-        ''' Handle the special treatment required for variables and parameters.
+        '''Handle the special treatment required for variables and parameters.
 
         A variable's default value can be updated when accessed as a regular
         class attribute. This behaviour does not apply when the assigned value

--- a/reframe/core/meta.py
+++ b/reframe/core/meta.py
@@ -230,7 +230,7 @@ class RegressionTestMeta(type):
         re-overriden in any case).
 
         Altering the value of a parameter when accessed as a class attribute
-        is not allowed.
+        is not allowed. This would break the parameter space internals.
         '''
 
         # Set the value of a variable (except when the value is a descriptor).

--- a/reframe/core/variables.py
+++ b/reframe/core/variables.py
@@ -39,22 +39,20 @@ class TestVar:
     '''
 
     __slots__ = (
-        'field_type', '_default_value', 'name',
-        'args', 'kwargs', '__attrs__'
+        'field', '_default_value', 'name', '__attrs__'
     )
 
     def __init__(self, *args, **kwargs):
-        self.field_type = kwargs.pop('field', fields.TypedField)
+        field_type = kwargs.pop('field', fields.TypedField)
         self._default_value = kwargs.pop('value', Undefined)
 
-        if not issubclass(self.field_type, fields.Field):
+        if not issubclass(field_type, fields.Field):
             raise ValueError(
-                f'field {self.field_type!r} is not derived from '
+                f'field {field_type!r} is not derived from '
                 f'{fields.Field.__qualname__}'
             )
 
-        self.args = args
-        self.kwargs = kwargs
+        self.field = field_type(*args, **kwargs)
         self.__attrs__ = dict()
 
     def is_defined(self):
@@ -528,7 +526,7 @@ class VarSpace(namespaces.Namespace):
         '''
 
         for name, var in self.items():
-            setattr(cls, name, var.field_type(*var.args, **var.kwargs))
+            setattr(cls, name, var.field)
             getattr(cls, name).__set_name__(obj, name)
 
             # If the var is defined, set its value

--- a/unittests/test_parameters.py
+++ b/unittests/test_parameters.py
@@ -301,3 +301,12 @@ def test_local_paramspace_is_empty():
         p = parameter([1, 2, 3])
 
     assert len(MyTest._rfm_local_param_space) == 0
+
+
+def test_class_attr_access():
+    class MyTest(rfm.RegressionTest):
+        p = parameter([1, 2, 3])
+
+    assert MyTest.p == (1, 2, 3,)
+    with pytest.raises(ValueError, match='cannot override parameter'):
+        MyTest.p = (4, 5,)

--- a/unittests/test_variables.py
+++ b/unittests/test_variables.py
@@ -99,6 +99,26 @@ def test_double_declare():
             v0 = variable(float, value=0.5)
 
 
+def test_class_attr_access():
+    class MyTest(rfm.RegressionTest):
+        v0 = variable(int, value=1)
+
+    assert MyTest.v0 == 1
+    MyTest.v0 = 2
+    assert MyTest.v0 == 2
+    MyTest.v0 += 1
+    assert MyTest.v0 == 3
+    assert MyTest().v0 == 3
+
+    class Descriptor:
+        '''Dummy descriptor to attempt overriding the variable descriptor.'''
+        def __get__(self, obj, objtype=None):
+            return 'dummy descriptor'
+
+    with pytest.raises(ValueError, match='cannot override variable descr'):
+        MyTest.v0 = Descriptor()
+
+
 def test_double_action_on_variable():
     '''Modifying a variable in the class body is permitted.'''
     class MyTest(rfm.RegressionTest):


### PR DESCRIPTION
This PR fixes a bug that was causing variables and parameters set as class attributes to be silently overridden. Bug reproducer:
```python
class Base(rfm.RegressionTest):
    ...
    p = parameter([1])
    v = variable(int, value=1)

Base.p = [2] # This PR will disallow updating parameters like this.
Base.v = 2

@rfm.simple_test
class Derived(Base):
    def __init__(self):
        print(self.p) # Prints 1
        print(self.v) # Prints 1. With this PR this prints 2.
```
This PR disables setting/updating parameters when accessed as class attributes. This is because such parameter update would break the internal iterators on the parameter space. If this feature is required, explicit `insert_parameter` or `update_parameter` class methods could be added.

This might be needed by #563