### PR TITLE
[bugfix] Fix division by zero when calculating the poll rate

### DIFF
--- a/reframe/frontend/executors/policies.py
+++ b/reframe/frontend/executors/policies.py
@@ -6,6 +6,7 @@
 import contextlib
 import functools
 import itertools
+import math
 import sys
 import time
 
@@ -63,7 +64,7 @@ class _PollController:
     def snooze(self):
         t_elapsed = time.time() - self._t_init
         self._num_polls += 1
-        poll_rate = self._num_polls / t_elapsed if t_elapsed else None
+        poll_rate = self._num_polls / t_elapsed if t_elapsed else math.inf
         getlogger().debug2(
             f'Poll rate control: sleeping for {self._sleep_duration}s '
             f'(current poll rate: {poll_rate} polls/s)'

--- a/reframe/frontend/executors/policies.py
+++ b/reframe/frontend/executors/policies.py
@@ -63,9 +63,10 @@ class _PollController:
     def snooze(self):
         t_elapsed = time.time() - self._t_init
         self._num_polls += 1
+        poll_rate = self._num_polls / t_elapsed if t_elapsed else None
         getlogger().debug2(
             f'Poll rate control: sleeping for {self._sleep_duration}s '
-            f'(current poll rate: {self._num_polls/t_elapsed} polls/s)'
+            f'(current poll rate: {poll_rate} polls/s)'
         )
         time.sleep(self._sleep_duration)
 


### PR DESCRIPTION
On my laptop quite often I get the error
```
[==========] Finished on Tue Sep 21 22:13:38 2021
Run report saved in '/Users/sarafael/.reframe/reports/run-report.json'
./bin/reframe: run session stopped: zero division error: float division by zero
./bin/reframe: Traceback (most recent call last):
  File "/Users/sarafael/git_/reframe/reframe/frontend/cli.py", line 1062, in main
    runner.runall(testcases, restored_cases)
  File "/Users/sarafael/git_/reframe/reframe/frontend/executors/__init__.py", line 431, in runall
    self._runall(testcases)
  File "/Users/sarafael/git_/reframe/reframe/frontend/executors/__init__.py", line 504, in _runall
    self._policy.exit()
  File "/Users/sarafael/git_/reframe/reframe/frontend/executors/policies.py", line 545, in exit
    self._pollctl.running_tasks(num_running).snooze()
  File "/Users/sarafael/git_/reframe/reframe/frontend/executors/policies.py", line 68, in snooze
    f'(current poll rate: {self._num_polls/t_elapsed} polls/s)'
ZeroDivisionError: float division by zero
```