### PR TITLE
[bugfix] Fix error when cache associativity information is not available by `sysctl`

### DIFF
--- a/reframe/utility/cpuinfo.py
+++ b/reframe/utility/cpuinfo.py
@@ -11,7 +11,6 @@ import re
 
 import reframe.utility.osext as osext
 from reframe.core.exceptions import SpawnedProcessError
-from reframe.core.logging import getlogger
 
 
 def _bits_from_str(mask_s):
@@ -207,44 +206,32 @@ def _sysctl_topo():
     match = re.search(r'hw\.ncpu: (?P<num_cpus>\d+)', exec_output.stdout)
     if match:
         num_cpus = int(match.group('num_cpus'))
-    else:
-        getlogger().warning(f'not able to detect num_cpus')
 
     match = re.search(r'hw\.physicalcpu: (?P<num_cores>\d+)',
                       exec_output.stdout)
     if match:
         num_cores = int(match.group('num_cores'))
-    else:
-        getlogger().warning(f'not able to detect num_cores')
 
     match = re.search(r'hw\.packages: (?P<num_sockets>\d+)',
                       exec_output.stdout)
     if match:
         num_sockets = int(match.group('num_sockets'))
         cpuinfo['num_sockets'] = num_sockets
-    else:
-        getlogger().warning(f'not able to detect num_sockets')
 
     match = re.search(r'hw\.cacheconfig:(?P<cacheconfig>(\s\d+)*)',
                       exec_output.stdout)
     if match:
         cacheconfig = list(map(int, match.group('cacheconfig').split()))
-    else:
-        getlogger().warning(f'not able to detect cacheconfig')
 
     match = re.search(r'hw\.cachesize:(?P<cachesize>(\s\d+)*)',
                       exec_output.stdout)
     if match:
         cachesize = list(map(int, match.group('cachesize').split()))
-    else:
-        getlogger().warning(f'not able to detect cachesize')
 
     match = re.search(r'hw\.cachelinesize: (?P<linesize>\d+)',
                       exec_output.stdout)
     if match:
         linesize = int(match.group('linesize'))
-    else:
-        getlogger().warning(f'not able to detect cache linesize')
 
     # index 0 is referring to memory
     cache_associativity = [0]
@@ -255,13 +242,7 @@ def _sysctl_topo():
         match = re.search(rf'machdep\.cpu\.cache\.L{i}_associativity: '
                           rf'(?P<associativity>\d+)',
                           exec_output.stdout)
-        if match:
-            assoc = int(match.group('associativity'))
-        else:
-            assoc = 0
-            getlogger().warning(f'not able to detect L{i} cache '
-                                f'associativity')
-
+        assoc = int(match.group('associativity')) if match else 0
         cache_associativity.append(assoc)
 
     num_cpus_per_socket = num_cpus // num_sockets

--- a/reframe/utility/cpuinfo.py
+++ b/reframe/utility/cpuinfo.py
@@ -195,7 +195,7 @@ def _sysfs_topo():
 
 def _sysctl_topo():
     try:
-        exec_output = osext.run_command('sysctl hw machdep.cpu.cache',
+        exec_output = osext.run_command('sysctl hw machdep.cpu',
                                         check=True)
     except (FileNotFoundError, SpawnedProcessError):
         return {}


### PR DESCRIPTION
Closes #2202 .

In the sysctl output from @rsarm's laptop I could not find the information for the cache associativity. So in order to fix the bug in the unittest I made the `sysctl` command more generic (to avoid the `SpawnedProcessError` exception).

We don't give a warning for every item of the processor information that we cannot detect because it would unnecessarily complicate the `--detect-host-topology` option, since it's supposed to print only the json object.