### PR TITLE
[bugfix] Do not crash if processor and/or device topology files are not properly formatted JSON files

### DIFF
--- a/reframe/frontend/autodetect.py
+++ b/reframe/frontend/autodetect.py
@@ -190,8 +190,8 @@ def detect_topology():
                 found_procinfo = True
             except json.decoder.JSONDecodeError:
                 getlogger().debug(
-                f'> could not load {topo_file!r}; ignoring...'
-            )
+                    f'> could not load {topo_file!r}; ignoring...'
+                )
 
         if not found_devinfo and os.path.exists(dev_file):
             getlogger().debug(
@@ -204,8 +204,8 @@ def detect_topology():
                 found_devinfo = True
             except json.decoder.JSONDecodeError:
                 getlogger().debug(
-                f'> could not load {dev_file!r}; ignoring...'
-            )
+                    f'> could not load {dev_file!r}; ignoring...'
+                )
 
         if found_procinfo and found_devinfo:
             continue

--- a/reframe/frontend/autodetect.py
+++ b/reframe/frontend/autodetect.py
@@ -188,7 +188,10 @@ def detect_topology():
                     topo_file, _subschema('#/defs/processor_info')
                 )
                 found_procinfo = True
-            except json.decoder.JSONDecodeError:
+            except json.decoder.JSONDecodeError as e:
+                getlogger().debug(
+                    f'> error while loading the file: {e}'
+                )
                 getlogger().debug(
                     f'> could not load {topo_file!r}; ignoring...'
                 )
@@ -202,7 +205,10 @@ def detect_topology():
                     dev_file, _subschema('#/defs/devices')
                 )
                 found_devinfo = True
-            except json.decoder.JSONDecodeError:
+            except json.decoder.JSONDecodeError as e:
+                getlogger().debug(
+                    f'> error while loading the file: {e}'
+                )
                 getlogger().debug(
                     f'> could not load {dev_file!r}; ignoring...'
                 )

--- a/reframe/frontend/autodetect.py
+++ b/reframe/frontend/autodetect.py
@@ -190,10 +190,7 @@ def detect_topology():
                 found_procinfo = True
             except json.decoder.JSONDecodeError as e:
                 getlogger().debug(
-                    f'> error while loading the file: {e}'
-                )
-                getlogger().debug(
-                    f'> could not load {topo_file!r}; ignoring...'
+                    f'> could not load {topo_file!r}: {e}: ignoring...'
                 )
 
         if not found_devinfo and os.path.exists(dev_file):
@@ -207,10 +204,7 @@ def detect_topology():
                 found_devinfo = True
             except json.decoder.JSONDecodeError as e:
                 getlogger().debug(
-                    f'> error while loading the file: {e}'
-                )
-                getlogger().debug(
-                    f'> could not load {dev_file!r}; ignoring...'
+                    f'> could not load {dev_file!r}: {e}: ignoring...'
                 )
 
         if found_procinfo and found_devinfo:

--- a/reframe/frontend/autodetect.py
+++ b/reframe/frontend/autodetect.py
@@ -183,17 +183,27 @@ def detect_topology():
             getlogger().debug(
                 f'> found topology file {topo_file!r}; loading...'
             )
-            part.processor._info = _load_info(
-                topo_file, _subschema('#/defs/processor_info')
+            try:
+                part.processor._info = _load_info(
+                    topo_file, _subschema('#/defs/processor_info')
+                )
+                found_procinfo = True
+            except json.decoder.JSONDecodeError:
+                getlogger().debug(
+                f'> could not load {topo_file!r}; ignoring...'
             )
-            found_procinfo = True
 
         if not found_devinfo and os.path.exists(dev_file):
             getlogger().debug(
                 f'> found devices file {dev_file!r}; loading...'
             )
-            part._devices = _load_info(dev_file, _subschema('#/defs/devices'))
-            found_devinfo = True
+            try:
+                part._devices = _load_info(dev_file, _subschema('#/defs/devices'))
+                found_devinfo = True
+            except json.decoder.JSONDecodeError:
+                getlogger().debug(
+                f'> could not load {dev_file!r}; ignoring...'
+            )
 
         if found_procinfo and found_devinfo:
             continue

--- a/reframe/frontend/autodetect.py
+++ b/reframe/frontend/autodetect.py
@@ -198,7 +198,9 @@ def detect_topology():
                 f'> found devices file {dev_file!r}; loading...'
             )
             try:
-                part._devices = _load_info(dev_file, _subschema('#/defs/devices'))
+                part._devices = _load_info(
+                    dev_file, _subschema('#/defs/devices')
+                )
                 found_devinfo = True
             except json.decoder.JSONDecodeError:
                 getlogger().debug(

--- a/unittests/test_autodetect.py
+++ b/unittests/test_autodetect.py
@@ -33,8 +33,32 @@ def exec_ctx(make_exec_ctx_g, tmp_path, monkeypatch):
     yield from make_exec_ctx_g()
 
 
+@pytest.fixture
+def invalid_topology_exec_ctx(make_exec_ctx_g, tmp_path, monkeypatch):
+    # Monkey-patch HOME, since topology is always written there
+    monkeypatch.setenv('HOME', str(tmp_path))
+
+    # Create invalid processor and devices files
+    meta_prefix = tmp_path / '.reframe' / 'topology' / 'generic-default'
+    os.makedirs(meta_prefix)
+    with open(meta_prefix / 'processor.json', 'w') as fp:
+        fp.write('{')
+
+    with open(meta_prefix / 'devices.json', 'w') as fp:
+        fp.write('{')
+
+    yield from make_exec_ctx_g()
+
+
 def test_autotect(exec_ctx):
     detect_topology()
     part = runtime().system.partitions[0]
     assert part.processor.info == cpuinfo()
     assert part.devices == [{'type': 'gpu', 'arch': 'a100', 'num_devices': 8}]
+
+
+def test_autotect_with_invalid_files(invalid_topology_exec_ctx):
+    detect_topology()
+    part = runtime().system.partitions[0]
+    assert part.processor.info == cpuinfo()
+    assert part.devices == []

--- a/unittests/test_autodetect.py
+++ b/unittests/test_autodetect.py
@@ -34,7 +34,7 @@ def exec_ctx(make_exec_ctx_g, tmp_path, monkeypatch):
 
 
 @pytest.fixture
-def invalid_topology_exec_ctx(make_exec_ctx_g, tmp_path, monkeypatch):
+def invalid_topo_exec_ctx(make_exec_ctx_g, tmp_path, monkeypatch):
     # Monkey-patch HOME, since topology is always written there
     monkeypatch.setenv('HOME', str(tmp_path))
 
@@ -57,7 +57,7 @@ def test_autotect(exec_ctx):
     assert part.devices == [{'type': 'gpu', 'arch': 'a100', 'num_devices': 8}]
 
 
-def test_autotect_with_invalid_files(invalid_topology_exec_ctx):
+def test_autotect_with_invalid_files(invalid_topo_exec_ctx):
     detect_topology()
     part = runtime().system.partitions[0]
     assert part.processor.info == cpuinfo()


### PR DESCRIPTION
Whenever the processor and device files exist but cannot be loaded (empty file, invalid syntax etc), Reframe just stops and throws a throwback. With this PR we ignore the `JSONDecodeError` and try to regenerate the file.
Closes #2110.