### PR TITLE
[testlib] Add generic NAMD check for the cscs-supported apps into hpctestlib/apps

### DIFF
--- a/cscs-checks/apps/namd/namd_check.py
+++ b/cscs-checks/apps/namd/namd_check.py
@@ -37,6 +37,7 @@ REFERENCE_CPU_PERFORMANCE = {
     },
 }
 
+
 @rfm.simple_test
 class NamdCheckCSCS(Namd_BaseCheck):
     maintainers = ['CB', 'LM']
@@ -71,7 +72,7 @@ class NamdCheckCSCS(Namd_BaseCheck):
 
     @run_after('init')
     def set_valid_systems(self):
-        if self.platform_name =='gpu':
+        if self.platform_name == 'gpu':
             self.valid_systems = ['daint:gpu']
         else:
             self.valid_systems = ['daint:mc',
@@ -98,7 +99,7 @@ class NamdCheckCSCS(Namd_BaseCheck):
 
     @run_after('setup')
     def set_executable_opts(self):
-        if self.platform_name =='gpu':
+        if self.platform_name == 'gpu':
             self.executable_opts = ['+idlepoll', '+ppn 23', 'stmv.namd']
             self.num_cpus_per_task = 24
             self.num_gpus_per_node = 1
@@ -113,7 +114,7 @@ class NamdCheckCSCS(Namd_BaseCheck):
 
     @run_after('setup')
     def set_reference(self):
-        if self.platform_name =='gpu':
+        if self.platform_name == 'gpu':
             self.reference = REFERENCE_GPU_PERFORMANCE
             if self.scale == 'small':
                 self.valid_systems += ['dom:gpu']

--- a/hpctestlib/apps/namd/base_check.py
+++ b/hpctestlib/apps/namd/base_check.py
@@ -67,15 +67,14 @@ class Namd_BaseCheck(rfm.RunOnlyRegressionTest):
                                            r' \S+ s/step (?P<days_ns>\S+) '
                                            r'days/ns \S+ MB memory',
                                            self.stdout, 'days_ns', float)),
-                               'days/ns')}
+                                   'days/ns')}
 
     @performance_function('days/ns', perf_key='perf')
     def set_perf_patterns(self):
-        return sn.avg(
-               sn.extractall(
-                   r'Info: Benchmark time: \S+ CPUs \S+ '
-                   r's/step (?P<days_ns>\S+) days/ns \S+ MB memory',
-                   self.stdout, 'days_ns', float))
+        return sn.avg(sn.extractall(
+                          r'Info: Benchmark time: \S+ CPUs \S+ '
+                          r's/step (?P<days_ns>\S+) days/ns \S+ MB memory',
+                          self.stdout, 'days_ns', float))
 
     @sanity_function
     def assert_energy_readout(self):

--- a/hpctestlib/apps/namd/base_check.py
+++ b/hpctestlib/apps/namd/base_check.py
@@ -72,9 +72,9 @@ class Namd_BaseCheck(rfm.RunOnlyRegressionTest):
     @performance_function('days/ns', perf_key='perf')
     def set_perf_patterns(self):
         return sn.avg(sn.extractall(
-                          r'Info: Benchmark time: \S+ CPUs \S+ '
-                          r's/step (?P<days_ns>\S+) days/ns \S+ MB memory',
-                          self.stdout, 'days_ns', float))
+                        r'Info: Benchmark time: \S+ CPUs \S+ '
+                        r's/step (?P<days_ns>\S+) days/ns \S+ MB memory',
+                        self.stdout, 'days_ns', float))
 
     @sanity_function
     def assert_energy_readout(self):

--- a/hpctestlib/apps/namd/base_check.py
+++ b/hpctestlib/apps/namd/base_check.py
@@ -67,15 +67,15 @@ class Namd_BaseCheck(rfm.RunOnlyRegressionTest):
                                            r' \S+ s/step (?P<days_ns>\S+) '
                                            r'days/ns \S+ MB memory',
                                            self.stdout, 'days_ns', float)),
-                                           'days/ns')}
+                                       'days/ns')}
 
     @performance_function('days/ns', perf_key='perf')
     def set_perf_patterns(self):
         return sn.avg(
-                 sn.extractall(
-                     r'Info: Benchmark time: \S+ CPUs \S+ '
-                     r's/step (?P<days_ns>\S+) days/ns \S+ MB memory',
-                     self.stdout, 'days_ns', float))
+                sn.extractall(
+                    r'Info: Benchmark time: \S+ CPUs \S+ '
+                    r's/step (?P<days_ns>\S+) days/ns \S+ MB memory',
+                    self.stdout, 'days_ns', float))
 
     @sanity_function
     def assert_energy_readout(self):

--- a/hpctestlib/apps/namd/base_check.py
+++ b/hpctestlib/apps/namd/base_check.py
@@ -1,0 +1,95 @@
+# Copyright 2016-2021 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# ReFrame Project Developers. See the top-level LICENSE file for details.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+import os
+
+import reframe as rfm
+import reframe.utility.sanity as sn
+
+
+class Namd_BaseCheck(rfm.RunOnlyRegressionTest):
+    '''Base class for the NAMD Test.
+
+    NAMD is a parallel molecular dynamics code designed for
+    high-performance simulation of large biomolecular systems.
+    Based on Charm++ parallel objects, NAMD scales to hundreds of
+    cores for typical simulations and beyond 500,000 cores for the
+    largest simulations. NAMD uses the popular molecular graphics
+    program VMD for simulation setup and trajectory analysis,
+    but is also file-compatible with AMBER, CHARMM, and X-PLOR.
+    (see ks.uiuc.edu/Research/namd/)
+
+    The presented abstract run-only class checks the NAMD perfomance.
+    To do this, it is necessary to define in tests  the reference values
+    of energy and possible deviations from this value. This data is used
+    to check if the task is being executed correctly, that is, the final
+    energy is correct (approximately the reference). The default
+    assumption is that NAMD is already installed on the device under test.
+    '''
+
+    #: Reference value of energy, that is used for the comparison
+    #: with the execution ouput on the sanity step. The absolute
+    #: difference between final energy value and reference value
+    #: should be smaller than energy_tolerance
+    #:
+    #: :type: str
+    #: :default: :class:`required`
+    energy_value = variable(float)
+
+    #: Maximum deviation from the reference value of energy,
+    #: that is acceptable.
+    #:
+    #: :default: :class:`required`
+    energy_tolerance = variable(float)
+
+    #: :default: :class:`required`
+    executable = required
+
+    executable = 'namd2'
+    energy_value = -2451359.5
+    energy_tolerance = 2720.
+
+    @run_after('init')
+    def source_install(self):
+        # Reset sources dir relative to the SCS apps prefix
+        self.sourcesdir = os.path.join(self.current_system.resourcesdir,
+                                       'NAMD', 'prod')
+
+    @run_before('performance')
+    def set_the_performance_dict(self):
+        self.perf_variables = {self.scale:
+                               sn.make_performance_function(
+                                    sn.avg(
+                                        sn.extractall(
+                                            r'Info: Benchmark time: \S+ CPUs'
+                                            r' \S+ s/step (?P<days_ns>\S+) '
+                                            r'days/ns \S+ MB memory',
+                                            self.stdout, 'days_ns', float)),
+                                        'days/ns')}
+
+    @performance_function('days/ns', perf_key='perf')
+    def set_perf_patterns(self):
+        return sn.avg(
+                   sn.extractall(
+                       r'Info: Benchmark time: \S+ CPUs \S+ '
+                       r's/step (?P<days_ns>\S+) days/ns \S+ MB memory',
+                       self.stdout, 'days_ns', float))
+
+    @sanity_function
+    def assert_energy_readout(self):
+        '''Assert the obtained energy meets the specified tolerances.'''
+
+        energy = sn.avg(sn.extractall(
+            r'ENERGY:([ \t]+\S+){10}[ \t]+(?P<energy>\S+)',
+            self.stdout, 'energy', float)
+        )
+        energy_diff = sn.abs(energy - self.energy_value)
+        ref_ener_diff = sn.abs(self.energy_tolerance)
+        return sn.all([
+            sn.assert_eq(sn.count(sn.extractall(
+                         r'TIMING: (?P<step_num>\S+)  CPU:',
+                         self.stdout, 'step_num')), 50),
+            sn.assert_lt(energy_diff, self.energy_tolerance)
+        ])

--- a/hpctestlib/apps/namd/base_check.py
+++ b/hpctestlib/apps/namd/base_check.py
@@ -61,18 +61,18 @@ class Namd_BaseCheck(rfm.RunOnlyRegressionTest):
     def set_the_performance_dict(self):
         self.perf_variables = {self.scale:
                                sn.make_performance_function(
-                                  sn.avg(
-                                     sn.extractall(
-                                        r'Info: Benchmark time: \S+ CPUs'
-                                        r' \S+ s/step (?P<days_ns>\S+) '
-                                        r'days/ns \S+ MB memory',
-                                        self.stdout, 'days_ns', float)),
-                                     'days/ns')}
+                                   sn.avg(
+                                       sn.extractall(
+                                           r'Info: Benchmark time: \S+ CPUs'
+                                           r' \S+ s/step (?P<days_ns>\S+) '
+                                           r'days/ns \S+ MB memory',
+                                           self.stdout, 'days_ns', float)),
+                                           'days/ns')}
 
     @performance_function('days/ns', perf_key='perf')
     def set_perf_patterns(self):
         return sn.avg(
-                  sn.extractall(
+                 sn.extractall(
                      r'Info: Benchmark time: \S+ CPUs \S+ '
                      r's/step (?P<days_ns>\S+) days/ns \S+ MB memory',
                      self.stdout, 'days_ns', float))

--- a/hpctestlib/apps/namd/base_check.py
+++ b/hpctestlib/apps/namd/base_check.py
@@ -72,9 +72,9 @@ class Namd_BaseCheck(rfm.RunOnlyRegressionTest):
     @performance_function('days/ns', perf_key='perf')
     def set_perf_patterns(self):
         return sn.avg(sn.extractall(
-                        r'Info: Benchmark time: \S+ CPUs \S+ '
-                        r's/step (?P<days_ns>\S+) days/ns \S+ MB memory',
-                        self.stdout, 'days_ns', float))
+                       r'Info: Benchmark time: \S+ CPUs \S+ '
+                       r's/step (?P<days_ns>\S+) days/ns \S+ MB memory',
+                       self.stdout, 'days_ns', float))
 
     @sanity_function
     def assert_energy_readout(self):

--- a/hpctestlib/apps/namd/base_check.py
+++ b/hpctestlib/apps/namd/base_check.py
@@ -61,21 +61,21 @@ class Namd_BaseCheck(rfm.RunOnlyRegressionTest):
     def set_the_performance_dict(self):
         self.perf_variables = {self.scale:
                                sn.make_performance_function(
-                                    sn.avg(
-                                        sn.extractall(
-                                            r'Info: Benchmark time: \S+ CPUs'
-                                            r' \S+ s/step (?P<days_ns>\S+) '
-                                            r'days/ns \S+ MB memory',
-                                            self.stdout, 'days_ns', float)),
-                                        'days/ns')}
+                                  sn.avg(
+                                     sn.extractall(
+                                        r'Info: Benchmark time: \S+ CPUs'
+                                        r' \S+ s/step (?P<days_ns>\S+) '
+                                        r'days/ns \S+ MB memory',
+                                        self.stdout, 'days_ns', float)),
+                                     'days/ns')}
 
     @performance_function('days/ns', perf_key='perf')
     def set_perf_patterns(self):
         return sn.avg(
-                   sn.extractall(
-                       r'Info: Benchmark time: \S+ CPUs \S+ '
-                       r's/step (?P<days_ns>\S+) days/ns \S+ MB memory',
-                       self.stdout, 'days_ns', float))
+                  sn.extractall(
+                     r'Info: Benchmark time: \S+ CPUs \S+ '
+                     r's/step (?P<days_ns>\S+) days/ns \S+ MB memory',
+                     self.stdout, 'days_ns', float))
 
     @sanity_function
     def assert_energy_readout(self):

--- a/hpctestlib/apps/namd/base_check.py
+++ b/hpctestlib/apps/namd/base_check.py
@@ -72,9 +72,9 @@ class Namd_BaseCheck(rfm.RunOnlyRegressionTest):
     @performance_function('days/ns', perf_key='perf')
     def set_perf_patterns(self):
         return sn.avg(sn.extractall(
-                       r'Info: Benchmark time: \S+ CPUs \S+ '
-                       r's/step (?P<days_ns>\S+) days/ns \S+ MB memory',
-                       self.stdout, 'days_ns', float))
+                      r'Info: Benchmark time: \S+ CPUs \S+ '
+                      r's/step (?P<days_ns>\S+) days/ns \S+ MB memory',
+                      self.stdout, 'days_ns', float))
 
     @sanity_function
     def assert_energy_readout(self):

--- a/hpctestlib/apps/namd/base_check.py
+++ b/hpctestlib/apps/namd/base_check.py
@@ -67,15 +67,15 @@ class Namd_BaseCheck(rfm.RunOnlyRegressionTest):
                                            r' \S+ s/step (?P<days_ns>\S+) '
                                            r'days/ns \S+ MB memory',
                                            self.stdout, 'days_ns', float)),
-                                       'days/ns')}
+                               'days/ns')}
 
     @performance_function('days/ns', perf_key='perf')
     def set_perf_patterns(self):
         return sn.avg(
-                sn.extractall(
-                    r'Info: Benchmark time: \S+ CPUs \S+ '
-                    r's/step (?P<days_ns>\S+) days/ns \S+ MB memory',
-                    self.stdout, 'days_ns', float))
+               sn.extractall(
+                   r'Info: Benchmark time: \S+ CPUs \S+ '
+                   r's/step (?P<days_ns>\S+) days/ns \S+ MB memory',
+                   self.stdout, 'days_ns', float))
 
     @sanity_function
     def assert_energy_readout(self):


### PR DESCRIPTION
This is a continuation of #2084, devoted exclusively to the NAMD test. A new file nve.py has been added, introducing the main class for the NAMD test, as well as the CSCS tests inherited from it.