### PR TITLE
[bugfix] Do not set up Spack shell support

### DIFF
--- a/docs/tutorial_build_automation.rst
+++ b/docs/tutorial_build_automation.rst
@@ -120,12 +120,10 @@ Here is what ReFrame generates as a build script for this example:
 
 .. code:: bash
 
-   . "$(spack location --spack-root)/share/spack/setup-env.sh"
    spack env create -d rfm_spack_env
-   spack env activate -V -d rfm_spack_env
-   spack config add "config:install_tree:root:opt/spack"
-   spack add bzip2@1.0.6
-   spack install
+   spack -e rfm_spack_env config add "config:install_tree:root:opt/spack"
+   spack -e rfm_spack_env add bzip2@1.0.6
+   spack -e rfm_spack_env install
 
 As you might have noticed ReFrame expects that Spack is already installed on the system.
 The packages specified in the environment and the tests will be installed in the test's stage directory, where the environment is copied before building.
@@ -155,10 +153,8 @@ Finally, here is the generated run script that ReFrame uses to run the test, onc
 .. code-block:: bash
 
    #!/bin/bash
-   . "$(spack location --spack-root)/share/spack/setup-env.sh"
    spack env create -d rfm_spack_env
-   spack env activate -V -d rfm_spack_env
-   spack load bzip2@1.0.6
+   eval `spack -e rfm_spack_env load --sh bzip2@1.0.6`
    bzip2 --help
 
 From this point on, sanity and performance checking are exactly identical to any other ReFrame test.

--- a/reframe/core/buildsystems.py
+++ b/reframe/core/buildsystems.py
@@ -879,8 +879,10 @@ class Spack(BuildSystem):
     def prepare_cmds(self):
         cmds = self._create_env_cmds()
         if self.specs and self.emit_load_cmds:
-            cmds.append(f'eval `spack -e {self.environment} load --sh ' +
-                        ' '.join(s for s in self.specs) + '`')
+            cmds.append(
+                f'eval `spack -e {self.environment} load '
+                f'--sh {" ".join(self.specs)}`'
+            )
 
         return cmds
 

--- a/reframe/core/buildsystems.py
+++ b/reframe/core/buildsystems.py
@@ -850,38 +850,37 @@ class Spack(BuildSystem):
         self._auto_env = False
 
     def emit_build_commands(self, environ):
-        ret = self._env_activate_cmds()
+        ret = self._create_env_cmds()
 
         if self._auto_env:
             install_tree = self.install_tree or 'opt/spack'
-            ret.append(f'spack config add '
+            ret.append(f'spack -e {self.environment} config add '
                        f'"config:install_tree:root:{install_tree}"')
 
         if self.specs:
             specs_str = ' '.join(self.specs)
-            ret.append(f'spack add {specs_str}')
+            ret.append(f'spack -e {self.environment} add {specs_str}')
 
-        install_cmd = 'spack install'
+        install_cmd = f'spack -e {self.environment} install'
         if self.install_opts:
             install_cmd += ' ' + ' '.join(self.install_opts)
 
         ret.append(install_cmd)
         return ret
 
-    def _env_activate_cmds(self):
-        cmds = ['. "$(spack location --spack-root)/share/spack/setup-env.sh"']
-        if not self.environment:
-            self.environment = 'rfm_spack_env'
-            cmds.append(f'spack env create -d {self.environment}')
-            self._auto_env = True
+    def _create_env_cmds(self):
+        if self.environment:
+            return []
 
-        cmds.append(f'spack env activate -V -d {self.environment}')
-        return cmds
+        self.environment = 'rfm_spack_env'
+        self._auto_env = True
+        return [f'spack env create -d {self.environment}']
 
     def prepare_cmds(self):
-        cmds = self._env_activate_cmds()
+        cmds = self._create_env_cmds()
         if self.specs and self.emit_load_cmds:
-            cmds.append('spack load ' + ' '.join(s for s in self.specs))
+            cmds.append(f'eval `spack -e {self.environment} load --sh ' +
+                        ' '.join(s for s in self.specs) + '`')
 
         return cmds
 

--- a/unittests/test_buildsystems.py
+++ b/unittests/test_buildsystems.py
@@ -249,13 +249,9 @@ def test_spack(environ, tmp_path):
     build_system.install_opts = ['-j 10']
     with osext.change_dir(tmp_path):
         assert build_system.emit_build_commands(environ) == [
-            f'. "$(spack location --spack-root)/share/spack/setup-env.sh"',
-            f'spack env activate -V -d {build_system.environment}',
-            f'spack install -j 10'
+            f'spack -e {build_system.environment} install -j 10'
         ]
         assert build_system.prepare_cmds() == [
-            f'. "$(spack location --spack-root)/share/spack/setup-env.sh"',
-            f'spack env activate -V -d {build_system.environment}',
         ]
 
 
@@ -266,15 +262,11 @@ def test_spack_with_spec(environ, tmp_path):
     specs_str = ' '.join(build_system.specs)
     with osext.change_dir(tmp_path):
         assert build_system.emit_build_commands(environ) == [
-            f'. "$(spack location --spack-root)/share/spack/setup-env.sh"',
-            f'spack env activate -V -d {build_system.environment}',
-            f'spack add {specs_str}',
-            f'spack install'
+            f'spack -e {build_system.environment} add {specs_str}',
+            f'spack -e {build_system.environment} install'
         ]
         assert build_system.prepare_cmds() == [
-            f'. "$(spack location --spack-root)/share/spack/setup-env.sh"',
-            f'spack env activate -V -d {build_system.environment}',
-            f'spack load {specs_str}',
+            f'eval `spack -e {build_system.environment} load --sh {specs_str}`'
         ]
 
 
@@ -282,11 +274,10 @@ def test_spack_no_env(environ, tmp_path):
     build_system = bs.Spack()
     with osext.change_dir(tmp_path):
         assert build_system.emit_build_commands(environ) == [
-            f'. "$(spack location --spack-root)/share/spack/setup-env.sh"',
             f'spack env create -d rfm_spack_env',
-            f'spack env activate -V -d rfm_spack_env',
-            f'spack config add "config:install_tree:root:opt/spack"',
-            f'spack install'
+            f'spack -e rfm_spack_env config add '
+            '"config:install_tree:root:opt/spack"',
+            f'spack -e rfm_spack_env install'
         ]
 
     assert build_system.environment == 'rfm_spack_env'


### PR DESCRIPTION
I have two-fold motivations for this:

1. I'm trying to use reframe with spack build system on a system where activating shell support seems to screw something up
2. not enabling shell support lets us skip the line https://github.com/eth-cscs/reframe/blob/f996fabf25a35f3bb2a5b7090dd0ea4bf327bace/reframe/core/buildsystems.py#L872 which is very useful when using https://github.com/eth-cscs/spack-batteries-included/ with the single squashfs file (there is no material `$(spack location --spack-root)/share/spack/setup-env.sh` file on disk, so this line would fail).  Also, that line caused problems in the past (see #2097, now solved), and not activating the shell support just makes things more transparent.

As an added bonus, this PR has a negative net diff :slightly_smiling_face: 