### PR TITLE
[bugfix] Fix timestamp prefix when `--timestamp` option is passed no arguments

### DIFF
--- a/reframe/frontend/argparse.py
+++ b/reframe/frontend/argparse.py
@@ -184,8 +184,7 @@ class _ArgumentHolder:
         kwargs['dest'] = opt_name
 
         # Convert 'store_true' and 'store_false' actions to their
-        # 'store_const' equivalents, because they otherwise imply imply a
-        # default
+        # 'store_const' equivalents, because they otherwise imply a default
         action = kwargs.get('action', None)
         if action == 'store_true' or action == 'store_false':
             kwargs['action'] = 'store_const'

--- a/reframe/frontend/cli.py
+++ b/reframe/frontend/cli.py
@@ -217,7 +217,8 @@ def main():
         envvar='RFM_SAVE_LOG_FILES', configvar='general/save_log_files'
     )
     output_options.add_argument(
-        '--timestamp', action='store', nargs='?', const='', metavar='TIMEFMT',
+        '--timestamp', action='store', nargs='?', const='%FT%T',
+        metavar='TIMEFMT',
         help=('Append a timestamp to the output and stage directory prefixes '
               '(default: "%%FT%%T")'),
         envvar='RFM_TIMESTAMP_DIRS', configvar='general/timestamp_dirs'

--- a/unittests/test_argparser.py
+++ b/unittests/test_argparser.py
@@ -104,7 +104,7 @@ def extended_parser():
         envvar='RFM_KEEP_STAGE_FILES', configvar='general/keep_stage_files'
     )
     foo_options.add_argument(
-        '--timestamp', action='store', nargs='?', const='',
+        '--timestamp', action='store',
         envvar='RFM_TIMESTAMP_DIRS', configvar='general/timestamp_dirs'
     )
     foo_options.add_argument(
@@ -180,10 +180,3 @@ def test_option_envvar_conversion_error(default_exec_ctx, extended_parser):
         options = extended_parser.parse_args(['--nocolor'])
         errors = options.update_config(site_config)
         assert len(errors) == 1
-
-
-def test_option_nargs(default_exec_ctx, extended_parser):
-    site_config = rt.runtime().site_config
-    options = extended_parser.parse_args(['--timestamp'])
-    assert options.timestamp == ''
-    assert site_config.get('general/0/timestamp_dirs') == '%FT%T'

--- a/unittests/test_argparser.py
+++ b/unittests/test_argparser.py
@@ -104,7 +104,7 @@ def extended_parser():
         envvar='RFM_KEEP_STAGE_FILES', configvar='general/keep_stage_files'
     )
     foo_options.add_argument(
-        '--timestamp', action='store',
+        '--timestamp', action='store', nargs='?', const='',
         envvar='RFM_TIMESTAMP_DIRS', configvar='general/timestamp_dirs'
     )
     foo_options.add_argument(
@@ -180,3 +180,10 @@ def test_option_envvar_conversion_error(default_exec_ctx, extended_parser):
         options = extended_parser.parse_args(['--nocolor'])
         errors = options.update_config(site_config)
         assert len(errors) == 1
+
+
+def test_option_nargs(default_exec_ctx, extended_parser):
+    site_config = rt.runtime().site_config
+    options = extended_parser.parse_args(['--timestamp'])
+    assert options.timestamp == ''
+    assert site_config.get('general/0/timestamp_dirs') == '%FT%T'

--- a/unittests/test_cli.py
+++ b/unittests/test_cli.py
@@ -11,6 +11,7 @@ import os
 import pytest
 import re
 import sys
+import time
 
 import reframe.core.environments as env
 import reframe.frontend.runreport as runreport
@@ -474,9 +475,7 @@ def test_execution_modes(run_reframe):
 
 
 def test_timestamp_option(run_reframe):
-    from datetime import datetime
-
-    timefmt = datetime.now().strftime('xxx_%F')
+    timefmt = time.strftime('xxx_%F')
     returncode, stdout, _ = run_reframe(
         checkpath=['unittests/resources/checks'],
         action='list',
@@ -484,6 +483,17 @@ def test_timestamp_option(run_reframe):
     )
     assert returncode == 0
     assert timefmt in stdout
+
+
+def test_timestamp_option_default(run_reframe):
+    timefmt_date_part = time.strftime('%FT')
+    returncode, stdout, _ = run_reframe(
+        checkpath=['unittests/resources/checks'],
+        action='list',
+        more_options=['-R', '--timestamp']
+    )
+    assert returncode == 0
+    assert timefmt_date_part in stdout
 
 
 def test_list_empty_prgenvs_check_and_options(run_reframe):


### PR DESCRIPTION
The fix is easy, but there is a subtlety. In this case, we do not use the default from the configuration, which is `''`. This is used when the `--timestamp` option is not passed at all.

Fixes #2169.