### PR TITLE
[bugfix] Handle `None` in `Decimal` conversion of junit report

### DIFF
--- a/reframe/frontend/runreport.py
+++ b/reframe/frontend/runreport.py
@@ -213,7 +213,7 @@ def junit_xml_report(json_report):
                     # XSD schema does not like the exponential format and since
                     # we do not want to impose a fixed width, we pass it to
                     # `Decimal` to format it automatically.
-                    'time': str(decimal.Decimal(tc['time_total'])),
+                    'time': str(decimal.Decimal(tc['time_total'] or 0)),
                 }
             )
             if tc['result'] == 'failure':

--- a/unittests/test_policies.py
+++ b/unittests/test_policies.py
@@ -237,6 +237,9 @@ def test_runall(make_runner, make_cases, common_exec_ctx, tmp_path):
     with open(report_file, 'w') as fp:
         jsonext.dump(report, fp)
 
+    # Test handling of `None` in `time_total` in junit report
+    report['runs'][0]['testcases'][0]['time_total'] = None
+
     # Validate the junit report
     xml_report = runreport.junit_xml_report(report)
     _validate_junit_report(xml_report)

--- a/unittests/test_policies.py
+++ b/unittests/test_policies.py
@@ -237,8 +237,9 @@ def test_runall(make_runner, make_cases, common_exec_ctx, tmp_path):
     with open(report_file, 'w') as fp:
         jsonext.dump(report, fp)
 
-    # Test handling of `None` in `time_total` in junit report
-    report['runs'][0]['testcases'][0]['time_total'] = None
+    # We explicitly set `time_total` to `None` in the last test case, in order
+    # to test the proper handling of `None`.`
+    report['runs'][0]['testcases'][-1]['time_total'] = None
 
     # Validate the junit report
     xml_report = runreport.junit_xml_report(report)


### PR DESCRIPTION
* Correctly treat `None` value for `time_total` of a `TestCase` when
converting to `Decimal` during the creation of the Junit report.

* Test the above in the testing of policies.

Fixes #2057 