### PR TITLE
[test] Build HIP using the latest release

### DIFF
--- a/cscs-checks/prgenv/hip/build_hip.py
+++ b/cscs-checks/prgenv/hip/build_hip.py
@@ -23,7 +23,7 @@ class BuildHip(rfm.RegressionTest):
     build_system = 'CMake'
 
     # Checkout the latest tag - git describe doesn't work here
-    prebuild_cmds = ["git tag | tail -1 | xargs git checkout $1"]
+    prebuild_cmds = ['git tag | tail -1 | xargs git checkout $1']
 
     postbuild_cmds = ['make install']
     executable = f'{hip_path}/bin/hipcc'


### PR DESCRIPTION
This test was previously using the tip of main, which made the test a bit unstable.