### PR TITLE
[ci] Serialize unit tests everywhere

### DIFF
--- a/ci-scripts/ci-runner.bash
+++ b/ci-scripts/ci-runner.bash
@@ -125,10 +125,7 @@ if [ "X${MODULEUSE}" != "X" ]; then
     module use ${MODULEUSE}
 fi
 
-parallel_opts="--workers=auto --forked"
-if [[ $(hostname) =~ tsa|uan ]]; then
-    parallel_opts=""
-fi
+parallel_opts=""
 
 # Bootstrap ReFrame
 ./bootstrap.sh


### PR DESCRIPTION
For a couple of reasons:

1. `pytest-parallel` is not yet stable (0.x versions)
2. Running multiple instances of ReFrame at the same time is not supported and can have unpredictable side effects. 