### PR TITLE
[test] Remove production tag from HPX checks

### DIFF
--- a/cscs-checks/libraries/hpx/hpx_hello_world.py
+++ b/cscs-checks/libraries/hpx/hpx_hello_world.py
@@ -20,7 +20,6 @@ class HelloWorldHPXCheck(rfm.RunOnlyRegressionTest):
 
         self.use_multithreading = None
 
-        self.tags = {'production'}
         self.maintainers = ['VH', 'JG']
 
     @run_after('setup')

--- a/cscs-checks/libraries/hpx/hpx_stencil.py
+++ b/cscs-checks/libraries/hpx/hpx_stencil.py
@@ -47,7 +47,6 @@ class Stencil4HPXCheck(rfm.RunOnlyRegressionTest):
             },
         }
 
-        self.tags = {'production'}
         self.maintainers = ['VH', 'JG']
 
     @run_after('setup')

--- a/cscs-checks/libraries/hpx/hpx_stencil.py
+++ b/cscs-checks/libraries/hpx/hpx_stencil.py
@@ -133,7 +133,6 @@ class Stencil8HPXCheck(rfm.RunOnlyRegressionTest):
             },
         }
 
-        self.tags = {'production'}
         self.maintainers = ['VH', 'JG']
 
     @run_after('setup')


### PR DESCRIPTION
HPX is [no longer supported in production as of Cray PE 21.09](https://github.com/eth-cscs/production/blob/master/jenkins-builds/7.0.UP03-21.09-dom-gpu), therefore [the corresponding checks fail on Dom](https://jenkins.cscs.ch/blue/organizations/jenkins/reframe-dom-production-daily/detail/reframe-dom-production-daily/1447/pipeline).