### PR TITLE
[bugfix] Do not emit `module unuse <path>` after loading modules with Lmod from a specific path

### DIFF
--- a/reframe/core/modules.py
+++ b/reframe/core/modules.py
@@ -1154,3 +1154,4 @@ class SpackImpl(ModulesSystemImpl):
 
     def emit_unload_instr(self, module):
         return [f'spack unload {module.fullname}']
+                                                                                                                            

--- a/reframe/core/modules.py
+++ b/reframe/core/modules.py
@@ -876,7 +876,7 @@ class TMod4Impl(TModImpl):
 
         return super().conflicted_modules(module)
 
-    def _load_instr_collections(self, module):
+    def _emit_restore_instr(self, module):
         cmds = [f'module restore {module}']
 
         # Here we append module searchpath removal/addition commands
@@ -889,7 +889,7 @@ class TMod4Impl(TModImpl):
 
     def emit_load_instr(self, module):
         if module.collection:
-            return self._load_instr_collections(module)
+            return self._emit_restore_instr(module)
 
         return super().emit_load_instr(module)
 
@@ -1009,14 +1009,13 @@ class LModImpl(TMod4Impl):
 
     def emit_load_instr(self, module):
         if module.collection:
-            return self._load_instr_collections(module)
+            return self._emit_restore_instr(module)
 
         cmds = []
         if module.path:
             cmds.append(f'module use {module.path}')
 
         cmds.append(f'module load {module.fullname}')
-
         return cmds
 
 

--- a/unittests/test_modules.py
+++ b/unittests/test_modules.py
@@ -236,16 +236,12 @@ def _emit_load_commands_tmod(modules_system):
     assert emit_cmds('m0') == ['module load m0']
 
 
-def _emit_load_commands_tmod4(modules_system):
-    emit_cmds = modules_system.emit_load_commands
+def _emit_load_commands_tmod4_lmod(modules_system, emit_cmds):
     assert emit_cmds('foo') == ['module load foo']
     assert emit_cmds('foo', collection=True) == [
         'module restore foo', f'module use {test_util.TEST_MODULES}'
     ]
     assert emit_cmds('foo/1.2') == ['module load foo/1.2']
-    assert emit_cmds('foo', path='/path') == ['module use /path',
-                                              'module load foo',
-                                              'module unuse /path']
 
     # Module mappings are not taking into account since v3.3
     assert emit_cmds('m0') == ['module load m0']
@@ -254,8 +250,19 @@ def _emit_load_commands_tmod4(modules_system):
     ]
 
 
+def _emit_load_commands_tmod4(modules_system):
+    emit_cmds = modules_system.emit_load_commands
+    _emit_load_commands_tmod4_lmod(modules_system, emit_cmds)
+    assert emit_cmds('foo', path='/path') == ['module use /path',
+                                              'module load foo',
+                                              'module unuse /path']
+
+
 def _emit_load_commands_lmod(modules_system):
-    return _emit_load_commands_tmod4(modules_system)
+    emit_cmds = modules_system.emit_load_commands
+    _emit_load_commands_tmod4_lmod(modules_system, emit_cmds)
+    assert emit_cmds('foo', path='/path') == ['module use /path',
+                                              'module load foo']
 
 
 def _emit_load_commands_spack(modules_system):

--- a/unittests/test_modules.py
+++ b/unittests/test_modules.py
@@ -236,12 +236,20 @@ def _emit_load_commands_tmod(modules_system):
     assert emit_cmds('m0') == ['module load m0']
 
 
-def _emit_load_commands_tmod4_lmod(modules_system, emit_cmds):
+def _emit_load_commands_tmod4(modules_system):
+    emit_cmds = modules_system.emit_load_commands
     assert emit_cmds('foo') == ['module load foo']
     assert emit_cmds('foo', collection=True) == [
         'module restore foo', f'module use {test_util.TEST_MODULES}'
     ]
     assert emit_cmds('foo/1.2') == ['module load foo/1.2']
+    if modules_system.name is 'lmod':
+        assert emit_cmds('foo', path='/path') == ['module use /path',
+                                                  'module load foo']
+    else:
+        assert emit_cmds('foo', path='/path') == ['module use /path',
+                                                  'module load foo',
+                                                  'module unuse /path']
 
     # Module mappings are not taking into account since v3.3
     assert emit_cmds('m0') == ['module load m0']
@@ -250,19 +258,8 @@ def _emit_load_commands_tmod4_lmod(modules_system, emit_cmds):
     ]
 
 
-def _emit_load_commands_tmod4(modules_system):
-    emit_cmds = modules_system.emit_load_commands
-    _emit_load_commands_tmod4_lmod(modules_system, emit_cmds)
-    assert emit_cmds('foo', path='/path') == ['module use /path',
-                                              'module load foo',
-                                              'module unuse /path']
-
-
 def _emit_load_commands_lmod(modules_system):
-    emit_cmds = modules_system.emit_load_commands
-    _emit_load_commands_tmod4_lmod(modules_system, emit_cmds)
-    assert emit_cmds('foo', path='/path') == ['module use /path',
-                                              'module load foo']
+    return _emit_load_commands_tmod4(modules_system)
 
 
 def _emit_load_commands_spack(modules_system):


### PR DESCRIPTION
Closes #2065 