### PR TITLE
[ci] Fix sanity function deprecation unit test

### DIFF
--- a/unittests/test_deferrable.py
+++ b/unittests/test_deferrable.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 import pytest
+import reframe.core.warnings as warnings
 import reframe.utility.sanity as sn
 from reframe.core.warnings import ReframeDeprecationWarning
 
@@ -22,7 +23,8 @@ def test_evaluate():
     assert 3 == sn.evaluate(3)
 
 
-def test_depr_warn():
+def test_depr_warn(monkeypatch):
+    monkeypatch.setattr(warnings, '_RAISE_DEPRECATION_ALWAYS', True)
     with pytest.warns(ReframeDeprecationWarning):
         @sn.sanity_function
         def foo():


### PR DESCRIPTION
When testing for deprecation warnings in unit tests, we should force them to be raised, because we might end up with CI failures on master when doing patch-level version bumps.