### PR TITLE
[bugfix] Fix pattern matching for test name in `--ci-generate` output

### DIFF
--- a/reframe/frontend/ci.py
+++ b/reframe/frontend/ci.py
@@ -40,7 +40,7 @@ def _emit_gitlab_pipeline(testcases):
             f'-R' if recurse else '',
             f'--report-file={report_file}',
             f'--restore-session={restore_files}' if restore_files else '',
-            '-n', f'^{testcase.check.name}$', '-r'
+            '-n', f"'^{testcase.check.name}$'", '-r'
         ])
 
     max_level = 0   # We need the maximum level to generate the stages section

--- a/reframe/frontend/ci.py
+++ b/reframe/frontend/ci.py
@@ -40,7 +40,7 @@ def _emit_gitlab_pipeline(testcases):
             f'-R' if recurse else '',
             f'--report-file={report_file}',
             f'--restore-session={restore_files}' if restore_files else '',
-            '-n', testcase.check.name, '-r'
+            '-n', f'^{testcase.check.name}$', '-r'
         ])
 
     max_level = 0   # We need the maximum level to generate the stages section


### PR DESCRIPTION
This PR fixes the pattern matching for the `-n` option generated in the `--ci-generate` feature.
Currently, in the CI generate the `-n` option is emitted as
```
reframe ...  -n MyTest_1 -r
```
And this PR changes it to
```
reframe ...  -n ^MyTest_1$ -r
```

This should fix the issue that `-n MyTest_1` pattern matches `MyTest_1.*`, e.g, it matches the tests `MyTest_10` and `MyTest_1_OtherOptions`. 

Closes #2165 