### PR TITLE
[feat] Add a utility function to skip tests that have no topology information

### DIFF
--- a/reframe/core/pipeline.py
+++ b/reframe/core/pipeline.py
@@ -2218,8 +2218,10 @@ class RegressionTest(RegressionMixin, jsonext.JSONSerializable):
 
         proc = self.current_partition.processor
         pname = self.current_partition.fullname
-        self.skip_if(not proc.info,
-                     f'no topology information found for partition {pname!r}')
+        if msg is None:
+            msg = f'no topology information found for partition {pname!r}'
+
+        self.skip_if(not proc.info, msg)
 
     def __str__(self):
         return "%s(name='%s', prefix='%s')" % (type(self).__name__,

--- a/reframe/core/pipeline.py
+++ b/reframe/core/pipeline.py
@@ -2203,6 +2203,24 @@ class RegressionTest(RegressionMixin, jsonext.JSONSerializable):
         if cond:
             self.skip(msg)
 
+    def skip_if_no_procinfo(self, msg=None):
+        '''Skip test if no processor topology information is available.
+
+        This method has effect only if called after the ``setup`` stage.
+
+        :arg msg: A message explaining why the test was skipped.
+            If not specified, a default message will be used.
+
+        .. versionadded:: 3.9.1
+        '''
+        if not self.current_partition:
+            return
+
+         proc = self.current_partition.processor
+         pname = self.current_partition.fullname
+         self.skip_if(not proc.info,
+                      f'no topology information found for partition {pname!r}')
+
     def __str__(self):
         return "%s(name='%s', prefix='%s')" % (type(self).__name__,
                                                self.name, self.prefix)

--- a/reframe/core/pipeline.py
+++ b/reframe/core/pipeline.py
@@ -2216,10 +2216,10 @@ class RegressionTest(RegressionMixin, jsonext.JSONSerializable):
         if not self.current_partition:
             return
 
-         proc = self.current_partition.processor
-         pname = self.current_partition.fullname
-         self.skip_if(not proc.info,
-                      f'no topology information found for partition {pname!r}')
+        proc = self.current_partition.processor
+        pname = self.current_partition.fullname
+        self.skip_if(not proc.info,
+                     f'no topology information found for partition {pname!r}')
 
     def __str__(self):
         return "%s(name='%s', prefix='%s')" % (type(self).__name__,


### PR DESCRIPTION
This is quite useful with the topology autodetection, since it should be called the the first time that the topology is requested in a test. Otherwise, users would have to write a post-setup hook doing the same thing. I am not adding for the moment an equivalent function for the device autodetection, because I would like to first see the usage scenarios in practice.