### PR TITLE
[bugfix] Restrict use of `required` keyword

### DIFF
--- a/reframe/core/meta.py
+++ b/reframe/core/meta.py
@@ -243,7 +243,7 @@ class RegressionTestMeta(type):
 
         blacklist = [
             'parameter', 'variable', 'bind', 'run_before', 'run_after',
-            'require_deps'
+            'require_deps', 'required'
         ]
         for b in blacklist:
             namespace.pop(b, None)

--- a/reframe/core/variables.py
+++ b/reframe/core/variables.py
@@ -493,6 +493,11 @@ class VarSpace(namespaces.Namespace):
             if key in self.vars:
                 self.vars[key].define(value)
                 _assigned_vars.add(key)
+            elif value is Undefined:
+                # Cannot be set as Undefined if not a variable
+                raise ValueError(
+                    f'{key!r} has not been declared as a variable'
+                )
 
         # Delete the vars from the class __dict__.
         for key in _assigned_vars:

--- a/unittests/test_meta.py
+++ b/unittests/test_meta.py
@@ -20,6 +20,7 @@ def test_directives():
         run_before('run')(ext)
         run_after('run')(ext)
         require_deps(ext)
+        v = required
 
         def __init__(self):
             assert not hasattr(self, 'parameter')
@@ -28,6 +29,7 @@ def test_directives():
             assert not hasattr(self, 'run_before')
             assert not hasattr(self, 'run_after')
             assert not hasattr(self, 'require_deps')
+            assert not hasattr(self, 'required')
 
     MyTest()
 

--- a/unittests/test_variables.py
+++ b/unittests/test_variables.py
@@ -170,6 +170,13 @@ def test_required_var_not_present(OneVarTest):
     MyTest()
 
 
+def test_required_non_var():
+    msg = "'not_a_var' has not been declared as a variable"
+    with pytest.raises(ValueError, match=msg):
+        class Foo(rfm.RegressionTest):
+            not_a_var = required
+
+
 def test_invalid_field():
     class Foo:
         '''An invalid descriptor'''


### PR DESCRIPTION
See linked issue for details.

Closes #2011.