### PR TITLE
[bugfix] Fix hook execution order for hooks in the same class

### DIFF
--- a/reframe/core/hooks.py
+++ b/reframe/core/hooks.py
@@ -156,15 +156,19 @@ class HookRegistry:
             v._rfm_attach = ['post_setup']
             self.__hooks.add(Hook(v))
 
-    def update(self, hooks, *, denied_hooks=None):
+    def update(self, other, *, denied_hooks=None):
         '''Update the hook registry with the hooks from another hook registry.
 
         The optional ``denied_hooks`` argument takes a set of disallowed
         hook names, preventing their inclusion into the current hook registry.
         '''
+
+        assert isinstance(other, HookRegistry)
         denied_hooks = denied_hooks or set()
-        for h in hooks:
+        for h in other:
             if h.__name__ not in denied_hooks:
+                # Hooks in `other` override ours
+                self.__hooks.discard(h)
                 self.__hooks.add(h)
 
     def __repr__(self):

--- a/reframe/core/meta.py
+++ b/reframe/core/meta.py
@@ -411,13 +411,14 @@ class RegressionTestMeta(type):
         cls._rfm_dir.update(cls.__dict__)
 
         # Populate the global hook registry with the hook registries of the
-        # parent classes in MRO order
-        cls._rfm_hook_registry.update(cls._rfm_local_hook_registry)
-        for c in cls.mro()[1:]:
+        # parent classes in reverse MRO order
+        for c in list(reversed(cls.mro()))[:-1]:
             if hasattr(c, '_rfm_local_hook_registry'):
                 cls._rfm_hook_registry.update(
                     c._rfm_local_hook_registry, denied_hooks=namespace
                 )
+
+        cls._rfm_hook_registry.update(cls._rfm_local_hook_registry)
 
         # Search the bases if no local sanity functions exist.
         if '_rfm_sanity' not in namespace:

--- a/reframe/core/pipeline.py
+++ b/reframe/core/pipeline.py
@@ -197,15 +197,11 @@ class RegressionTest(RegressionMixin, jsonext.JSONSerializable):
 
     @classmethod
     def pipeline_hooks(cls):
-        # The hook registry stores hooks in MRO order, but we want to attach
-        # the hooks in reverse order so that the more specialized hooks (those
-        # at the beginning of the MRO list) will be executed last
-
         ret = {}
         for hook in cls._rfm_hook_registry:
             for stage in hook.stages:
                 try:
-                    ret[stage].insert(0, hook.fn)
+                    ret[stage].append(hook.fn)
                 except KeyError:
                     ret[stage] = [hook.fn]
 

--- a/unittests/test_pipeline.py
+++ b/unittests/test_pipeline.py
@@ -753,15 +753,19 @@ def test_inherited_hooks(HelloTest, local_exec_ctx):
         def z(self):
             self.var += 1
 
+        @run_after('setup')
+        def w(self):
+            self.var += 1
+
     class MyTest(DerivedTest):
         pass
 
     test = MyTest()
     _run(test, *local_exec_ctx)
-    assert test.var == 2
+    assert test.var == 3
     assert test.foo == 1
     assert test.pipeline_hooks() == {
-        'post_setup': [BaseTest.x, DerivedTest.z],
+        'post_setup': [BaseTest.x, DerivedTest.z, DerivedTest.w],
         'pre_run': [C.y],
     }
 


### PR DESCRIPTION
This was practically introduced because we blindly reversed the order of hooks in `RegressionTest.pipeline_hooks()`. Now the reverse MRO order is ensured as we build the global hook registry of the class. Since the local registries of the parent classes are used to update this class' registry, the order of their hooks as they are inserted is preserved.

Fixes #2284.