### PR TITLE
[bugfix] Fix incomplete processor info object when processor topology is auto-detected

### DIFF
--- a/reframe/core/systems.py
+++ b/reframe/core/systems.py
@@ -15,9 +15,9 @@ from reframe.core.modules import ModulesSystem
 
 class ProcessorType(jsonext.JSONSerializable):
     '''A representation of a processor inside ReFrame.
-    You can access all the keys of the processor dictionary in configuration
-    as direct properties. You can see a full list
-    `here <config_reference.html#processor-info>`__.
+
+    You can access all the keys of the `processor configuration object
+    <config_reference.html#processor-info>`__.
 
     .. versionadded:: 3.5.0
 
@@ -111,9 +111,9 @@ class ProcessorType(jsonext.JSONSerializable):
 
 class DeviceType(jsonext.JSONSerializable):
     '''A representation of a device inside ReFrame.
-    You can access all the keys of the device dictionary in configuration
-    as direct properties. You can see a full list
-    `here <config_reference.html#device-info>`__.
+
+    You can access all the keys of the `device configuration object
+    <config_reference.html#device-info>`__.
 
     .. versionadded:: 3.5.0
 

--- a/reframe/core/systems.py
+++ b/reframe/core/systems.py
@@ -15,6 +15,9 @@ from reframe.core.modules import ModulesSystem
 
 class ProcessorType(jsonext.JSONSerializable):
     '''A representation of a processor inside ReFrame.
+    You can access all the keys of the processor dictionary in configuration
+    as direct properties. You can see a full list
+    `here <config_reference.html#processor-info>`__.
 
     .. versionadded:: 3.5.0
 
@@ -108,6 +111,9 @@ class ProcessorType(jsonext.JSONSerializable):
 
 class DeviceType(jsonext.JSONSerializable):
     '''A representation of a device inside ReFrame.
+    You can access all the keys of the device dictionary in configuration
+    as direct properties. You can see a full list
+    `here <config_reference.html#device-info>`__.
 
     .. versionadded:: 3.5.0
 

--- a/reframe/core/systems.py
+++ b/reframe/core/systems.py
@@ -48,6 +48,7 @@ class _ReadOnlyInfo(jsonext.JSONSerializable):
         '''
         return self.__info
 
+
 class ProcessorInfo(_ReadOnlyInfo):
     '''A representation of a processor inside ReFrame.
 

--- a/reframe/core/systems.py
+++ b/reframe/core/systems.py
@@ -13,43 +13,33 @@ from reframe.core.logging import getlogger
 from reframe.core.modules import ModulesSystem
 
 
-class _ReadOnlyInfo(jsonext.JSONSerializable):
+class _ReadOnlyInfo:
+    __slots__ = ('_info',)
+    _known_attrs = ()
 
     def __init__(self, info):
-        self.__info = info
+        self._info = info
 
     def __deepcopy__(self, memo):
         # This is a read-only object; simply return ourself
         return self
 
-
     def __getattr__(self, name):
-        if name in self.__slots__:
-            return self.__info.get(name, None)
+        if name in self._known_attrs:
+            return self._info.get(name, None)
         else:
             raise AttributeError(
                 f'{type(self).__qualname__!r} object has no attribute {name!r}'
             )
 
     def __setattr__(self, name, value):
-        if name in self.__slots__:
-            raise AttributeError(
-                f'attribute {name!r} is not writeable'
-            )
+        if name in self._known_attrs:
+            raise AttributeError(f'attribute {name!r} is not writeable')
         else:
-            # Let Python data model raise the AttributeError here
             super().__setattr__(name, value)
 
-    @property
-    def info(self):
-        '''All the available information from the configuration.
 
-        :type: :class:`dict`
-        '''
-        return self.__info
-
-
-class ProcessorInfo(_ReadOnlyInfo):
+class ProcessorInfo(_ReadOnlyInfo, jsonext.JSONSerializable):
     '''A representation of a processor inside ReFrame.
 
     You can access all the keys of the `processor configuration object
@@ -62,10 +52,19 @@ class ProcessorInfo(_ReadOnlyInfo):
 
     '''
 
-    __slots__ = (
-        '__info', 'arch', 'num_cpus', 'num_cpus_per_core',
+    __slots__ = ()
+    _known_attrs = (
+        'arch', 'num_cpus', 'num_cpus_per_core',
         'num_cpus_per_socket', 'num_sockets', 'topology'
     )
+
+    @property
+    def info(self):
+        '''All the available information from the configuration.
+
+        :type: :class:`dict`
+        '''
+        return self._info
 
     @property
     def num_cores(self):
@@ -113,7 +112,7 @@ class ProcessorInfo(_ReadOnlyInfo):
             return None
 
 
-class DeviceInfo(_ReadOnlyInfo):
+class DeviceInfo(_ReadOnlyInfo, jsonext.JSONSerializable):
     '''A representation of a device inside ReFrame.
 
     You can access all the keys of the `device configuration object
@@ -126,7 +125,16 @@ class DeviceInfo(_ReadOnlyInfo):
 
     '''
 
-    __slots__ = ('__info', 'type', 'arch')
+    __slots__ = ()
+    _known_attrs = ('type', 'arch')
+
+    @property
+    def info(self):
+        '''All the available information from the configuration.
+
+        :type: :class:`dict`
+        '''
+        return self._info
 
     @property
     def num_devices(self):
@@ -136,7 +144,7 @@ class DeviceInfo(_ReadOnlyInfo):
 
         :type: integral
         '''
-        return self.__info.get('num_devices', 1)
+        return self._info.get('num_devices', 1)
 
     @property
     def device_type(self):

--- a/reframe/core/systems.py
+++ b/reframe/core/systems.py
@@ -49,6 +49,7 @@ class ProcessorType(jsonext.JSONSerializable):
                 f'attribute {name!r} is not writeable'
             )
         else:
+            # Let Python data model raise the AttributeError here
             super().__setattr__(name, value)
 
     @property

--- a/reframe/core/systems.py
+++ b/reframe/core/systems.py
@@ -13,30 +13,15 @@ from reframe.core.logging import getlogger
 from reframe.core.modules import ModulesSystem
 
 
-class ProcessorType(jsonext.JSONSerializable):
-    '''A representation of a processor inside ReFrame.
+class _ReadOnlyInfo(jsonext.JSONSerializable):
 
-    You can access all the keys of the `processor configuration object
-    <config_reference.html#processor-info>`__.
-
-    .. versionadded:: 3.5.0
-
-    .. warning::
-       Users may not create :class:`ProcessorType` objects directly.
-
-    '''
-
-    __slots__ = (
-        '__info', 'arch', 'num_cpus', 'num_cpus_per_core',
-        'num_cpus_per_socket', 'num_sockets', 'topology'
-    )
+    def __init__(self, info):
+        self.__info = info
 
     def __deepcopy__(self, memo):
         # This is a read-only object; simply return ourself
         return self
 
-    def __init__(self, processor_info):
-        self.__info = processor_info
 
     def __getattr__(self, name):
         if name in self.__slots__:
@@ -62,6 +47,24 @@ class ProcessorType(jsonext.JSONSerializable):
         :type: :class:`dict`
         '''
         return self.__info
+
+class ProcessorInfo(_ReadOnlyInfo):
+    '''A representation of a processor inside ReFrame.
+
+    You can access all the keys of the `processor configuration object
+    <config_reference.html#processor-info>`__.
+
+    .. versionadded:: 3.5.0
+
+    .. warning::
+       Users may not create :class:`ProcessorInfo` objects directly.
+
+    '''
+
+    __slots__ = (
+        '__info', 'arch', 'num_cpus', 'num_cpus_per_core',
+        'num_cpus_per_socket', 'num_sockets', 'topology'
+    )
 
     @property
     def num_cores(self):
@@ -109,7 +112,7 @@ class ProcessorType(jsonext.JSONSerializable):
             return None
 
 
-class DeviceType(jsonext.JSONSerializable):
+class DeviceInfo(_ReadOnlyInfo):
     '''A representation of a device inside ReFrame.
 
     You can access all the keys of the `device configuration object
@@ -118,35 +121,11 @@ class DeviceType(jsonext.JSONSerializable):
     .. versionadded:: 3.5.0
 
     .. warning::
-       Users may not create :class:`DeviceType` objects directly.
+       Users may not create :class:`DeviceInfo` objects directly.
 
     '''
 
     __slots__ = ('__info', 'type', 'arch')
-
-    def __deepcopy__(self, memo):
-        # This is a read-only object; simply return ourself
-        return self
-
-    def __init__(self, device_info):
-        self.__info = device_info
-
-    def __getattr__(self, name):
-        if name in self.__slots__:
-            return self.__info.get(name, None)
-        else:
-            raise AttributeError(
-                f'{type(self).__qualname__!r} object has no attribute {name!r}'
-            )
-
-    def __setattr__(self, name, value):
-        if name in self.__slots__:
-            raise AttributeError(
-                f'attribute {name!r} is not writeable'
-            )
-        else:
-            # Let Python data model raise the AttributeError here
-            super().__setattr__(name, value)
 
     @property
     def num_devices(self):
@@ -157,14 +136,6 @@ class DeviceType(jsonext.JSONSerializable):
         :type: integral
         '''
         return self.__info.get('num_devices', 1)
-
-    @property
-    def info(self):
-        '''All the available information from the configuration.
-
-        :type: :class:`dict`
-        '''
-        return self.__info
 
     @property
     def device_type(self):
@@ -200,8 +171,8 @@ class SystemPartition(jsonext.JSONSerializable):
         self._max_jobs = max_jobs
         self._prepare_cmds = prepare_cmds
         self._resources = {r['name']: r['options'] for r in resources}
-        self._processor = ProcessorType(processor)
-        self._devices = [DeviceType(d) for d in devices]
+        self._processor = ProcessorInfo(processor)
+        self._devices = [DeviceInfo(d) for d in devices]
         self._extras = extras
 
     @property
@@ -368,7 +339,7 @@ class SystemPartition(jsonext.JSONSerializable):
 
         .. versionadded:: 3.5.0
 
-        :type: :class:`reframe.core.systems.ProcessorType`
+        :type: :class:`reframe.core.systems.ProcessorInfo`
         '''
         return self._processor
 
@@ -378,7 +349,7 @@ class SystemPartition(jsonext.JSONSerializable):
 
         .. versionadded:: 3.5.0
 
-        :type: :class:`List[reframe.core.systems.DeviceType]`
+        :type: :class:`List[reframe.core.systems.DeviceInfo]`
         '''
         return self._devices
 

--- a/reframe/frontend/autodetect.py
+++ b/reframe/frontend/autodetect.py
@@ -15,7 +15,7 @@ import reframe.utility.osext as osext
 from reframe.core.exceptions import ConfigError
 from reframe.core.logging import getlogger
 from reframe.core.schedulers import Job
-from reframe.core.systems import ProcessorType
+from reframe.core.systems import DeviceType, ProcessorType
 from reframe.utility.cpuinfo import cpuinfo
 
 
@@ -198,9 +198,10 @@ def detect_topology():
                 f'> found devices file {dev_file!r}; loading...'
             )
             try:
-                part._devices = _load_info(
+                devices_info = _load_info(
                     dev_file, _subschema('#/defs/devices')
                 )
+                part._devices = [DeviceType(d) for d in devices_info]
                 found_devinfo = True
             except json.decoder.JSONDecodeError as e:
                 getlogger().debug(

--- a/reframe/frontend/autodetect.py
+++ b/reframe/frontend/autodetect.py
@@ -15,6 +15,7 @@ import reframe.utility.osext as osext
 from reframe.core.exceptions import ConfigError
 from reframe.core.logging import getlogger
 from reframe.core.schedulers import Job
+from reframe.core.systems import ProcessorType
 from reframe.utility.cpuinfo import cpuinfo
 
 
@@ -183,8 +184,8 @@ def detect_topology():
                 f'> found topology file {topo_file!r}; loading...'
             )
             try:
-                part.processor._info = _load_info(
-                    topo_file, _subschema('#/defs/processor_info')
+                part._processor = ProcessorType(
+                    _load_info(topo_file, _subschema('#/defs/processor_info'))
                 )
                 found_procinfo = True
             except json.decoder.JSONDecodeError as e:
@@ -220,13 +221,13 @@ def detect_topology():
 
                 # Unconditionally detect the system for fully local partitions
                 with runtime.temp_environment(modules=modules, variables=vars):
-                    part.processor._info = cpuinfo()
+                    part._processor = ProcessorType(cpuinfo())
 
                 _save_info(topo_file, part.processor.info)
             elif detect_remote_systems:
                 with runtime.temp_environment(modules=temp_modules,
                                               variables=temp_vars):
-                    part.processor._info = _remote_detect(part)
+                    part._processor = ProcessorType(_remote_detect(part))
 
                 if part.processor.info:
                     _save_info(topo_file, part.processor.info)

--- a/reframe/frontend/autodetect.py
+++ b/reframe/frontend/autodetect.py
@@ -15,7 +15,7 @@ import reframe.utility.osext as osext
 from reframe.core.exceptions import ConfigError
 from reframe.core.logging import getlogger
 from reframe.core.schedulers import Job
-from reframe.core.systems import DeviceType, ProcessorType
+from reframe.core.systems import DeviceInfo, ProcessorInfo
 from reframe.utility.cpuinfo import cpuinfo
 
 
@@ -184,7 +184,7 @@ def detect_topology():
                 f'> found topology file {topo_file!r}; loading...'
             )
             try:
-                part._processor = ProcessorType(
+                part._processor = ProcessorInfo(
                     _load_info(topo_file, _subschema('#/defs/processor_info'))
                 )
                 found_procinfo = True
@@ -201,7 +201,7 @@ def detect_topology():
                 devices_info = _load_info(
                     dev_file, _subschema('#/defs/devices')
                 )
-                part._devices = [DeviceType(d) for d in devices_info]
+                part._devices = [DeviceInfo(d) for d in devices_info]
                 found_devinfo = True
             except json.decoder.JSONDecodeError as e:
                 getlogger().debug(
@@ -222,13 +222,13 @@ def detect_topology():
 
                 # Unconditionally detect the system for fully local partitions
                 with runtime.temp_environment(modules=modules, variables=vars):
-                    part._processor = ProcessorType(cpuinfo())
+                    part._processor = ProcessorInfo(cpuinfo())
 
                 _save_info(topo_file, part.processor.info)
             elif detect_remote_systems:
                 with runtime.temp_environment(modules=temp_modules,
                                               variables=temp_vars):
-                    part._processor = ProcessorType(_remote_detect(part))
+                    part._processor = ProcessorInfo(_remote_detect(part))
 
                 if part.processor.info:
                     _save_info(topo_file, part.processor.info)

--- a/reframe/utility/jsonext.py
+++ b/reframe/utility/jsonext.py
@@ -12,12 +12,20 @@ import reframe.utility as util
 
 
 class JSONSerializable:
+    __slots__ = ()
+
     def __rfm_json_encode__(self):
         ret = {
             '__rfm_class__': type(self).__qualname__,
             '__rfm_file__': inspect.getfile(type(self))
         }
-        ret.update(self.__dict__)
+        if hasattr(self, '__dict__'):
+            ret.update(self.__dict__)
+
+        # Set the slots attribute
+        for attr in self.__slots__:
+            ret[attr] = getattr(self, attr)
+
         encoded_ret = encode_dict(ret, recursive=True)
         return encoded_ret if encoded_ret else ret
 
@@ -90,7 +98,9 @@ def _object_hook(json):
     mod = util.import_module_from_file(filename)
     cls = getattr(mod, typename)
     obj = cls.__new__(cls)
-    obj.__dict__.update(json)
+    for attr, value in json.items():
+        setattr(obj, attr, value)
+
     if hasattr(obj, '__rfm_json_decode__'):
         obj.__rfm_json_decode__(json)
 

--- a/reframe/utility/jsonext.py
+++ b/reframe/utility/jsonext.py
@@ -98,8 +98,11 @@ def _object_hook(json):
     mod = util.import_module_from_file(filename)
     cls = getattr(mod, typename)
     obj = cls.__new__(cls)
-    for attr, value in json.items():
-        setattr(obj, attr, value)
+    if hasattr(obj, '__dict__'):
+        obj.__dict__.update(json)
+    else:
+        for attr, value in json.items():
+            setattr(obj, attr, value)
 
     if hasattr(obj, '__rfm_json_decode__'):
         obj.__rfm_json_decode__(json)

--- a/unittests/test_autodetect.py
+++ b/unittests/test_autodetect.py
@@ -65,12 +65,18 @@ def test_autotect(exec_ctx):
     }
     assert part.devices[0].device_type == 'gpu'
 
-    # Test immutability of ProcessorType and DeviceType
+    # Test immutability of ProcessorInfo and DeviceInfo
     with pytest.raises(AttributeError):
-        part.processor.info = {}
+        part.processor.num_cpus = 3
 
     with pytest.raises(AttributeError):
-        part.devices[0].info = {}
+        part.processor.foo = 10
+
+    with pytest.raises(AttributeError):
+        part.devices[0].arch = 'foo'
+
+    with pytest.raises(AttributeError):
+        part.devices[0].foo = 10
 
 
 def test_autotect_with_invalid_files(invalid_topo_exec_ctx):

--- a/unittests/test_autodetect.py
+++ b/unittests/test_autodetect.py
@@ -56,6 +56,7 @@ def test_autotect(exec_ctx):
     assert part.processor.info == cpuinfo()
     if part.processor.info:
         assert part.processor.num_cpus == part.processor.info['num_cpus']
+
     assert len(part.devices) == 1
     assert part.devices[0].info == {
         'type': 'gpu',

--- a/unittests/test_autodetect.py
+++ b/unittests/test_autodetect.py
@@ -57,7 +57,11 @@ def test_autotect(exec_ctx):
     if part.processor.info:
         assert part.processor.num_cpus == part.processor.info['num_cpus']
     assert len(part.devices) == 1
-    assert part.devices[0].info == {'type': 'gpu', 'arch': 'a100', 'num_devices': 8}
+    assert part.devices[0].info == {
+        'type': 'gpu',
+        'arch': 'a100',
+        'num_devices': 8
+    }
     assert part.devices[0].device_type == 'gpu'
 
 

--- a/unittests/test_autodetect.py
+++ b/unittests/test_autodetect.py
@@ -54,7 +54,11 @@ def test_autotect(exec_ctx):
     detect_topology()
     part = runtime().system.partitions[0]
     assert part.processor.info == cpuinfo()
-    assert part.devices == [{'type': 'gpu', 'arch': 'a100', 'num_devices': 8}]
+    if part.processor.info:
+        assert part.processor.num_cpus == part.processor.info['num_cpus']
+    assert len(part.devices) == 1
+    assert part.devices[0].info == {'type': 'gpu', 'arch': 'a100', 'num_devices': 8}
+    assert part.devices[0].device_type == 'gpu'
 
 
 def test_autotect_with_invalid_files(invalid_topo_exec_ctx):

--- a/unittests/test_autodetect.py
+++ b/unittests/test_autodetect.py
@@ -65,6 +65,13 @@ def test_autotect(exec_ctx):
     }
     assert part.devices[0].device_type == 'gpu'
 
+    # Test immutability of ProcessorType and DeviceType
+    with pytest.raises(AttributeError):
+        part.processor.info = {}
+
+    with pytest.raises(AttributeError):
+        part.devices[0].info = {}
+
 
 def test_autotect_with_invalid_files(invalid_topo_exec_ctx):
     detect_topology()

--- a/unittests/test_utility.py
+++ b/unittests/test_utility.py
@@ -1565,12 +1565,23 @@ class _Z(_D):
     pass
 
 
+class _T(jsonext.JSONSerializable):
+    __slots__ = ('t',)
+
+    def __eq__(self, other):
+        if not isinstance(other, _T):
+            return NotImplemented
+
+        return self.t == other.t
+
+
 class _C(jsonext.JSONSerializable):
     def __init__(self, x, y):
         self.x = x
         self.y = y
         self.z = None
         self.w = {1, 2}
+        self.t = None
 
         # Dump dict with tuples as keys
         self.v = {(1, 2): 1}
@@ -1587,7 +1598,8 @@ class _C(jsonext.JSONSerializable):
         return (self.x == other.x and
                 self.y == other.y and
                 self.z == other.z and
-                self.w == other.w)
+                self.w == other.w and
+                self.t == other.t)
 
 
 def test_jsonext_load(tmp_path):
@@ -1597,10 +1609,15 @@ def test_jsonext_load(tmp_path):
     c.z = _Z()
     c.z.a += 1
     c.z.b = 'barfoo'
+    c.t = _T()
+    c.t.t = 5
 
     json_dump = tmp_path / 'test.json'
     with open(json_dump, 'w') as fp:
         jsonext.dump(c, fp, indent=2)
+
+    with open(json_dump, 'r') as fp:
+        print(fp.read())
 
     with open(json_dump, 'r') as fp:
         c_restored = jsonext.load(fp)


### PR DESCRIPTION
When we detect automatically the topology we used to set directly only the `_info` attribute of the processor of the partition. As a result the other attributes of the `ProcessorType` were not set and we would get for example `self.current_partition.processor.num_cpus` as `None` while `self.current_partition.processor.info` is a non empty dictionary. The other attributes were only set in the `_init_`: https://github.com/eth-cscs/reframe/blob/34ee3d0bc91f7c9f5e56db1c6b46a49e8e5ee623/reframe/core/systems.py#L38

Same for the devices, we should set `self.current_partition._devices` to a list of `DeviceType` objects and not dictionaries.