### PR TITLE
[feat] Report whether measured performance was {greater,less} than reference

### DIFF
--- a/reframe/core/pipeline.py
+++ b/reframe/core/pipeline.py
@@ -1628,8 +1628,7 @@ class RegressionTest(RegressionMixin, jsonext.JSONSerializable):
                     sn.evaluate(
                         sn.assert_reference(
                             val, ref, low_thres, high_thres,
-                            msg=('failed to meet reference: %s={0}, '
-                                 'expected {1} (l={2}, u={3})' % tag))
+                        )
                     )
                 except SanityError as e:
                     raise PerformanceError(e)

--- a/reframe/utility/sanity.py
+++ b/reframe/utility/sanity.py
@@ -566,7 +566,8 @@ def assert_reference(val, ref, lower_thres=None, upper_thres=None, msg=None):
     try:
         evaluate(assert_bounded(val, lower, upper))
     except SanityError:
-        error_msg = msg or '{0} is beyond reference value {1} (l={2}, u={3})'
+        error_msg = msg or ('{0} is %s than reference value {1} (l={2}, u={3})'
+                            % ('lower' if val < lower else 'greater'))
         raise SanityError(_format(error_msg, val, ref, lower, upper)) from None
     else:
         return True

--- a/unittests/test_sanity_functions.py
+++ b/unittests/test_sanity_functions.py
@@ -451,25 +451,25 @@ def test_assert_reference():
     # Check upper threshold values greater than 1
     assert sn.assert_reference(20.0, 10.0, None, 3.0)
     assert sn.assert_reference(-50.0, -20.0, -2.0, 0.5)
-    with pytest.raises(SanityError, match=r'0\.5 is beyond reference value 1 '
-                                          r'\(l=0\.8, u=1\.1\)'):
+    with pytest.raises(SanityError, match=r'0\.5 is lower than reference value'
+                                          r' 1 \(l=0\.8, u=1\.1\)'):
         sn.evaluate(sn.assert_reference(0.5, 1, -0.2, 0.1))
 
-    with pytest.raises(SanityError, match=r'0\.5 is beyond reference value 1 '
-                                          r'\(l=0\.8, u=inf\)'):
+    with pytest.raises(SanityError, match=r'0\.5 is lower than reference value'
+                                          r' 1 \(l=0\.8, u=inf\)'):
         sn.evaluate(sn.assert_reference(0.5, 1, -0.2))
 
-    with pytest.raises(SanityError, match=r'1\.5 is beyond reference value 1 '
-                                          r'\(l=0\.8, u=1\.1\)'):
+    with pytest.raises(SanityError, match=r'1\.5 is greater than reference '
+                                          r'value 1 \(l=0\.8, u=1\.1\)'):
         sn.evaluate(sn.assert_reference(1.5, 1, -0.2, 0.1))
 
-    with pytest.raises(SanityError, match=r'1\.5 is beyond reference value 1 '
-                                          r'\(l=-inf, u=1\.1\)'):
+    with pytest.raises(SanityError, match=r'1\.5 is greater than reference '
+                                          r'value 1 \(l=-inf, u=1\.1\)'):
         sn.evaluate(sn.assert_reference(1.5, 1, lower_thres=None,
                                         upper_thres=0.1))
 
     with pytest.raises(SanityError,
-                       match=r'-0\.8 is beyond reference value -1 '
+                       match=r'-0\.8 is greater than reference value -1 '
                              r'\(l=-1\.2, u=-0\.9\)'):
         sn.evaluate(sn.assert_reference(-0.8, -1, -0.2, 0.1))
 


### PR DESCRIPTION
When a performance sanity check fails because the measured performance was
beyond allowed range, explicitly say whether the value was too small or too
large.  When the reference number has several digits, it's hard to quickly
compare the values by eyes.

This is orthogonal to #2045, but it's meant to improve the performance report in
a similar way, specifically when the performance benchmark fails because the
reference value isn't met.

Example with this pull request:
```
  * Reason: performance error: 21560000.0 is less than reference value 100000000.0 (l=90000000.0, u=110000000.00000001)
```
instead of the current
```
  * Reason: performance error: failed to meet reference: l_0=21560000.0, expected 100000000.0 (l=90000000.0, u=110000000.00000001)
```