### PR TITLE
[ci] Remove remote autodetect from CI

### DIFF
--- a/config/cscs-ci.py
+++ b/config/cscs-ci.py
@@ -209,7 +209,6 @@ site_configuration = {
                 'checks/'
             ],
             'check_search_recursive': True,
-            'remote_detect': True
         }
     ]
 }


### PR DESCRIPTION
We should not need that in the `config/cscs-ci.py` config file.