### PR TITLE
[test] Add generic ICON check for the cscs-supported apps into hpctestlib/apps

### DIFF
--- a/hpctestlib/apps/icon/base_check.py
+++ b/hpctestlib/apps/icon/base_check.py
@@ -1,0 +1,70 @@
+# Copyright 2016-2021 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# ReFrame Project Developers. See the top-level LICENSE file for details.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+import os
+
+import reframe as rfm
+import reframe.utility.sanity as sn
+
+
+class RRTMGPTest_Base(rfm.RegressionTest):
+    '''Base class for the ICON(Icosahedral Nonhydrostatic Weather
+    and Climate Model) Test.
+
+    The ICON modelling framework is a joint project between the German
+    Weather Service and the Max Planck Institute for Meteorology for
+    developing a unified next-generation global numerical weather prediction
+    and climate modelling system. The ICON model has been introduced into
+    DWD's operational forecast system in January 2015.
+    (see code.mpimet.mpg.de/projects/iconpublic)
+
+    The presented abstract run-only class checks the ICON perfomance.
+    The test is verified by checking the performance of the RRTMGP model.
+    RRTMGP uses a k-distribution to provide an optical description
+    (absorption and possibly Rayleigh optical depth) of the gaseous
+    atmosphere, along with the relevant source functions, on a pre-determined
+    spectral grid given temperatures, pressures, and gas concentration.
+    (see github.com/earth-system-radiation/rte-rrtmgp)
+    The default assumption is that ICON is already installed on the
+    device under test.
+    !!!ATTENTION!!!
+    This test is outdated and broken in general and needs to repair.
+    '''
+
+    executable = 'python'
+
+    #: This information is used to determine the name of the test file.
+    #:
+    #: :default: :class:`dict`
+    variables = {
+        'NCOL': '500',
+        'INIFILE': 'openacc-solvers-lw'
+    }
+    tags = {'external-resources'}
+
+    @run_before('run')
+    def set_executable_opts(self):
+        self.executable_opts = [
+            'util/scripts/run_tests.py',
+            '--verbose', '--rel_diff_cut 1e-13',
+            '--root ..', '--test ${INIFILE}_ncol-${NCOL}.ini'
+        ]
+
+    @run_before('run')
+    def set_prerun_cmds(self):
+        self.prerun_cmds = [
+            'pwd',
+            'module load netcdf-python/1.4.1-CrayGNU-19.06-python2',
+            'cd test'
+            ]
+
+    @sanity_function
+    def sanity_pattern(self):
+        values = sn.extractall(r'.*\[\S+, (\S+)\]', self.stdout, 1, float)
+        return sn.all(
+            sn.chain(
+                [sn.assert_gt(sn.count(values), 0, msg='regex not matched')],
+                sn.map(lambda x: sn.assert_lt(x, 1e-5), values))
+        )


### PR DESCRIPTION
This is a continuation of the work on the test library. This PR work has been done with ICON tests. A new file base_check.py has been added, introducing the main class for the ICON test, as well as the CSCS tests inherited from it.
Problems with this test in general 2. First, the original test is broken, so there is no way to check the functionality of the written test. Second, I did not find any normal documentation for this framework, as well as a description of the test, so perhaps the documentation of the test leaves much to be desired. 