### PR TITLE
[testlib] Append to `executable_opts` in Gromacs library test

### DIFF
--- a/hpctestlib/sciapps/gromacs/benchmarks.py
+++ b/hpctestlib/sciapps/gromacs/benchmarks.py
@@ -65,7 +65,7 @@ class gromacs_check(rfm.RunOnlyRegressionTest):
         self.prerun_cmds = [
             f'curl -LJO https://github.com/victorusu/GROMACS_Benchmark_Suite/raw/{self.benchmark_version}/{self.__bench}/benchmark.tpr'  # noqa: E501
         ]
-        self.executable_opts = ['-nb', self.nb_impl, '-s benchmark.tpr']
+        self.executable_opts += ['-nb', self.nb_impl, '-s benchmark.tpr']
 
     @property
     def bench_name(self):


### PR DESCRIPTION
The `executable_opts` passed by the tests are overwritten by the library-defined ones. e.g.
For the CSCS checks, instead of generating these command-line options for GROMACs
```
gmx_mpi mdrun -dlb yes -ntomp 1 -npme -1 -nb cpu -s benchmark.tpr   # correct set
```
one gets
```
gmx_mpi mdrun -nb cpu -s benchmark.tpr  # wrong set
```

This PR fixes this issue.

