### PR TITLE
[test] Modernize syntax of LAMMPS checks

### DIFF
--- a/cscs-checks/apps/lammps/lammps_check.py
+++ b/cscs-checks/apps/lammps/lammps_check.py
@@ -12,52 +12,76 @@ import reframe.utility.sanity as sn
 class LAMMPSCheck(rfm.RunOnlyRegressionTest):
     scale = parameter(['small', 'large'])
     variant = parameter(['maint', 'prod'])
+    modules = ['cray-python', 'LAMMPS']
+    tags = {'scs', 'external-resources'}
+    maintainers = ['LM']
+    strict_check = False
+    extra_resources = {
+        'switches': {
+            'num_switches': 1
+        }
+    }
 
-    def __init__(self):
+    @run_after('init')
+    def setup_by_system(self):
+        # Reset sources dir relative to the SCS apps prefix
+        self.sourcesdir = os.path.join(self.current_system.resourcesdir,
+                                       'LAMMPS')
         if self.current_system.name in ['eiger', 'pilatus']:
             self.valid_prog_environs = ['cpeGNU']
         else:
             self.valid_prog_environs = ['builtin']
-        self.modules = ['cray-python', 'LAMMPS']
 
-        # Reset sources dir relative to the SCS apps prefix
-        self.sourcesdir = os.path.join(self.current_system.resourcesdir,
-                                       'LAMMPS')
+    @performance_function('timesteps/s')
+    def perf(self):
+        return sn.extractsingle(r'\s+(?P<perf>\S+) timesteps/s',
+                                self.stdout, 'perf', float)
+
+    @sanity_function
+    def assert_energy_diff(self):
         energy_reference = -4.6195
         energy = sn.extractsingle(
             r'\s+500000(\s+\S+){3}\s+(?P<energy>\S+)\s+\S+\s\n',
             self.stdout, 'energy', float)
-        self.perf_patterns = {
-            'perf': sn.extractsingle(r'\s+(?P<perf>\S+) timesteps/s',
-                                     self.stdout, 'perf', float),
-        }
-        energy_diff = sn.abs(energy-energy_reference)
-        self.sanity_patterns = sn.all([
+        energy_diff = sn.abs(energy - energy_reference)
+        return sn.all([
             sn.assert_found(r'Total wall time:', self.stdout),
             sn.assert_lt(energy_diff, 6e-4)
         ])
-        self.strict_check = False
-        self.extra_resources = {
-            'switches': {
-                'num_switches': 1
-            }
-        }
-
-        self.tags = {'scs', 'external-resources'}
-        self.maintainers = ['LM']
 
 
 @rfm.simple_test
 class LAMMPSGPUCheck(LAMMPSCheck):
-    def __init__(self):
-        super().__init__()
+    valid_systems = ['daint:gpu']
+    executable = 'lmp_mpi'
+    executable_opts = ['-sf gpu', '-pk gpu 1', '-in in.lj.gpu']
+    variables = {'CRAY_CUDA_MPS': '1'}
+    num_gpus_per_node = 1
+    references_by_variant = {
+        'maint': {
+            'small': {
+                'dom:gpu': {'perf': (3457, -0.10, None, 'timesteps/s')},
+                'daint:gpu': {'perf': (2524, -0.10, None, 'timesteps/s')}
+            },
+            'large': {
+                'daint:gpu': {'perf': (3832, -0.05, None, 'timesteps/s')}
+            }
+        },
+        'prod': {
+            'small': {
+                'dom:gpu': {'perf': (3132, -0.05, None, 'timesteps/s')},
+                'daint:gpu': {'perf': (2400, -0.40, None, 'timesteps/s')}
+            },
+            'large': {
+                'daint:gpu': {'perf': (3260, -0.50, None, 'timesteps/s')}
+            }
+        },
+    }
+
+    @run_after('init')
+    def setup_by_variant(self):
         self.descr = (f'LAMMPS GPU check (version: {self.scale}, '
                       f'{self.variant})')
-        self.valid_systems = ['daint:gpu']
-        self.executable = 'lmp_mpi'
-        self.executable_opts = ['-sf gpu', '-pk gpu 1', '-in in.lj.gpu']
-        self.variables = {'CRAY_CUDA_MPS': '1'}
-        self.num_gpus_per_node = 1
         if self.scale == 'small':
             self.valid_systems += ['dom:gpu']
             self.num_tasks = 12
@@ -66,27 +90,7 @@ class LAMMPSGPUCheck(LAMMPSCheck):
             self.num_tasks = 32
             self.num_tasks_per_node = 2
 
-        references = {
-            'maint': {
-                'small': {
-                    'dom:gpu': {'perf': (3457, -0.10, None, 'timesteps/s')},
-                    'daint:gpu': {'perf': (2524, -0.10, None, 'timesteps/s')}
-                },
-                'large': {
-                    'daint:gpu': {'perf': (3832, -0.05, None, 'timesteps/s')}
-                }
-            },
-            'prod': {
-                'small': {
-                    'dom:gpu': {'perf': (3132, -0.05, None, 'timesteps/s')},
-                    'daint:gpu': {'perf': (2400, -0.40, None, 'timesteps/s')}
-                },
-                'large': {
-                    'daint:gpu': {'perf': (3260, -0.50, None, 'timesteps/s')}
-                }
-            },
-        }
-        self.reference = references[self.variant][self.scale]
+        self.reference = self.references_by_variant[self.variant][self.scale]
         self.tags |= {
             'maintenance' if self.variant == 'maint' else 'production'
         }
@@ -94,11 +98,40 @@ class LAMMPSGPUCheck(LAMMPSCheck):
 
 @rfm.simple_test
 class LAMMPSCPUCheck(LAMMPSCheck):
-    def __init__(self):
-        super().__init__()
+    valid_systems = ['daint:mc', 'eiger:mc', 'pilatus:mc']
+    references_by_variant = {
+        'maint': {
+            'small': {
+                'dom:mc': {'perf': (4394, -0.05, None, 'timesteps/s')},
+                'daint:mc': {'perf': (3824, -0.10, None, 'timesteps/s')},
+                'eiger:mc': {'perf': (4500, -0.10, None, 'timesteps/s')},
+                'pilatus:mc': {'perf': (5000, -0.10, None, 'timesteps/s')}
+            },
+            'large': {
+                'daint:mc': {'perf': (5310, -0.65, None, 'timesteps/s')},
+                'eiger:mc': {'perf': (6500, -0.10, None, 'timesteps/s')},
+                'pilatus:mc': {'perf': (7500, -0.10, None, 'timesteps/s')}
+            }
+        },
+        'prod': {
+            'small': {
+                'dom:mc': {'perf': (4394, -0.05, None, 'timesteps/s')},
+                'daint:mc': {'perf': (3824, -0.10, None, 'timesteps/s')},
+                'eiger:mc': {'perf': (4500, -0.10, None, 'timesteps/s')},
+                'pilatus:mc': {'perf': (5000, -0.10, None, 'timesteps/s')}
+            },
+            'large': {
+                'daint:mc': {'perf': (5310, -0.65, None, 'timesteps/s')},
+                'eiger:mc': {'perf': (6500, -0.10, None, 'timesteps/s')},
+                'pilatus:mc': {'perf': (7500, -0.10, None, 'timesteps/s')}
+            }
+        }
+    }
+
+    @run_after('init')
+    def setup_by_variant(self):
         self.descr = (f'LAMMPS CPU check (version: {self.scale}, '
                       f'{self.variant})')
-        self.valid_systems = ['daint:mc', 'eiger:mc', 'pilatus:mc']
         if self.current_system.name in ['eiger', 'pilatus']:
             self.executable = 'lmp_mpi'
             self.executable_opts = ['-in in.lj.cpu']
@@ -118,35 +151,7 @@ class LAMMPSCPUCheck(LAMMPSCheck):
             self.num_tasks_per_node = 128
             self.num_tasks = 256 if self.scale == 'small' else 512
 
-        references = {
-            'maint': {
-                'small': {
-                    'dom:mc': {'perf': (4394, -0.05, None, 'timesteps/s')},
-                    'daint:mc': {'perf': (3824, -0.10, None, 'timesteps/s')},
-                    'eiger:mc': {'perf': (4500, -0.10, None, 'timesteps/s')},
-                    'pilatus:mc': {'perf': (5000, -0.10, None, 'timesteps/s')}
-                },
-                'large': {
-                    'daint:mc': {'perf': (5310, -0.65, None, 'timesteps/s')},
-                    'eiger:mc': {'perf': (6500, -0.10, None, 'timesteps/s')},
-                    'pilatus:mc': {'perf': (7500, -0.10, None, 'timesteps/s')}
-                }
-            },
-            'prod': {
-                'small': {
-                    'dom:mc': {'perf': (4394, -0.05, None, 'timesteps/s')},
-                    'daint:mc': {'perf': (3824, -0.10, None, 'timesteps/s')},
-                    'eiger:mc': {'perf': (4500, -0.10, None, 'timesteps/s')},
-                    'pilatus:mc': {'perf': (5000, -0.10, None, 'timesteps/s')}
-                },
-                'large': {
-                    'daint:mc': {'perf': (5310, -0.65, None, 'timesteps/s')},
-                    'eiger:mc': {'perf': (6500, -0.10, None, 'timesteps/s')},
-                    'pilatus:mc': {'perf': (7500, -0.10, None, 'timesteps/s')}
-                }
-            }
-        }
-        self.reference = references[self.variant][self.scale]
+        self.reference = self.references_by_variant[self.variant][self.scale]
         self.tags |= {
             'maintenance' if self.variant == 'maint' else 'production'
         }


### PR DESCRIPTION
I provide an updated version of the LAMMPS check, addressing the warnings and adding `cray-python` in the modules loaded: without that dependency, I get a failure with ReFrame on Dom (see [PROGENV-20](https://jira.cscs.ch/browse/PROGENV-20)), while manually loading the module works instead.