### PR TITLE
[bugfix] Fix `--restore-session` failure when ReFrame root directory is not in `sys.path[0]`

### DIFF
--- a/reframe/core/exceptions.py
+++ b/reframe/core/exceptions.py
@@ -10,8 +10,8 @@
 import contextlib
 import inspect
 import os
-import sys
 
+import reframe
 import reframe.utility as utility
 
 
@@ -305,7 +305,7 @@ def user_frame(exc_type, exc_value, tb):
         return None
 
     for finfo in reversed(inspect.getinnerframes(tb)):
-        relpath = os.path.relpath(finfo.filename, sys.path[0])
+        relpath = os.path.relpath(finfo.filename, reframe.INSTALL_PREFIX)
         if relpath.split(os.sep)[0] != 'reframe':
             return finfo
 

--- a/reframe/utility/__init__.py
+++ b/reframe/utility/__init__.py
@@ -17,6 +17,8 @@ import sys
 import types
 import weakref
 
+import reframe
+
 from collections import UserDict
 from . import typecheck as typ
 
@@ -81,9 +83,7 @@ def import_module_from_file(filename, force=False):
         filename = os.path.join(filename, '__init__.py')
 
     # Express filename relative to reframe
-    rfm_root = os.path.realpath(os.path.join(os.path.dirname(__file__),
-                                '../..'))
-    rel_filename = os.path.relpath(filename, rfm_root)
+    rel_filename = os.path.relpath(filename, reframe.INSTALL_PREFIX)
     module_name = _get_module_name(rel_filename)
     if rel_filename.startswith('..'):
         # We cannot use the standard Python import mechanism here, because the

--- a/reframe/utility/__init__.py
+++ b/reframe/utility/__init__.py
@@ -81,7 +81,10 @@ def import_module_from_file(filename, force=False):
         filename = os.path.join(filename, '__init__.py')
 
     # Express filename relative to reframe
-    rel_filename = os.path.relpath(filename, sys.path[0])
+    rfm_root = os.path.realpath(os.path.join(os.path.dirname(__file__),
+                                '../..'))
+    rel_filename = os.path.relpath(filename, rfm_root)
+    # rel_filename = os.path.relpath(filename, __file__)
     module_name = _get_module_name(rel_filename)
     if rel_filename.startswith('..'):
         # We cannot use the standard Python import mechanism here, because the

--- a/reframe/utility/__init__.py
+++ b/reframe/utility/__init__.py
@@ -84,7 +84,6 @@ def import_module_from_file(filename, force=False):
     rfm_root = os.path.realpath(os.path.join(os.path.dirname(__file__),
                                 '../..'))
     rel_filename = os.path.relpath(filename, rfm_root)
-    # rel_filename = os.path.relpath(filename, __file__)
     module_name = _get_module_name(rel_filename)
     if rel_filename.startswith('..'):
         # We cannot use the standard Python import mechanism here, because the


### PR DESCRIPTION
Close #2135 