### PR TITLE
[test] Skip the TensorFlow checks if the processor information is not found

### DIFF
--- a/cscs-checks/apps/tensorflow/tf2_horovod_check.py
+++ b/cscs-checks/apps/tensorflow/tf2_horovod_check.py
@@ -26,13 +26,13 @@ class cscs_tensorflow_horovod_check(tensorflow_cnn_check):
         8: {
             'sm_60': {
                 'throughput_total': (1712, -0.05, None, 'images/s'),
-                'throughput_iteration': (214, -0.05, None, 'images/s')
+                'throughput_per_gpu': (214, -0.05, None, 'images/s')
             }
         },
         32: {
             'sm_60': {
                 'throughput_total': (6848, -0.05, None, 'images/s'),
-                'throughput_iteration': (214, -0.05, None, 'images/s')
+                'throughput_per_gpu': (214, -0.05, None, 'images/s')
             }
         },
     }
@@ -44,6 +44,7 @@ class cscs_tensorflow_horovod_check(tensorflow_cnn_check):
 
     @run_before('run')
     def setup_run(self):
+        self.skip_if_no_procinfo()
         proc = self.current_partition.processor
         self.num_tasks = self.num_nodes * self.num_tasks_per_node
         self.num_cpus_per_task = proc.num_cores


### PR DESCRIPTION
I'm renaming `'throughput_iteration'` to `'throughput_per_gpu'`. I think it's a clearer name.