### PR TITLE
[feat] Show % of reference value in performance report

### DIFF
--- a/reframe/frontend/statistics.py
+++ b/reframe/frontend/statistics.py
@@ -313,12 +313,15 @@ class TestStats:
             for key, ref in t.check.perfvalues.items():
                 var = key.split(':')[-1]
                 val = ref[0]
-                try:
-                    unit = ref[4]
-                except IndexError:
-                    unit = '(no unit specified)'
+                unit = ' ' + ref[4] if ref[4] else ''
+                ref_val = ref[1]
+                if ref_val:
+                    percent = round(val / ref_val * 100)
+                    details = f' ({percent}% of {ref_val}{unit})'
+                else:
+                    details = ''
 
-                report_body.append(f'      * {var}: {val} {unit}')
+                report_body.append(f'      * {var}: {val}{unit}{details}')
 
         if report_body:
             return '\n'.join([report_start, report_title, *report_body,

--- a/unittests/test_cli.py
+++ b/unittests/test_cli.py
@@ -377,7 +377,7 @@ def test_performance_report(run_reframe):
         more_options=['-t', 'PerformanceFailureCheck', '--performance-report']
     )
     assert r'PERFORMANCE REPORT' in stdout
-    assert r'perf: 10 Gflop/s (50% of 20 Gflop/s)' in stdout
+    assert r'perf: 10 Gflop/s ( 50% of 20 Gflop/s)' in stdout
 
 
 def test_skip_system_check_option(run_reframe):

--- a/unittests/test_cli.py
+++ b/unittests/test_cli.py
@@ -377,7 +377,7 @@ def test_performance_report(run_reframe):
         more_options=['-t', 'PerformanceFailureCheck', '--performance-report']
     )
     assert r'PERFORMANCE REPORT' in stdout
-    assert r'perf: 10 Gflop/s' in stdout
+    assert r'perf: 10 Gflop/s (50% of 20 Gflop/s)' in stdout
 
 
 def test_skip_system_check_option(run_reframe):


### PR DESCRIPTION
This adds a little section in the performance report that compares each value to its corresponding reference value. It's a tiny change, but something I thought might be useful, and it's also simple enough that I thought it might be a good first contribution.

As an example, the performance report for `tutorials/basics/stream/stream2.py` now looks like this:
```text
PERFORMANCE REPORT
------------------------------------------------------------------------------
StreamWithRefTest
- prism:default
   - gnu
      * num_tasks: 1
      * Copy: 34477.1 MB/s (137% of 25200 MB/s)
      * Scale: 22701.7 MB/s (135% of 16800 MB/s)
      * Add: 24816.0 MB/s (134% of 18500 MB/s)
      * Triad: 24675.3 MB/s (131% of 18800 MB/s)
------------------------------------------------------------------------------
```
Also, as part of this change, `(no unit specified)` is no longer shown when there's no unit.

Feedback is welcome, especially since this is a visual change. Here are some possible changes I thought of (reference values changed for demonstration purposes):
<details>
 <summary>Increasing spacing before details</summary>

```text
PERFORMANCE REPORT
------------------------------------------------------------------------------
StreamWithRefTest
- prism:default
   - gnu
      * num_tasks: 1
      * Copy: 34496.6 MB/s  (3% of 1000000 MB/s)
      * Scale: 22695.0 MB/s  (45% of 50000 MB/s)
      * Add: 24926.0 MB/s  (125% of 20000 MB/s)
      * Triad: 24424.8 MB/s  (2442% of 1000 MB/s)
------------------------------------------------------------------------------
```
</details>
<details>
 <summary>Two columns</summary>

```text
PERFORMANCE REPORT
------------------------------------------------------------------------------
StreamWithRefTest
- prism:default
   - gnu
      * num_tasks: 1
      * Copy: 34496.6 MB/s          (3% of 1000000 MB/s)
      * Scale: 22695.0 MB/s         (45% of 50000 MB/s)
      * Add: 24926.0 MB/s           (125% of 20000 MB/s)
      * Triad: 24424.8 MB/s         (2442% of 1000 MB/s)
------------------------------------------------------------------------------
```
</details>
<details>
 <summary>Aligned details</summary>

```text
PERFORMANCE REPORT
------------------------------------------------------------------------------
StreamWithRefTest
- prism:default
   - gnu
      * num_tasks: 1
      * Copy: 34496.6 MB/s  (3% of 1000000 MB/s)
      * Scale: 22695.0 MB/s (45% of 50000 MB/s)
      * Add: 24926.0 MB/s   (125% of 20000 MB/s)
      * Triad: 24424.8 MB/s (2442% of 1000 MB/s)
------------------------------------------------------------------------------
```
</details>
<details>
 <summary>Aligned everything</summary>

```text
PERFORMANCE REPORT
------------------------------------------------------------------------------
StreamWithRefTest
- prism:default
   - gnu
      * num_tasks: 1
      * Copy:  34496.6 MB/s (   3% of 1000000 MB/s)
      * Scale: 22695.0 MB/s (  45% of 50000   MB/s)
      * Add:   24926.0 MB/s ( 125% of 20000   MB/s)
      * Triad: 24424.8 MB/s (2442% of 1000    MB/s)
------------------------------------------------------------------------------
```
</details>

…or some combination of the above. The goal is to avoid making things too visually noisy/hard to read at a glance.

Again, feedback is welcome! I did my best to adhere to the style/contribution guidelines, but I might've missed things. And feedback on whether the output is easy to read as-is or if could be improved (or even whether this feature is even worth adding at all) would be appreciated too.