### PR TITLE
[bugfix] Always use `$HOME` for storing processor auto-detection results

### DIFF
--- a/reframe/frontend/autodetect.py
+++ b/reframe/frontend/autodetect.py
@@ -154,14 +154,7 @@ def _remote_detect(part):
 def detect_topology():
     rt = runtime()
     detect_remote_systems = rt.get_option('general/0/remote_detect')
-    config_file = rt.site_config.filename
-    if config_file == '<builtin>':
-        config_prefix = os.path.join(
-            os.getenv('HOME'), '.reframe/topology'
-        )
-    else:
-        config_prefix = os.path.join(os.path.dirname(config_file), '_meta')
-
+    topo_prefix = os.path.join(os.getenv('HOME'), '.reframe/topology')
     for part in rt.system.partitions:
         getlogger().debug(f'detecting topology info for {part.fullname}')
         found_procinfo = False
@@ -184,10 +177,10 @@ def detect_topology():
             continue
 
         topo_file = os.path.join(
-            config_prefix, f'{rt.system.name}-{part.name}', 'processor.json'
+            topo_prefix, f'{rt.system.name}-{part.name}', 'processor.json'
         )
         dev_file = os.path.join(
-            config_prefix, f'{rt.system.name}-{part.name}', 'devices.json'
+            topo_prefix, f'{rt.system.name}-{part.name}', 'devices.json'
         )
         if not found_procinfo and os.path.exists(topo_file):
             getlogger().debug(

--- a/unittests/test_autodetect.py
+++ b/unittests/test_autodetect.py
@@ -15,13 +15,12 @@ from reframe.utility.cpuinfo import cpuinfo
 
 
 @pytest.fixture
-def exec_ctx(make_exec_ctx_g, tmp_path):
-    # Copy the default settings to the temp dir
-    config_file = tmp_path / 'conf.py'
-    shutil.copy('reframe/core/settings.py', config_file)
+def exec_ctx(make_exec_ctx_g, tmp_path, monkeypatch):
+    # Monkey-patch HOME, since topology is always written there
+    monkeypatch.setenv('HOME', str(tmp_path))
 
     # Create a devices file manually, since it is not auto-generated
-    meta_prefix = tmp_path / '_meta' / 'generic-default'
+    meta_prefix = tmp_path / '.reframe' / 'topology' / 'generic-default'
     os.makedirs(meta_prefix)
     with open(meta_prefix / 'devices.json', 'w') as fp:
         json.dump([
@@ -32,7 +31,7 @@ def exec_ctx(make_exec_ctx_g, tmp_path):
             }
         ], fp)
 
-    yield from make_exec_ctx_g(config_file)
+    yield from make_exec_ctx_g()
 
 
 def test_autotect(exec_ctx):

--- a/unittests/test_autodetect.py
+++ b/unittests/test_autodetect.py
@@ -6,7 +6,6 @@
 import json
 import os
 import pytest
-import shutil
 
 
 from reframe.core.runtime import runtime

--- a/unittests/test_cli.py
+++ b/unittests/test_cli.py
@@ -10,7 +10,6 @@ import json
 import os
 import pytest
 import re
-import shutil
 import sys
 
 import reframe.core.environments as env

--- a/unittests/test_cli.py
+++ b/unittests/test_cli.py
@@ -54,13 +54,7 @@ def perflogdir(tmp_path):
 
 
 @pytest.fixture
-def rm_config_meta():
-    yield
-    shutil.rmtree('unittests/resources/_meta', ignore_errors=True)
-
-
-@pytest.fixture
-def run_reframe(tmp_path, perflogdir, rm_config_meta):
+def run_reframe(tmp_path, perflogdir, monkeypatch):
     def _run_reframe(system='generic:default',
                      checkpath=['unittests/resources/checks/hellocheck.py'],
                      environs=['builtin'],
@@ -113,6 +107,7 @@ def run_reframe(tmp_path, perflogdir, rm_config_meta):
 
         return run_command_inline(argv, cli.main)
 
+    monkeypatch.setenv('HOME', str(tmp_path))
     return _run_reframe
 
 


### PR DESCRIPTION
Fixes #2072.