### PR TITLE
[bugfix] Fix remote auto-detection crash

### DIFF
--- a/reframe/frontend/autodetect.py
+++ b/reframe/frontend/autodetect.py
@@ -8,6 +8,7 @@ import jsonschema
 import os
 import shutil
 import tempfile
+import traceback
 
 import reframe as rfm
 import reframe.core.runtime as runtime
@@ -17,6 +18,10 @@ from reframe.core.logging import getlogger
 from reframe.core.schedulers import Job
 from reframe.core.systems import DeviceInfo, ProcessorInfo
 from reframe.utility.cpuinfo import cpuinfo
+
+
+# This is meant to be used by the unit tests
+_TREAT_WARNINGS_AS_ERRORS = False
 
 
 def _contents(filename):
@@ -35,8 +40,8 @@ def _log_contents(filename):
 
 class _copy_reframe:
     def __init__(self, prefix):
-        self._prefix = prefix
-        self._prefix = runtime().get_option('general/0/remote_workdir')
+        rt = runtime.runtime()
+        self._prefix = rt.get_option('general/0/remote_workdir')
         self._workdir = None
 
     def __enter__(self):
@@ -82,6 +87,9 @@ def _load_info(filename, schema=None):
         with open(filename) as fp:
             return _validate_info(json.load(fp), schema)
     except OSError as e:
+        if _TREAT_WARNINGS_AS_ERRORS:
+            raise
+
         getlogger().warning(
             f'could not load file: {filename!r}: {e}'
         )
@@ -101,9 +109,14 @@ def _save_info(filename, topo_info):
         with open(filename, 'w') as fp:
             json.dump(topo_info, fp, indent=2)
     except OSError as e:
+        if _TREAT_WARNINGS_AS_ERRORS:
+            raise
+
         getlogger().warning(
             f'could not save topology file: {filename!r}: {e}'
         )
+    else:
+        getlogger().debug(f'> saved topology in {filename!r}')
 
 
 def _is_part_local(part):
@@ -143,7 +156,11 @@ def _remote_detect(part):
                 _log_contents(job.stderr)
                 topo_info = json.loads(_contents('topo.json'))
     except Exception as e:
+        if _TREAT_WARNINGS_AS_ERRORS:
+            raise
+
         getlogger().warning(f'failed to retrieve remote processor info: {e}')
+        getlogger().debug(traceback.format_exc())
 
     return topo_info
 
@@ -226,14 +243,11 @@ def detect_topology():
 
                 _save_info(topo_file, part.processor.info)
             elif detect_remote_systems:
-                with runtime.temp_environment(modules=temp_modules,
-                                              variables=temp_vars):
+                with runtime.temp_environment(modules=modules, variables=vars):
                     part._processor = ProcessorInfo(_remote_detect(part))
 
                 if part.processor.info:
                     _save_info(topo_file, part.processor.info)
-
-            getlogger().debug(f'> saved topology in {topo_file!r}')
 
         if not found_devinfo:
             getlogger().debug(f'> device auto-detection is not supported')

--- a/reframe/frontend/autodetect.py
+++ b/reframe/frontend/autodetect.py
@@ -40,8 +40,7 @@ def _log_contents(filename):
 
 class _copy_reframe:
     def __init__(self, prefix):
-        rt = runtime.runtime()
-        self._prefix = rt.get_option('general/0/remote_workdir')
+        self._prefix = prefix
         self._workdir = None
 
     def __enter__(self):

--- a/unittests/test_autodetect.py
+++ b/unittests/test_autodetect.py
@@ -14,7 +14,7 @@ from reframe.utility.cpuinfo import cpuinfo
 
 
 @pytest.fixture
-def exec_ctx(make_exec_ctx_g, tmp_path, monkeypatch):
+def temp_topo(tmp_path, monkeypatch):
     # Monkey-patch HOME, since topology is always written there
     monkeypatch.setenv('HOME', str(tmp_path))
 
@@ -30,11 +30,9 @@ def exec_ctx(make_exec_ctx_g, tmp_path, monkeypatch):
             }
         ], fp)
 
-    yield from make_exec_ctx_g()
-
 
 @pytest.fixture
-def invalid_topo_exec_ctx(make_exec_ctx_g, tmp_path, monkeypatch):
+def invalid_topo(tmp_path, monkeypatch):
     # Monkey-patch HOME, since topology is always written there
     monkeypatch.setenv('HOME', str(tmp_path))
 
@@ -47,10 +45,41 @@ def invalid_topo_exec_ctx(make_exec_ctx_g, tmp_path, monkeypatch):
     with open(meta_prefix / 'devices.json', 'w') as fp:
         fp.write('{')
 
+
+@pytest.fixture
+def user_exec_ctx(make_exec_ctx_g):
+    if test_util.USER_CONFIG_FILE is None:
+        pytest.skip('no user configuration file supplied')
+
+    yield from make_exec_ctx_g(test_util.USER_CONFIG_FILE,
+                               test_util.USER_SYSTEM)
+
+
+@pytest.fixture
+def remote_exec_ctx(user_exec_ctx):
+    partition = test_util.partition_by_scheduler()
+    if not partition:
+        pytest.skip('job submission not supported')
+
+    yield partition, partition.environs[0]
+
+
+@pytest.fixture
+def default_exec_ctx(make_exec_ctx_g, temp_topo):
     yield from make_exec_ctx_g()
 
 
-def test_autotect(exec_ctx):
+@pytest.fixture
+def remote_topo_exec_ctx(remote_exec_ctx, temp_topo):
+    yield from remote_exec_ctx()
+
+
+@pytest.fixture
+def invalid_topo_exec_ctx(make_exec_ctx_g, invalid_topo):
+    yield from make_exec_ctx_g()
+
+
+def test_autotect(default_exec_ctx):
     detect_topology()
     part = runtime().system.partitions[0]
     assert part.processor.info == cpuinfo()
@@ -86,27 +115,7 @@ def test_autotect_with_invalid_files(invalid_topo_exec_ctx):
     assert part.devices == []
 
 
-# FIXME: We should consider making these framework-wide fixtures
-
-@pytest.fixture
-def user_exec_ctx(make_exec_ctx_g):
-    if test_util.USER_CONFIG_FILE is None:
-        pytest.skip('no user configuration file supplied')
-
-    yield from make_exec_ctx_g(test_util.USER_CONFIG_FILE,
-                               test_util.USER_SYSTEM)
-
-
-@pytest.fixture
-def remote_exec_ctx(user_exec_ctx):
-    partition = test_util.partition_by_scheduler()
-    if not partition:
-        pytest.skip('job submission not supported')
-
-    return partition, partition.environs[0]
-
-
-def test_remote_autodetect(remote_exec_ctx):
+def test_remote_autodetect(remote_topo_exec_ctx):
     # All we can do with this test is to trigger the remote auto-detection
     # path; since we don't know what the remote user system is, we cannot test
     # if the topology is right.

--- a/unittests/test_autodetect.py
+++ b/unittests/test_autodetect.py
@@ -47,31 +47,19 @@ def invalid_topo(tmp_path, monkeypatch):
 
 
 @pytest.fixture
-def user_exec_ctx(make_exec_ctx_g):
-    if test_util.USER_CONFIG_FILE is None:
-        pytest.skip('no user configuration file supplied')
-
-    yield from make_exec_ctx_g(test_util.USER_CONFIG_FILE,
-                               test_util.USER_SYSTEM)
-
-
-@pytest.fixture
-def remote_exec_ctx(user_exec_ctx):
-    partition = test_util.partition_by_scheduler()
-    if not partition:
-        pytest.skip('job submission not supported')
-
-    yield partition, partition.environs[0]
-
-
-@pytest.fixture
 def default_exec_ctx(make_exec_ctx_g, temp_topo):
     yield from make_exec_ctx_g()
 
 
 @pytest.fixture
-def remote_topo_exec_ctx(remote_exec_ctx, temp_topo):
-    yield from remote_exec_ctx()
+def remote_exec_ctx(make_exec_ctx):
+    if test_util.USER_CONFIG_FILE is None:
+        pytest.skip('no user configuration file supplied')
+
+    ctx = make_exec_ctx(test_util.USER_CONFIG_FILE,
+                        test_util.USER_SYSTEM,
+                        {'general/remote_detect': True})
+    yield ctx
 
 
 @pytest.fixture
@@ -115,7 +103,7 @@ def test_autotect_with_invalid_files(invalid_topo_exec_ctx):
     assert part.devices == []
 
 
-def test_remote_autodetect(remote_topo_exec_ctx):
+def test_remote_autodetect(remote_exec_ctx):
     # All we can do with this test is to trigger the remote auto-detection
     # path; since we don't know what the remote user system is, we cannot test
     # if the topology is right.


### PR DESCRIPTION
If you try to auto-detect a remote partition, ReFrame will crash as follows:

```
Traceback (most recent call last):
  File "./bin/reframe", line 22, in <module>
    cli.main()
  File "/users/karakasv/Devel/reframe/reframe/frontend/cli.py", line 617, in main
    autodetect.detect_topology()
  File "/users/karakasv/Devel/reframe/reframe/frontend/autodetect.py", line 229, in detect_topology
    with runtime.temp_environment(modules=temp_modules,
NameError: name 'temp_modules' is not defined
```

This PR fixes this and introduces a unit test that tests that.