### PR TITLE
[test] Bugfix `cuda_aware_mpi_check`

### DIFF
--- a/cscs-checks/prgenv/cuda/cuda_aware_mpi.py
+++ b/cscs-checks/prgenv/cuda/cuda_aware_mpi.py
@@ -47,6 +47,10 @@ class cuda_aware_mpi_check(rfm.CompileOnlyRegressionTest):
     def set_compilers(self):
         if self.current_environ.name == 'PrgEnv-pgi':
             self.build_system.cflags = ['-std=c99', ' -O3']
+        elif self.current_environ.name == 'PrgEnv-nvidia':
+            self.variables = {
+                'CUDA_HOME': '/opt/nvidia/hpc_sdk/Linux_x86_64/21.3/cuda'
+            }
 
         gcd_flgs = (
             '-gencode arch=compute_{0},code=sm_{0}'.format(self.gpu_arch)

--- a/cscs-checks/prgenv/cuda/cuda_aware_mpi.py
+++ b/cscs-checks/prgenv/cuda/cuda_aware_mpi.py
@@ -49,7 +49,7 @@ class cuda_aware_mpi_check(rfm.CompileOnlyRegressionTest):
             self.build_system.cflags = ['-std=c99', ' -O3']
         elif self.current_environ.name == 'PrgEnv-nvidia':
             self.variables = {
-                'CUDA_HOME': '/opt/nvidia/hpc_sdk/Linux_x86_64/21.3/cuda'
+                'CUDA_HOME': '$CRAY_NVIDIA_PREFIX/cuda'
             }
 
         gcd_flgs = (


### PR DESCRIPTION
The `CUDA_HOME` env var was missing and has to be added manually for the `PrgEnv-nvidia`