### PR TITLE
[bugfix] Fix incorrect regex for `gpu_bandwidth_check` perf results

### DIFF
--- a/hpctestlib/microbenchmarks/gpu/memory_bandwidth/__init__.py
+++ b/hpctestlib/microbenchmarks/gpu/memory_bandwidth/__init__.py
@@ -179,6 +179,6 @@ class GpuBandwidthD2D(GpuBandwidthBase):
         '''
         self.perf_patterns = {
             'bw': sn.min(sn.extractall(
-                r'^[^,]*\[[^\]]*\]\s+GPU\s+\d+\s+(\s*\d+.\d+\s)+',
+                r'^\[[^\]]*\]\s+GPU\s+\d+\s+(\s*\d+.\d+\s)+',
                 self.stdout, 1, float))
         }

--- a/hpctestlib/microbenchmarks/gpu/memory_bandwidth/__init__.py
+++ b/hpctestlib/microbenchmarks/gpu/memory_bandwidth/__init__.py
@@ -5,7 +5,6 @@
 
 import reframe.utility.sanity as sn
 import reframe as rfm
-import sys
 
 
 __all__ = ['GpuBandwidth', 'GpuBandwidthD2D']

--- a/hpctestlib/microbenchmarks/gpu/memory_bandwidth/__init__.py
+++ b/hpctestlib/microbenchmarks/gpu/memory_bandwidth/__init__.py
@@ -5,6 +5,7 @@
 
 import reframe.utility.sanity as sn
 import reframe as rfm
+import sys
 
 
 __all__ = ['GpuBandwidth', 'GpuBandwidthD2D']
@@ -144,7 +145,7 @@ class GpuBandwidth(GpuBandwidthBase):
 
         # Extract the bandwidth corresponding to the right node, transfer and
         # device.
-        return (rf'^[^,]*\[[^\]]*\]\s*{direction}\s*bandwidth on device'
+        return (rf'^\[[^\]]*\]\s*{direction}\s*bandwidth on device'
                 r' \d+ is \s*(\S+)\s*GB/s.')
 
 


### PR DESCRIPTION
The string tested on is multiline, so must not match stuff with *