### PR TITLE
[bugfix] Fix `TypeError` in logger when using tuples as dict keys

### DIFF
--- a/reframe/utility/jsonext.py
+++ b/reframe/utility/jsonext.py
@@ -24,7 +24,10 @@ class JSONSerializable:
 
 
 def encode_dict(obj, recursive=False):
-    '''Transform non-compatible dict keys into strings.'''
+    '''Transform non-compatible dict keys into strings.
+
+    Use the recursive option to also check the keys in nested dicts.
+    '''
     if isinstance(obj, MutableMapping):
         _valid_keys = (str, int, float, bool, type(None))
         if recursive or not all(isinstance(k, _valid_keys) for k in obj):
@@ -56,7 +59,7 @@ def encode(obj, **kwargs):
     if inspect.istraceback(obj):
         return traceback.format_tb(obj)
 
-    newobj = encode_dict(obj)
+    newobj = encode_dict(obj, recursive=True)
     if newobj:
         return newobj
 

--- a/reframe/utility/jsonext.py
+++ b/reframe/utility/jsonext.py
@@ -23,18 +23,18 @@ class JSONSerializable:
         return _ret
 
 
-def encode_dict(obj, recursive=False):
-    '''Transform non-compatible dict keys into strings.
+def encode_dict(obj, *, recursive=False):
+    '''Transform tuple dict keys into strings.
 
     Use the recursive option to also check the keys in nested dicts.
     '''
+
     if isinstance(obj, MutableMapping):
-        _valid_keys = (str, int, float, bool, type(None))
-        if recursive or not all(isinstance(k, _valid_keys) for k in obj):
+        if recursive or any(isinstance(k, tuple) for k in obj):
             newobj = type(obj)()
             for k, v in obj.items():
-                _key = str(k) if not isinstance(k, _valid_keys) else k
-                _v = encode_dict(v)
+                _key = str(k) if isinstance(k, tuple) else k
+                _v = encode_dict(v, recursive=recursive)
                 newobj[_key] = _v if _v else v
 
             return newobj
@@ -59,7 +59,7 @@ def encode(obj, **kwargs):
     if inspect.istraceback(obj):
         return traceback.format_tb(obj)
 
-    newobj = encode_dict(obj, recursive=True)
+    newobj = encode_dict(obj)
     if newobj:
         return newobj
 

--- a/reframe/utility/jsonext.py
+++ b/reframe/utility/jsonext.py
@@ -27,7 +27,7 @@ def encode_dict(obj, *, recursive=False):
 
     Use the recursive option to also check the keys in nested dicts.
     '''
-
+    # FIXME: Need to add support for a decode_dict functionality
     if isinstance(obj, MutableMapping):
         if recursive or any(isinstance(k, tuple) for k in obj):
             newobj = type(obj)()

--- a/reframe/utility/jsonext.py
+++ b/reframe/utility/jsonext.py
@@ -19,8 +19,7 @@ class JSONSerializable:
         }
         ret.update(self.__dict__)
         encoded_ret = encode_dict(ret, recursive=True)
-        _ret = encoded_ret if encoded_ret else ret
-        return _ret
+        return encoded_ret if encoded_ret else ret
 
 
 def encode_dict(obj, *, recursive=False):
@@ -35,7 +34,7 @@ def encode_dict(obj, *, recursive=False):
             for k, v in obj.items():
                 _key = str(k) if isinstance(k, tuple) else k
                 _v = encode_dict(v, recursive=recursive)
-                newobj[_key] = _v if _v else v
+                newobj[_key] = _v if _v is not None else v
 
             return newobj
 
@@ -60,7 +59,7 @@ def encode(obj, **kwargs):
         return traceback.format_tb(obj)
 
     newobj = encode_dict(obj)
-    if newobj:
+    if newobj is not None:
         return newobj
 
     return None

--- a/unittests/test_utility.py
+++ b/unittests/test_utility.py
@@ -1540,7 +1540,7 @@ def test_jsonext_dumps():
     assert '{"foo":["bar"]}' == jsonext.dumps(
         {'foo': sn.defer(['bar']).evaluate()}, separators=(',', ':')
     )
-    assert '{"(1, 2, 3)": 1}' == jsonext.dumps({(1, 2, 3):1})
+    assert '{"(1, 2, 3)": 1}' == jsonext.dumps({(1, 2, 3): 1})
 
 # Classes to test JSON deserialization
 

--- a/unittests/test_utility.py
+++ b/unittests/test_utility.py
@@ -1540,7 +1540,7 @@ def test_jsonext_dumps():
     assert '{"foo":["bar"]}' == jsonext.dumps(
         {'foo': sn.defer(['bar']).evaluate()}, separators=(',', ':')
     )
-
+    assert '{"(1, 2, 3)": 1}' == jsonext.dumps({(1, 2, 3):1})
 
 # Classes to test JSON deserialization
 
@@ -1566,6 +1566,9 @@ class _C(jsonext.JSONSerializable):
         self.y = y
         self.z = None
         self.w = {1, 2}
+
+        # Dump dict with tuples as keys
+        self.v = {(1, 2): 1}
 
     def __rfm_json_decode__(self, json):
         # Sets are converted to lists when encoding, we need to manually


### PR DESCRIPTION
When defining a custom variable of type `dict`, the logger raised a `TypeError` from the `json.dumps` call if the dict had tuples as keys. This error is now caught and the dict keys are converted to strings using the `toalphanum` utility.

Note that fixing this in the `default` hook would not work, because dictionaries are recognised types by json. The alternative fix through the encoder would be a total overkill just for this minor issue (see https://stackoverflow.com/questions/16405969/how-to-change-json-encoding-behaviour-for-serializable-python-object for a similar issue).

Closes #2022 