### PR TITLE
[feat] Define the execution order of hooks and implement it properly

### DIFF
--- a/reframe/core/pipeline.py
+++ b/reframe/core/pipeline.py
@@ -197,11 +197,15 @@ class RegressionTest(RegressionMixin, jsonext.JSONSerializable):
 
     @classmethod
     def pipeline_hooks(cls):
+        # The hook registry stores hooks in MRO order, but we want to attach
+        # the hooks in reverse order so that the more specialized hooks (those
+        # at the beginning of the MRO list) will be executed last
+
         ret = {}
         for hook in cls._rfm_hook_registry:
             for stage in hook.stages:
                 try:
-                    ret[stage].append(hook.fn)
+                    ret[stage].insert(0, hook.fn)
                 except KeyError:
                     ret[stage] = [hook.fn]
 

--- a/unittests/test_pipeline.py
+++ b/unittests/test_pipeline.py
@@ -772,7 +772,7 @@ def weird_mro_test(HelloTest):
     #
     # See example in https://www.python.org/download/releases/2.3/mro/
     #
-    # The MRO of A is ABECDFO, which means that E is more specialized than C!
+    # The MRO of A is ABECDFX, which means that E is more specialized than C!
     class X(rfm.RegressionMixin):
         pass
 

--- a/unittests/test_pipeline.py
+++ b/unittests/test_pipeline.py
@@ -761,9 +761,58 @@ def test_inherited_hooks(HelloTest, local_exec_ctx):
     assert test.var == 2
     assert test.foo == 1
     assert test.pipeline_hooks() == {
-        'post_setup': [DerivedTest.z, BaseTest.x],
+        'post_setup': [BaseTest.x, DerivedTest.z],
         'pre_run': [C.y],
     }
+
+
+@pytest.fixture
+def weird_mro_test(HelloTest):
+    # This returns a class with non-obvious MRO resolution.
+    #
+    # See example in https://www.python.org/download/releases/2.3/mro/
+    #
+    # The MRO of A is ABECDFO, which means that E is more specialized than C!
+    class X(rfm.RegressionMixin):
+        pass
+
+    class D(X):
+        @run_after('setup')
+        def d(self):
+            pass
+
+    class E(X):
+        @run_after('setup')
+        def e(self):
+            pass
+
+    class F(X):
+        @run_after('setup')
+        def f(self):
+            pass
+
+    class C(D, F):
+        @run_after('setup')
+        def c(self):
+            pass
+
+    class B(E, D):
+        @run_after('setup')
+        def b(self):
+            pass
+
+    class A(B, C, HelloTest):
+        @run_after('setup')
+        def a(self):
+            pass
+
+    return A
+
+
+def test_inherited_hooks_order(weird_mro_test, local_exec_ctx):
+    t = weird_mro_test()
+    hook_order = [fn.__name__ for fn in t.pipeline_hooks()['post_setup']]
+    assert hook_order == ['f', 'd', 'c', 'e', 'b', 'a']
 
 
 def test_inherited_hooks_from_instantiated_tests(HelloTest, local_exec_ctx):


### PR DESCRIPTION
As indicated in #2268 the order of execution of inherited hooks was not documented and it was also wrong. This PR solves this issue by imposing a reverse MRO execution order, so that the hooks of the most specialized class are executed last. In the part, hooks were executed starting from the derived classes going up to the bases, but without following strict MRO order.

Fixes #2268.