### PR TITLE
[test] Update CSCS ipcmagic test (JupyterLab)

### DIFF
--- a/cscs-checks/apps/jupyter/check_ipcmagic.py
+++ b/cscs-checks/apps/jupyter/check_ipcmagic.py
@@ -12,13 +12,12 @@ from hpctestlib.interactive.jupyter.ipcmagic import ipcmagic_check
 class cscs_ipcmagic_check(ipcmagic_check):
     valid_systems = ['daint:gpu', 'dom:gpu']
     valid_prog_environs = ['builtin']
+    modules = ['Horovod', 'jupyterlab']
 
     @run_after('init')
-    def set_modules(self):
+    def modules_workaround(self):
         if self.current_system.name == 'dom':
             self.modules = ['Horovod', 'JuliaExtensions', 'jupyterlab']
-        else:
-            self.modules = ['Horovod', 'jupyterlab']
 
     maintainers = ['RS', 'TR']
     tags = {'production'}

--- a/cscs-checks/apps/jupyter/check_ipcmagic.py
+++ b/cscs-checks/apps/jupyter/check_ipcmagic.py
@@ -12,7 +12,14 @@ from hpctestlib.interactive.jupyter.ipcmagic import ipcmagic_check
 class cscs_ipcmagic_check(ipcmagic_check):
     valid_systems = ['daint:gpu', 'dom:gpu']
     valid_prog_environs = ['builtin']
-    modules = ['JuliaExtensions', 'jupyterlab', 'Horovod']
+
+    @run_after('init')
+    def set_modules(self):
+        if self.current_system.name == 'dom':
+            self.modules = ['Horovod', 'JuliaExtensions', 'jupyterlab']
+        else:
+            self.modules = ['Horovod', 'jupyterlab']
+
     maintainers = ['RS', 'TR']
     tags = {'production'}
     reference = {

--- a/cscs-checks/apps/jupyter/check_ipcmagic.py
+++ b/cscs-checks/apps/jupyter/check_ipcmagic.py
@@ -12,7 +12,7 @@ from hpctestlib.interactive.jupyter.ipcmagic import ipcmagic_check
 class cscs_ipcmagic_check(ipcmagic_check):
     valid_systems = ['daint:gpu', 'dom:gpu']
     valid_prog_environs = ['builtin']
-    modules = ['jupyterlab', 'Horovod']
+    modules = ['JuliaExtensions', 'jupyterlab', 'Horovod']
     maintainers = ['RS', 'TR']
     tags = {'production'}
     reference = {


### PR DESCRIPTION
I had to add the module `JuliaExtensions` (or `Julia`) explicitly, although it is a dependency of `jupyterlab`, otherwise I was getting the error message `Tcl command execution failed` when running the command `reframe -n cscs_ipcmagic_check -t prod -r` on Dom (module `jupyterlab` built in my sandbox for the time being).