### PR TITLE
[bugfix] Fix deep-copy of `_Undefined` constant

### DIFF
--- a/reframe/core/buildsystems.py
+++ b/reframe/core/buildsystems.py
@@ -14,6 +14,10 @@ from reframe.core.exceptions import BuildSystemError
 
 class _UndefinedType:
     '''Used as an initial value for undefined values instead of None.'''
+    __slots__ = ()
+
+    def __deepcopy__(self, memo):
+        return self
 
 
 _Undefined = _UndefinedType()
@@ -866,7 +870,7 @@ class Spack(BuildSystem):
 
     def emit_build_commands(self, environ):
         self._prefix_save = os.getcwd()
-        if isinstance(self.environment, _UndefinedType):
+        if self.environment is _Undefined:
             raise BuildSystemError(f'no Spack environment is defined')
 
         ret = self._env_activate_cmds()

--- a/reframe/core/buildsystems.py
+++ b/reframe/core/buildsystems.py
@@ -866,7 +866,7 @@ class Spack(BuildSystem):
 
     def emit_build_commands(self, environ):
         self._prefix_save = os.getcwd()
-        if self.environment is _Undefined:
+        if isinstance(self.environment, _UndefinedType):
             raise BuildSystemError(f'no Spack environment is defined')
 
         ret = self._env_activate_cmds()


### PR DESCRIPTION
The condition `self.environment is _Undefined` is always `False`, so the error
is actually never raised.

Without this change, I get a much more obscure error message:
```
==============================================================================
SUMMARY OF FAILURES
------------------------------------------------------------------------------
FAILURE INFO for Test 
  * Test Description: Test
  * System partition: catalina:default
  * Environment: gnu
  * Stage directory: /home/mose/repo/reframe/stage/catalina/default/gnu/Test
  * Node list: 
  * Job type: local (id=None)
  * Dependencies (conceptual): []
  * Dependencies (actual): []
  * Maintainers: []
  * Failing phase: compile_wait
  * Rerun with '-n Test -p gnu --system catalina:default -r'
  * Reason: build error: stdout: 'rfm_Test_build.out', stderr: 'rfm_Test_build.err'
--- rfm_Test_build.err (first 10 lines) ---
/home/mose/repo/reframe/stage/catalina/default/gnu/Test/rfm_Test_build.sh: line 13: syntax error near unexpected token `newline'
/home/mose/repo/reframe/stage/catalina/default/gnu/Test/rfm_Test_build.sh: line 13: `spack env activate -V -d <reframe.core.buildsystems._UndefinedType object at 0x7effb15a5c70>'
--- rfm_Test_build.err --- 
------------------------------------------------------------------------------
Log file(s) saved in: '/tmp/rfm-mtmrgbz_.log'
```
With this change I get
```
==============================================================================
SUMMARY OF FAILURES
------------------------------------------------------------------------------
FAILURE INFO for Test 
  * Test Description: Test
  * System partition: catalina:default
  * Environment: gnu
  * Stage directory: /home/mose/repo/reframe/stage/catalina/default/gnu/Test
  * Node list: 
  * Job type: local (id=None)
  * Dependencies (conceptual): []
  * Dependencies (actual): []
  * Maintainers: []
  * Failing phase: compile
  * Rerun with '-n Test -p gnu --system catalina:default -r'
  * Reason: build system error: no Spack environment is defined
------------------------------------------------------------------------------
Log file(s) saved in: '/tmp/rfm-93cirj79.log'
```
which I guess was the point of this check