### PR TITLE
[feat] Add convenience function to check if a test variables is defined

### DIFF
--- a/docs/regression_test_api.rst
+++ b/docs/regression_test_api.rst
@@ -670,6 +670,19 @@ Therefore, classes that derive from the base :class:`~reframe.core.pipeline.Regr
 .. automethod:: reframe.core.pipeline.RegressionMixin.variant_name
 
 
+---------------------
+Class-level utilities
+---------------------
+
+.. versionadded:: 3.10.1
+
+
+The :class:`~reframe.core.pipeline.RegressionMixin` and the provides various utilities methods that give access the metadata related to the test class.
+This is usually useful when you need to inspect test class properties, such as the parameter or variable space of the test.
+
+.. automethod:: reframe.core.pipeline.RegressionMixin.is_abstract
+
+.. automethod:: reframe.core.pipeline.RegressionMixin.is_var_defined
 
 ------------------------
 Environments and Systems

--- a/reframe/core/meta.py
+++ b/reframe/core/meta.py
@@ -829,16 +829,31 @@ class RegressionTestMeta(type):
         '''Expose the fixture space.'''
         return cls._rfm_fixture_space
 
+    def is_var_defined(cls, name):
+        '''Check if variable ``name`` is defined.
+
+        A variable is undefined if it is declared and required and no value is
+        yet assigned to it.
+
+        :param name: The name of the variable to check if it is defined.
+        :returns: :obj:`True` if the variable is defined, :obj:`False` otherwise.
+
+        .. versionadded:: 3.10.1
+        '''
+        try:
+            return cls.var_space[name].is_defined()
+        except KeyError:
+            raise ValueError(f'no such variable: {name!r}')
+
     def is_abstract(cls):
         '''Check if the class is an abstract test.
 
-        This is the case when some parameters are undefined, which results in
-        the length of the parameter space being 0.
+        A test is considered abstract if any of its direct or indirect
+        parameters (inherited from a base class or from a fixture) is
+        undefined.
 
-        :return: bool indicating whether the test or any of its fixtures has
-          undefined parameters.
+        :returns: :obj:`True` if the test is abstract, :obj:`False` otherwise.
 
-        :meta private:
         '''
         return cls.num_variants == 0
 
@@ -907,6 +922,8 @@ def make_test(name, bases, body, **kwargs):
         attributes in the newly created class.
     :param kwargs: Any keyword arguments to be passed to the
         :class:`RegressionTestMeta` metaclass.
+
+    .. versionadded:: 3.10.0
 
     '''
     namespace = RegressionTestMeta.__prepare__(name, bases, **kwargs)

--- a/unittests/test_variables.py
+++ b/unittests/test_variables.py
@@ -39,6 +39,9 @@ def test_custom_variable(OneVarTest):
     assert OneVarTest.foo == 10
     assert hasattr(inst, 'foo')
     assert inst.foo == 10
+    assert OneVarTest.is_var_defined('foo')
+    with pytest.raises(ValueError):
+        assert OneVarTest.is_var_defined('bar')
 
 
 def test_redeclare_builtin_var_clash(NoVarsTest):


### PR DESCRIPTION
This PR adds a convenience function to check if a variable is defined. This is particularly useful in library tests, when you would like to set a default in a pipeline hook and you should only do that if the user has not defined another value with the `-S` option.