### PR TITLE
[feat] Expose `@final` decorator in the class body

### DIFF
--- a/reframe/core/meta.py
+++ b/reframe/core/meta.py
@@ -176,6 +176,7 @@ class RegressionTestMeta(type):
         namespace['variable'] = variables.TestVar
         namespace['required'] = variables.Undefined
 
+        # Utility decorators
         def bind(fn, name=None):
             '''Directive to bind a free function to a class.
 
@@ -186,7 +187,14 @@ class RegressionTestMeta(type):
             namespace[inst.__name__] = inst
             return inst
 
+        def final(fn):
+            '''Indicate that a function is final and cannot be overridden.'''
+
+            fn._rfm_final = True
+            return fn
+
         namespace['bind'] = bind
+        namespace['final'] = final
 
         # Hook-related functionality
         def run_before(stage):
@@ -204,8 +212,6 @@ class RegressionTestMeta(type):
                 raise ValueError('pre-init hooks are not allowed')
 
             return hooks.attach_to('pre_' + stage)
-
-        namespace['run_before'] = run_before
 
         def run_after(stage):
             '''Decorator for attaching a test method to a pipeline stage.
@@ -228,6 +234,7 @@ class RegressionTestMeta(type):
 
             return hooks.attach_to('post_' + stage)
 
+        namespace['run_before'] = run_before
         namespace['run_after'] = run_after
         namespace['require_deps'] = hooks.require_deps
 
@@ -259,7 +266,8 @@ class RegressionTestMeta(type):
 
         directives = [
             'parameter', 'variable', 'bind', 'run_before', 'run_after',
-            'require_deps', 'required', 'deferrable', 'sanity_function'
+            'require_deps', 'required', 'deferrable', 'sanity_function',
+            'final'
         ]
         for b in directives:
             namespace.pop(b, None)
@@ -326,13 +334,12 @@ class RegressionTestMeta(type):
                               if hasattr(v, '_rfm_final')}
 
         # Add the final functions from its parents
-        cls._final_methods.update(*(b._final_methods for b in bases
-                                    if hasattr(b, '_final_methods')))
+        bases_w_final = [b for b in bases if hasattr(b, '_final_methods')]
+        cls._final_methods.update(*(b._final_methods for b in bases_w_final))
 
         if getattr(cls, '_rfm_special_test', None):
             return
 
-        bases_w_final = [b for b in bases if hasattr(b, '_final_methods')]
         for v in namespace.values():
             for b in bases_w_final:
                 if callable(v) and v.__name__ in b._final_methods:

--- a/reframe/core/meta.py
+++ b/reframe/core/meta.py
@@ -337,7 +337,7 @@ class RegressionTestMeta(type):
         bases_w_final = [b for b in bases if hasattr(b, '_final_methods')]
         cls._final_methods.update(*(b._final_methods for b in bases_w_final))
 
-        if getattr(cls, '_rfm_special_test', None):
+        if getattr(cls, '_rfm_override_final', None):
             return
 
         for v in namespace.values():

--- a/reframe/core/pipeline.py
+++ b/reframe/core/pipeline.py
@@ -92,6 +92,11 @@ _PIPELINE_STAGES = (
 
 def final(fn):
     fn._rfm_final = True
+    warn.user_deprecation_warning(
+        'using the @rfm.final decorator from the rfm module is '
+        'deprecated; please use the built-in decorator @final instead.',
+        from_version='3.7.0'
+    )
 
     @functools.wraps(fn)
     def _wrapped(*args, **kwargs):

--- a/reframe/core/pipeline.py
+++ b/reframe/core/pipeline.py
@@ -92,7 +92,7 @@ _PIPELINE_STAGES = (
 
 def final(fn):
     fn._rfm_final = True
-    warn.user_deprecation_warning(
+    user_deprecation_warning(
         'using the @rfm.final decorator from the rfm module is '
         'deprecated; please use the built-in decorator @final instead.',
         from_version='3.7.0'
@@ -1939,7 +1939,7 @@ class RunOnlyRegressionTest(RegressionTest, special=True):
                 self._copy_to_stagedir(os.path.join(self._prefix,
                                                     self.sourcesdir))
 
-        super().run.__wrapped__(self)
+        super().run()
 
 
 class CompileOnlyRegressionTest(RegressionTest, special=True):

--- a/reframe/core/pipeline.py
+++ b/reframe/core/pipeline.py
@@ -807,7 +807,7 @@ class RegressionTest(RegressionMixin, jsonext.JSONSerializable):
     @classmethod
     def __init_subclass__(cls, *, special=False, pin_prefix=False, **kwargs):
         super().__init_subclass__(**kwargs)
-        cls._rfm_special_test = special
+        cls._rfm_override_final = special
 
         # Insert the prefix to pin the test to if the test lives in a test
         # library with resources in it.

--- a/unittests/test_loader.py
+++ b/unittests/test_loader.py
@@ -136,18 +136,3 @@ def test_special_test():
 
             def setup(self, partition, environ, **job_opts):
                 super().setup(partition, environ, **job_opts)
-
-    @rfm.simple_test
-    class TestFinal(rfm.RegressionTest):
-        def __init__(self):
-            pass
-
-        @rfm.final
-        def my_new_final(self):
-            pass
-
-    with pytest.raises(ReframeSyntaxError):
-        @rfm.simple_test
-        class TestFinalDerived(TestFinal):
-            def my_new_final(self, a, b):
-                pass

--- a/unittests/test_loader.py
+++ b/unittests/test_loader.py
@@ -8,6 +8,7 @@ import pytest
 
 import reframe as rfm
 from reframe.core.exceptions import NameConflictError, ReframeSyntaxError
+from reframe.core.warnings import ReframeDeprecationWarning
 from reframe.frontend.loader import RegressionCheckLoader
 
 
@@ -136,3 +137,13 @@ def test_special_test():
 
             def setup(self, partition, environ, **job_opts):
                 super().setup(partition, environ, **job_opts)
+
+    with pytest.warns(ReframeDeprecationWarning):
+        @rfm.simple_test
+        class TestFinal(rfm.RegressionTest):
+            def __init__(self):
+                pass
+
+            @rfm.final
+            def my_new_final(self):
+                pass

--- a/unittests/test_meta.py
+++ b/unittests/test_meta.py
@@ -52,6 +52,7 @@ def test_directives(MyMeta):
         deferrable(ext)
         sanity_function(ext)
         v = required
+        final(ext)
 
         def __init__(self):
             assert not hasattr(self, 'parameter')
@@ -63,6 +64,7 @@ def test_directives(MyMeta):
             assert not hasattr(self, 'deferrable')
             assert not hasattr(self, 'sanity_function')
             assert not hasattr(self, 'required')
+            assert not hasattr(self, 'final')
 
     MyTest()
 
@@ -201,3 +203,15 @@ def test_hook_attachments(MyMeta):
     assert not Bar.hook_in_stage('hook_b', 'pre_compile')
     assert Bar.hook_in_stage('hook_c', 'post_run_wait')
     assert Bar.hook_in_stage('hook_a', 'pre_sanity')
+
+
+def test_final(MyMeta):
+    class MyBase(MyMeta):
+        @final
+        def foo(self):
+            pass
+
+    with pytest.raises(ReframeSyntaxError):
+        class MyDerived(MyBase):
+            def foo(self):
+                '''Override attempt'''

--- a/unittests/test_meta.py
+++ b/unittests/test_meta.py
@@ -206,12 +206,19 @@ def test_hook_attachments(MyMeta):
 
 
 def test_final(MyMeta):
-    class MyBase(MyMeta):
+    class Base(MyMeta):
         @final
         def foo(self):
             pass
 
     with pytest.raises(ReframeSyntaxError):
-        class MyDerived(MyBase):
+        class Derived(Base):
             def foo(self):
-                '''Override attempt'''
+                '''Override attempt.'''
+
+    class AllowFinalOverride(Base):
+        '''Use flag to bypass the final override check.'''
+        _rfm_override_final = True
+
+        def foo(self):
+            '''Overriding foo is now allowed.'''


### PR DESCRIPTION
One now can do
```python
class MyTest(rfm.RegressionTest):
    @final
    def foo(self):
        ...
```
instead of having to use the `@rfm.final` syntax.

### Other changes:

- Renamed `_rfm_special_test` to `_rfm_override_final`. This flag is only used in the metaclass to allow the override of final methods, so this name is more descriptive. Also, the "special" naming of it should just be down to the `RegressionTest` class.
- The unit test of this functionality is now in `unit tests/tests_meta.py` instead of the file with the loader tests.
- The `run` stage of the `RunOnlyRegressionTest` was calling `super().run.__wrapped__(self)`. I've replaced this line for `super.run()` since now the `final` decorator does not create a `functors.wrap` wrapper.


Closes #2001 