### PR TITLE
[feat] Remove runtime timings from the default output

### DIFF
--- a/docs/listings/alltests_daint.txt
+++ b/docs/listings/alltests_daint.txt
@@ -9,7 +9,7 @@
   output directory:  '/home/user/Devel/reframe/output'
 
 [==========] Running 4 check(s)
-[==========] Started on Sat Jan 22 22:43:38 2022 
+[==========] Started on Sat Jan 22 22:43:38 2022
 
 [----------] start processing checks
 [ RUN      ] HelloMultiLangTest %lang=cpp @daint:login+builtin
@@ -54,52 +54,52 @@
 [ RUN      ] StreamWithRefTest @daint:login+gnu
 [ RUN      ] StreamWithRefTest @daint:gpu+gnu
 [ RUN      ] StreamWithRefTest @daint:mc+gnu
-[       OK ] ( 1/42) HelloMultiLangTest %lang=cpp @daint:login+builtin [compile: 4.053s run: 36.016s total: 43.208s]
-[       OK ] ( 2/42) HelloMultiLangTest %lang=cpp @daint:login+gnu [compile: 4.047s run: 36.009s total: 43.203s]
-[       OK ] ( 3/42) HelloMultiLangTest %lang=cpp @daint:login+intel [compile: 3.431s run: 35.376s total: 43.206s]
-[       OK ] ( 4/42) HelloMultiLangTest %lang=cpp @daint:login+pgi [compile: 2.758s run: 34.675s total: 43.208s]
-[       OK ] ( 5/42) HelloMultiLangTest %lang=cpp @daint:login+cray [compile: 2.149s run: 34.052s total: 43.211s]
-[       OK ] ( 6/42) HelloMultiLangTest %lang=cpp @daint:gpu+gnu [compile: 2.139s run: 60.830s total: 69.995s]
-[       OK ] ( 7/42) HelloMultiLangTest %lang=cpp @daint:gpu+intel [compile: 8.863s run: 55.184s total: 70.004s]
-[       OK ] ( 8/42) HelloMultiLangTest %lang=c @daint:login+builtin [compile: 32.460s run: 18.053s total: 69.949s]
-[       OK ] ( 9/42) HelloMultiLangTest %lang=c @daint:login+gnu [compile: 27.081s run: 18.051s total: 69.954s]
-[       OK ] (10/42) HelloMultiLangTest %lang=c @daint:login+intel [compile: 39.615s run: 32.065s total: 87.922s]
-[       OK ] (11/42) HelloMultiLangTest %lang=c @daint:login+pgi [compile: 38.873s run: 31.356s total: 87.926s]
-[       OK ] (12/42) HelloMultiLangTest %lang=c @daint:login+cray [compile: 38.265s run: 30.731s total: 87.931s]
-[       OK ] (13/42) HelloThreadedExtended2Test @daint:login+builtin [compile: 12.837s run: 7.254s total: 92.404s]
-[       OK ] (14/42) HelloThreadedExtended2Test @daint:login+gnu [compile: 31.377s run: 31.894s total: 119.747s]
-[       OK ] (15/42) HelloThreadedExtended2Test @daint:login+intel [compile: 30.708s run: 31.252s total: 119.749s]
-[       OK ] (16/42) HelloThreadedExtended2Test @daint:login+pgi [compile: 18.581s run: 30.571s total: 119.753s]
-[       OK ] (17/42) HelloThreadedExtended2Test @daint:login+cray [compile: 17.981s run: 29.963s total: 119.756s]
-[       OK ] (18/42) HelloMultiLangTest %lang=cpp @daint:mc+intel [compile: 33.792s run: 87.427s total: 130.572s]
-[       OK ] (19/42) HelloMultiLangTest %lang=cpp @daint:mc+pgi [compile: 33.120s run: 84.192s total: 130.591s]
-[       OK ] (20/42) HelloMultiLangTest %lang=cpp @daint:mc+cray [compile: 32.474s run: 81.119s total: 130.609s]
-[       OK ] (21/42) HelloMultiLangTest %lang=c @daint:mc+pgi [compile: 13.468s run: 51.389s total: 130.540s]
-[       OK ] (22/42) HelloMultiLangTest %lang=c @daint:mc+cray [compile: 12.847s run: 48.146s total: 130.559s]
-[       OK ] (23/42) HelloMultiLangTest %lang=cpp @daint:gpu+pgi [compile: 8.167s run: 120.870s total: 138.874s]
-[       OK ] (24/42) HelloMultiLangTest %lang=cpp @daint:gpu+cray [compile: 7.412s run: 109.470s total: 138.883s]
-[       OK ] (25/42) HelloMultiLangTest %lang=c @daint:gpu+gnu [compile: 13.293s run: 81.519s total: 138.729s]
-[       OK ] (26/42) HelloMultiLangTest %lang=c @daint:gpu+cray [compile: 11.378s run: 74.651s total: 138.736s]
-[       OK ] (27/42) HelloMultiLangTest %lang=c @daint:mc+gnu [compile: 25.399s run: 65.789s total: 138.749s]
-[       OK ] (28/42) HelloMultiLangTest %lang=c @daint:gpu+intel [compile: 12.677s run: 79.097s total: 139.421s]
-[       OK ] (29/42) HelloMultiLangTest %lang=c @daint:gpu+pgi [compile: 23.579s run: 69.505s total: 139.432s]
-[       OK ] (30/42) HelloThreadedExtended2Test @daint:gpu+gnu [compile: 22.616s run: 46.878s total: 139.268s]
-[       OK ] (31/42) HelloThreadedExtended2Test @daint:gpu+pgi [compile: 21.265s run: 40.181s total: 139.267s]
-[       OK ] (32/42) HelloThreadedExtended2Test @daint:gpu+cray [compile: 20.642s run: 37.158s total: 139.275s]
-[       OK ] (33/42) HelloThreadedExtended2Test @daint:mc+gnu [compile: 4.691s run: 30.273s total: 139.280s]
-[       OK ] (34/42) HelloThreadedExtended2Test @daint:mc+intel [compile: 28.304s run: 19.597s total: 139.281s]
-[       OK ] (35/42) StreamWithRefTest @daint:login+gnu [compile: 24.257s run: 10.594s total: 139.286s]
-[       OK ] (36/42) HelloMultiLangTest %lang=c @daint:mc+intel [compile: 14.135s run: 70.976s total: 146.961s]
-[       OK ] (37/42) HelloMultiLangTest %lang=cpp @daint:mc+gnu [compile: 7.397s run: 194.065s total: 229.737s]
-[       OK ] (38/42) HelloThreadedExtended2Test @daint:gpu+intel [compile: 21.956s run: 133.885s total: 229.342s]
-[       OK ] (39/42) HelloThreadedExtended2Test @daint:mc+pgi [compile: 27.596s run: 106.403s total: 229.264s]
-[       OK ] (40/42) HelloThreadedExtended2Test @daint:mc+cray [compile: 26.958s run: 103.318s total: 229.274s]
-[       OK ] (41/42) StreamWithRefTest @daint:gpu+gnu [compile: 38.940s run: 98.873s total: 229.279s]
-[       OK ] (42/42) StreamWithRefTest @daint:mc+gnu [compile: 38.304s run: 94.811s total: 229.299s]
+[       OK ] ( 1/42) HelloMultiLangTest %lang=cpp @daint:login+builtin
+[       OK ] ( 2/42) HelloMultiLangTest %lang=cpp @daint:login+gnu
+[       OK ] ( 3/42) HelloMultiLangTest %lang=cpp @daint:login+intel
+[       OK ] ( 4/42) HelloMultiLangTest %lang=cpp @daint:login+pgi
+[       OK ] ( 5/42) HelloMultiLangTest %lang=cpp @daint:login+cray
+[       OK ] ( 6/42) HelloMultiLangTest %lang=cpp @daint:gpu+gnu
+[       OK ] ( 7/42) HelloMultiLangTest %lang=cpp @daint:gpu+intel
+[       OK ] ( 8/42) HelloMultiLangTest %lang=c @daint:login+builtin
+[       OK ] ( 9/42) HelloMultiLangTest %lang=c @daint:login+gnu
+[       OK ] (10/42) HelloMultiLangTest %lang=c @daint:login+intel
+[       OK ] (11/42) HelloMultiLangTest %lang=c @daint:login+pgi
+[       OK ] (12/42) HelloMultiLangTest %lang=c @daint:login+cray
+[       OK ] (13/42) HelloThreadedExtended2Test @daint:login+builtin
+[       OK ] (14/42) HelloThreadedExtended2Test @daint:login+gnu
+[       OK ] (15/42) HelloThreadedExtended2Test @daint:login+intel
+[       OK ] (16/42) HelloThreadedExtended2Test @daint:login+pgi
+[       OK ] (17/42) HelloThreadedExtended2Test @daint:login+cray
+[       OK ] (18/42) HelloMultiLangTest %lang=cpp @daint:mc+intel
+[       OK ] (19/42) HelloMultiLangTest %lang=cpp @daint:mc+pgi
+[       OK ] (20/42) HelloMultiLangTest %lang=cpp @daint:mc+cray
+[       OK ] (21/42) HelloMultiLangTest %lang=c @daint:mc+pgi
+[       OK ] (22/42) HelloMultiLangTest %lang=c @daint:mc+cray
+[       OK ] (23/42) HelloMultiLangTest %lang=cpp @daint:gpu+pgi
+[       OK ] (24/42) HelloMultiLangTest %lang=cpp @daint:gpu+cray
+[       OK ] (25/42) HelloMultiLangTest %lang=c @daint:gpu+gnu
+[       OK ] (26/42) HelloMultiLangTest %lang=c @daint:gpu+cray
+[       OK ] (27/42) HelloMultiLangTest %lang=c @daint:mc+gnu
+[       OK ] (28/42) HelloMultiLangTest %lang=c @daint:gpu+intel
+[       OK ] (29/42) HelloMultiLangTest %lang=c @daint:gpu+pgi
+[       OK ] (30/42) HelloThreadedExtended2Test @daint:gpu+gnu
+[       OK ] (31/42) HelloThreadedExtended2Test @daint:gpu+pgi
+[       OK ] (32/42) HelloThreadedExtended2Test @daint:gpu+cray
+[       OK ] (33/42) HelloThreadedExtended2Test @daint:mc+gnu
+[       OK ] (34/42) HelloThreadedExtended2Test @daint:mc+intel
+[       OK ] (35/42) StreamWithRefTest @daint:login+gnu
+[       OK ] (36/42) HelloMultiLangTest %lang=c @daint:mc+intel
+[       OK ] (37/42) HelloMultiLangTest %lang=cpp @daint:mc+gnu
+[       OK ] (38/42) HelloThreadedExtended2Test @daint:gpu+intel
+[       OK ] (39/42) HelloThreadedExtended2Test @daint:mc+pgi
+[       OK ] (40/42) HelloThreadedExtended2Test @daint:mc+cray
+[       OK ] (41/42) StreamWithRefTest @daint:gpu+gnu
+[       OK ] (42/42) StreamWithRefTest @daint:mc+gnu
 [----------] all spawned checks have finished
 
 [  PASSED  ] Ran 42/42 test case(s) from 4 check(s) (0 failure(s), 0 skipped)
-[==========] Finished on Sat Jan 22 22:47:28 2022 
+[==========] Finished on Sat Jan 22 22:47:28 2022
 ==============================================================================
 PERFORMANCE REPORT
 ------------------------------------------------------------------------------

--- a/docs/listings/deps_complex_run.txt
+++ b/docs/listings/deps_complex_run.txt
@@ -9,46 +9,46 @@
   output directory:  '/home/user/Repositories/reframe/output'
 
 [==========] Running 10 check(s)
-[==========] Started on Sat Jan 22 23:44:18 2022 
+[==========] Started on Sat Jan 22 23:44:18 2022
 
 [----------] start processing checks
 [ RUN      ] T0 @generic:default+builtin
-[       OK ] ( 1/10) T0 @generic:default+builtin [compile: 0.018s run: 0.292s total: 0.336s]
+[       OK ] ( 1/10) T0 @generic:default+builtin
 [ RUN      ] T4 @generic:default+builtin
-[       OK ] ( 2/10) T4 @generic:default+builtin [compile: 0.016s run: 0.336s total: 0.380s]
+[       OK ] ( 2/10) T4 @generic:default+builtin
 [ RUN      ] T5 @generic:default+builtin
-[       OK ] ( 3/10) T5 @generic:default+builtin [compile: 0.016s run: 0.389s total: 0.446s]
+[       OK ] ( 3/10) T5 @generic:default+builtin
 [ RUN      ] T1 @generic:default+builtin
-[       OK ] ( 4/10) T1 @generic:default+builtin [compile: 0.016s run: 0.459s total: 0.501s]
+[       OK ] ( 4/10) T1 @generic:default+builtin
 [ RUN      ] T8 @generic:default+builtin
-[     FAIL ] ( 5/10) T8 @generic:default+builtin [compile: n/a run: n/a total: 0.006s]
+[     FAIL ] ( 5/10) T8 @generic:default+builtin
 ==> test failed during 'setup': test staged in '/home/user/Repositories/reframe/stage/generic/default/builtin/T8'
-[     FAIL ] ( 6/10) T9 @generic:default+builtin [compile: n/a run: n/a total: n/a]
+[     FAIL ] ( 6/10) T9 @generic:default+builtin
 ==> test failed during 'startup': test staged in None
 [ RUN      ] T6 @generic:default+builtin
-[       OK ] ( 7/10) T6 @generic:default+builtin [compile: 0.016s run: 0.530s total: 0.584s]
+[       OK ] ( 7/10) T6 @generic:default+builtin
 [ RUN      ] T2 @generic:default+builtin
 [ RUN      ] T3 @generic:default+builtin
-[     FAIL ] ( 8/10) T2 @generic:default+builtin [compile: 0.019s run: 0.324s total: 0.424s]
+[     FAIL ] ( 8/10) T2 @generic:default+builtin
 ==> test failed during 'sanity': test staged in '/home/user/Repositories/reframe/stage/generic/default/builtin/T2'
-[     FAIL ] ( 9/10) T7 @generic:default+builtin [compile: n/a run: n/a total: n/a]
+[     FAIL ] ( 9/10) T7 @generic:default+builtin
 ==> test failed during 'startup': test staged in None
-[       OK ] (10/10) T3 @generic:default+builtin [compile: 0.017s run: 0.328s total: 0.403s]
+[       OK ] (10/10) T3 @generic:default+builtin
 [----------] all spawned checks have finished
 
 [  FAILED  ] Ran 10/10 test case(s) from 10 check(s) (4 failure(s), 0 skipped)
-[==========] Finished on Sat Jan 22 23:44:21 2022 
+[==========] Finished on Sat Jan 22 23:44:21 2022
 
 ==============================================================================
 SUMMARY OF FAILURES
 ------------------------------------------------------------------------------
-FAILURE INFO for T8 
+FAILURE INFO for T8
   * Expanded name: T8
   * Description: T8
   * System partition: generic:default
   * Environment: builtin
   * Stage directory: /home/user/Repositories/reframe/stage/generic/default/builtin/T8
-  * Node list: 
+  * Node list:
   * Job type: local (id=None)
   * Dependencies (conceptual): ['T1']
   * Dependencies (actual): [('T1', 'generic:default', 'builtin')]
@@ -68,13 +68,13 @@ Traceback (most recent call last):
 Exception
 
 ------------------------------------------------------------------------------
-FAILURE INFO for T9 
+FAILURE INFO for T9
   * Expanded name: T9
   * Description: T9
   * System partition: generic:default
   * Environment: builtin
   * Stage directory: None
-  * Node list: 
+  * Node list:
   * Job type: local (id=None)
   * Dependencies (conceptual): ['T8']
   * Dependencies (actual): [('T8', 'generic:default', 'builtin')]
@@ -83,7 +83,7 @@ FAILURE INFO for T9
   * Rerun with '-n T9 -p builtin --system generic:default -r'
   * Reason: task dependency error: dependencies failed
 ------------------------------------------------------------------------------
-FAILURE INFO for T2 
+FAILURE INFO for T2
   * Expanded name: T2
   * Description: T2
   * System partition: generic:default
@@ -98,13 +98,13 @@ FAILURE INFO for T2
   * Rerun with '-n T2 -p builtin --system generic:default -r'
   * Reason: sanity error: 31 != 30
 ------------------------------------------------------------------------------
-FAILURE INFO for T7 
+FAILURE INFO for T7
   * Expanded name: T7
   * Description: T7
   * System partition: generic:default
   * Environment: builtin
   * Stage directory: None
-  * Node list: 
+  * Node list:
   * Job type: local (id=None)
   * Dependencies (conceptual): ['T2']
   * Dependencies (actual): [('T2', 'generic:default', 'builtin')]

--- a/docs/listings/deps_rerun_t6.txt
+++ b/docs/listings/deps_rerun_t6.txt
@@ -9,14 +9,14 @@
   output directory:  '/home/user/Repositories/reframe/output'
 
 [==========] Running 1 check(s)
-[==========] Started on Sat Jan 22 23:44:25 2022 
+[==========] Started on Sat Jan 22 23:44:25 2022
 
 [----------] start processing checks
 [ RUN      ] T6 @generic:default+builtin
-[       OK ] (1/1) T6 @generic:default+builtin [compile: 0.017s run: 0.286s total: 0.330s]
+[       OK ] (1/1) T6 @generic:default+builtin
 [----------] all spawned checks have finished
 
 [  PASSED  ] Ran 1/1 test case(s) from 1 check(s) (0 failure(s), 0 skipped)
-[==========] Finished on Sat Jan 22 23:44:25 2022 
+[==========] Finished on Sat Jan 22 23:44:25 2022
 Run report saved in '/home/user/.reframe/reports/run-report.json'
 Log file(s) saved in '/var/folders/h7/k7cgrdl13r996m4dmsvjq7v80000gp/T/rfm-mug0a4cb.log'

--- a/docs/listings/deps_run_t6.txt
+++ b/docs/listings/deps_run_t6.txt
@@ -9,22 +9,22 @@
   output directory:  '/home/user/Repositories/reframe/output'
 
 [==========] Running 5 check(s)
-[==========] Started on Sat Jan 22 23:44:25 2022 
+[==========] Started on Sat Jan 22 23:44:25 2022
 
 [----------] start processing checks
 [ RUN      ] T0 @generic:default+builtin
-[       OK ] (1/5) T0 @generic:default+builtin [compile: 0.017s run: 0.289s total: 0.331s]
+[       OK ] (1/5) T0 @generic:default+builtin
 [ RUN      ] T4 @generic:default+builtin
-[       OK ] (2/5) T4 @generic:default+builtin [compile: 0.018s run: 0.330s total: 0.374s]
+[       OK ] (2/5) T4 @generic:default+builtin
 [ RUN      ] T5 @generic:default+builtin
-[       OK ] (3/5) T5 @generic:default+builtin [compile: 0.018s run: 0.384s total: 0.442s]
+[       OK ] (3/5) T5 @generic:default+builtin
 [ RUN      ] T1 @generic:default+builtin
-[       OK ] (4/5) T1 @generic:default+builtin [compile: 0.018s run: 0.452s total: 0.494s]
+[       OK ] (4/5) T1 @generic:default+builtin
 [ RUN      ] T6 @generic:default+builtin
-[       OK ] (5/5) T6 @generic:default+builtin [compile: 0.018s run: 0.525s total: 0.582s]
+[       OK ] (5/5) T6 @generic:default+builtin
 [----------] all spawned checks have finished
 
 [  PASSED  ] Ran 5/5 test case(s) from 5 check(s) (0 failure(s), 0 skipped)
-[==========] Finished on Sat Jan 22 23:44:28 2022 
+[==========] Finished on Sat Jan 22 23:44:28 2022
 Run report saved in '/home/user/.reframe/reports/run-report.json'
 Log file(s) saved in '/var/folders/h7/k7cgrdl13r996m4dmsvjq7v80000gp/T/rfm-ktylyaqk.log'

--- a/docs/listings/hello1.txt
+++ b/docs/listings/hello1.txt
@@ -9,14 +9,14 @@
   output directory:  '/path/to/reframe/output'
 
 [==========] Running 1 check(s)
-[==========] Started on Sat Jan 22 13:21:50 2022 
+[==========] Started on Sat Jan 22 13:21:50 2022
 
 [----------] start processing checks
 [ RUN      ] HelloTest @generic:default+builtin
-[       OK ] (1/1) HelloTest @generic:default+builtin [compile: 0.272s run: 0.359s total: 0.784s]
+[       OK ] (1/1) HelloTest @generic:default+builtin
 [----------] all spawned checks have finished
 
 [  PASSED  ] Ran 1/1 test case(s) from 1 check(s) (0 failure(s), 0 skipped)
-[==========] Finished on Sat Jan 22 13:21:51 2022 
+[==========] Finished on Sat Jan 22 13:21:51 2022
 Run report saved in '/home/user/.reframe/reports/run-report.json'
 Log file(s) saved in '/var/folders/h7/k7cgrdl13r996m4dmsvjq7v80000gp/T/rfm-8c6ybdvg.log'

--- a/docs/listings/hello2.txt
+++ b/docs/listings/hello2.txt
@@ -9,29 +9,29 @@
   output directory:  '/path/to/reframe/output'
 
 [==========] Running 2 check(s)
-[==========] Started on Sat Jan 22 13:21:51 2022 
+[==========] Started on Sat Jan 22 13:21:51 2022
 
 [----------] start processing checks
 [ RUN      ] HelloMultiLangTest %lang=cpp @generic:default+builtin
 [ RUN      ] HelloMultiLangTest %lang=c @generic:default+builtin
-[     FAIL ] (1/2) HelloMultiLangTest %lang=cpp @generic:default+builtin [compile: 0.006s run: n/a total: 0.043s]
+[     FAIL ] (1/2) HelloMultiLangTest %lang=cpp @generic:default+builtin
 ==> test failed during 'compile': test staged in '/path/to/reframe/stage/generic/default/builtin/HelloMultiLangTest_cpp'
-[       OK ] (2/2) HelloMultiLangTest %lang=c @generic:default+builtin [compile: 0.268s run: 0.368s total: 0.813s]
+[       OK ] (2/2) HelloMultiLangTest %lang=c @generic:default+builtin
 [----------] all spawned checks have finished
 
 [  FAILED  ] Ran 2/2 test case(s) from 2 check(s) (1 failure(s), 0 skipped)
-[==========] Finished on Sat Jan 22 13:21:52 2022 
+[==========] Finished on Sat Jan 22 13:21:52 2022
 
 ==============================================================================
 SUMMARY OF FAILURES
 ------------------------------------------------------------------------------
-FAILURE INFO for HelloMultiLangTest_cpp 
+FAILURE INFO for HelloMultiLangTest_cpp
   * Expanded name: HelloMultiLangTest %lang=cpp
   * Description: HelloMultiLangTest %lang=cpp
   * System partition: generic:default
   * Environment: builtin
   * Stage directory: /path/to/reframe/stage/generic/default/builtin/HelloMultiLangTest_cpp
-  * Node list: 
+  * Node list:
   * Job type: local (id=None)
   * Dependencies (conceptual): []
   * Dependencies (actual): []

--- a/docs/listings/hello2_catalina.txt
+++ b/docs/listings/hello2_catalina.txt
@@ -9,20 +9,20 @@
   output directory:  '/path/to/reframe/output'
 
 [==========] Running 2 check(s)
-[==========] Started on Sat Jan 22 13:21:53 2022 
+[==========] Started on Sat Jan 22 13:21:53 2022
 
 [----------] start processing checks
 [ RUN      ] HelloMultiLangTest %lang=cpp @catalina:default+gnu
 [ RUN      ] HelloMultiLangTest %lang=cpp @catalina:default+clang
 [ RUN      ] HelloMultiLangTest %lang=c @catalina:default+gnu
 [ RUN      ] HelloMultiLangTest %lang=c @catalina:default+clang
-[       OK ] (1/4) HelloMultiLangTest %lang=c @catalina:default+gnu [compile: 0.360s run: 0.511s total: 1.135s]
-[       OK ] (2/4) HelloMultiLangTest %lang=c @catalina:default+clang [compile: 0.359s run: 0.514s total: 1.139s]
-[       OK ] (3/4) HelloMultiLangTest %lang=cpp @catalina:default+gnu [compile: 0.563s run: 0.549s total: 1.343s]
-[       OK ] (4/4) HelloMultiLangTest %lang=cpp @catalina:default+clang [compile: 0.564s run: 0.551s total: 1.346s]
+[       OK ] (1/4) HelloMultiLangTest %lang=c @catalina:default+gnu
+[       OK ] (2/4) HelloMultiLangTest %lang=c @catalina:default+clang
+[       OK ] (3/4) HelloMultiLangTest %lang=cpp @catalina:default+gnu
+[       OK ] (4/4) HelloMultiLangTest %lang=cpp @catalina:default+clang
 [----------] all spawned checks have finished
 
 [  PASSED  ] Ran 4/4 test case(s) from 2 check(s) (0 failure(s), 0 skipped)
-[==========] Finished on Sat Jan 22 13:21:54 2022 
+[==========] Finished on Sat Jan 22 13:21:54 2022
 Run report saved in '/home/user/.reframe/reports/run-report.json'
 Log file(s) saved in '/var/folders/h7/k7cgrdl13r996m4dmsvjq7v80000gp/T/rfm-iehz9eub.log'

--- a/docs/listings/hello2_print_stdout.txt
+++ b/docs/listings/hello2_print_stdout.txt
@@ -9,7 +9,7 @@
   output directory:  '/home/user/Repositories/reframe/output'
 
 [==========] Running 2 check(s)
-[==========] Started on Sun Jan 23 00:11:07 2022 
+[==========] Started on Sun Jan 23 00:11:07 2022
 
 [----------] start processing checks
 [ RUN      ] HelloMultiLangTest %lang=cpp @catalina:default+gnu
@@ -17,16 +17,16 @@
 [ RUN      ] HelloMultiLangTest %lang=c @catalina:default+gnu
 [ RUN      ] HelloMultiLangTest %lang=c @catalina:default+clang
 rfm_HelloMultiLangTest_cpp_job.out
-[       OK ] (1/4) HelloMultiLangTest %lang=cpp @catalina:default+gnu [compile: 0.737s run: 0.748s total: 1.765s]
+[       OK ] (1/4) HelloMultiLangTest %lang=cpp @catalina:default+gnu
 rfm_HelloMultiLangTest_cpp_job.out
-[       OK ] (2/4) HelloMultiLangTest %lang=cpp @catalina:default+clang [compile: 0.735s run: 0.909s total: 1.928s]
+[       OK ] (2/4) HelloMultiLangTest %lang=cpp @catalina:default+clang
 rfm_HelloMultiLangTest_c_job.out
-[       OK ] (3/4) HelloMultiLangTest %lang=c @catalina:default+gnu [compile: 0.719s run: 1.072s total: 2.090s]
+[       OK ] (3/4) HelloMultiLangTest %lang=c @catalina:default+gnu
 rfm_HelloMultiLangTest_c_job.out
-[       OK ] (4/4) HelloMultiLangTest %lang=c @catalina:default+clang [compile: 0.714s run: 1.074s total: 2.094s]
+[       OK ] (4/4) HelloMultiLangTest %lang=c @catalina:default+clang
 [----------] all spawned checks have finished
 
 [  PASSED  ] Ran 4/4 test case(s) from 2 check(s) (0 failure(s), 0 skipped)
-[==========] Finished on Sun Jan 23 00:11:10 2022 
+[==========] Finished on Sun Jan 23 00:11:10 2022
 Run report saved in '/home/user/.reframe/reports/run-report.json'
 Log file(s) saved in '/var/folders/h7/k7cgrdl13r996m4dmsvjq7v80000gp/T/rfm-jumlrg66.log'

--- a/docs/listings/hellomp1.txt
+++ b/docs/listings/hellomp1.txt
@@ -9,16 +9,16 @@
   output directory:  '/path/to/reframe/output'
 
 [==========] Running 1 check(s)
-[==========] Started on Sat Jan 22 13:21:54 2022 
+[==========] Started on Sat Jan 22 13:21:54 2022
 
 [----------] start processing checks
 [ RUN      ] HelloThreadedTest @catalina:default+gnu
 [ RUN      ] HelloThreadedTest @catalina:default+clang
-[       OK ] (1/2) HelloThreadedTest @catalina:default+gnu [compile: 0.963s run: 0.296s total: 1.418s]
-[       OK ] (2/2) HelloThreadedTest @catalina:default+clang [compile: 0.760s run: 0.434s total: 1.421s]
+[       OK ] (1/2) HelloThreadedTest @catalina:default+gnu
+[       OK ] (2/2) HelloThreadedTest @catalina:default+clang
 [----------] all spawned checks have finished
 
 [  PASSED  ] Ran 2/2 test case(s) from 1 check(s) (0 failure(s), 0 skipped)
-[==========] Finished on Sat Jan 22 13:21:56 2022 
+[==========] Finished on Sat Jan 22 13:21:56 2022
 Run report saved in '/home/user/.reframe/reports/run-report.json'
 Log file(s) saved in '/var/folders/h7/k7cgrdl13r996m4dmsvjq7v80000gp/T/rfm-chq08zds.log'

--- a/docs/listings/hellomp2.txt
+++ b/docs/listings/hellomp2.txt
@@ -9,24 +9,24 @@
   output directory:  '/path/to/reframe/output'
 
 [==========] Running 1 check(s)
-[==========] Started on Sat Jan 22 13:21:56 2022 
+[==========] Started on Sat Jan 22 13:21:56 2022
 
 [----------] start processing checks
 [ RUN      ] HelloThreadedExtendedTest @catalina:default+gnu
 [ RUN      ] HelloThreadedExtendedTest @catalina:default+clang
-[     FAIL ] (1/2) HelloThreadedExtendedTest @catalina:default+clang [compile: 0.761s run: 0.413s total: 1.401s]
+[     FAIL ] (1/2) HelloThreadedExtendedTest @catalina:default+clang
 ==> test failed during 'sanity': test staged in '/path/to/reframe/stage/catalina/default/clang/HelloThreadedExtendedTest'
-[     FAIL ] (2/2) HelloThreadedExtendedTest @catalina:default+gnu [compile: 0.962s run: 0.412s total: 1.538s]
+[     FAIL ] (2/2) HelloThreadedExtendedTest @catalina:default+gnu
 ==> test failed during 'sanity': test staged in '/path/to/reframe/stage/catalina/default/gnu/HelloThreadedExtendedTest'
 [----------] all spawned checks have finished
 
 [  FAILED  ] Ran 2/2 test case(s) from 1 check(s) (2 failure(s), 0 skipped)
-[==========] Finished on Sat Jan 22 13:21:58 2022 
+[==========] Finished on Sat Jan 22 13:21:58 2022
 
 ==============================================================================
 SUMMARY OF FAILURES
 ------------------------------------------------------------------------------
-FAILURE INFO for HelloThreadedExtendedTest 
+FAILURE INFO for HelloThreadedExtendedTest
   * Expanded name: HelloThreadedExtendedTest
   * Description: HelloThreadedExtendedTest
   * System partition: catalina:default
@@ -41,7 +41,7 @@ FAILURE INFO for HelloThreadedExtendedTest
   * Rerun with '-n HelloThreadedExtendedTest -p gnu --system catalina:default -r'
   * Reason: sanity error: 7 != 16
 ------------------------------------------------------------------------------
-FAILURE INFO for HelloThreadedExtendedTest 
+FAILURE INFO for HelloThreadedExtendedTest
   * Expanded name: HelloThreadedExtendedTest
   * Description: HelloThreadedExtendedTest
   * System partition: catalina:default

--- a/docs/listings/osu_bench_deps.txt
+++ b/docs/listings/osu_bench_deps.txt
@@ -9,23 +9,23 @@
   output directory:  '/home/user/Devel/reframe/output'
 
 [==========] Running 8 check(s)
-[==========] Started on Sat Jan 22 22:49:00 2022 
+[==========] Started on Sat Jan 22 22:49:00 2022
 
 [----------] start processing checks
 [ RUN      ] OSUDownloadTest @daint:login+builtin
-[       OK ] ( 1/22) OSUDownloadTest @daint:login+builtin [compile: 0.017s run: 1.547s total: 1.594s]
+[       OK ] ( 1/22) OSUDownloadTest @daint:login+builtin
 [ RUN      ] OSUBuildTest @daint:gpu+gnu
 [ RUN      ] OSUBuildTest @daint:gpu+intel
 [ RUN      ] OSUBuildTest @daint:gpu+pgi
-[       OK ] ( 2/22) OSUBuildTest @daint:gpu+gnu [compile: 28.351s run: 2.614s total: 31.045s]
+[       OK ] ( 2/22) OSUBuildTest @daint:gpu+gnu
 [ RUN      ] OSUAllreduceTest %mpi_tasks=16 @daint:gpu+gnu
 [ RUN      ] OSUAllreduceTest %mpi_tasks=8 @daint:gpu+gnu
 [ RUN      ] OSUAllreduceTest %mpi_tasks=4 @daint:gpu+gnu
 [ RUN      ] OSUAllreduceTest %mpi_tasks=2 @daint:gpu+gnu
 [ RUN      ] OSUBandwidthTest @daint:gpu+gnu
 [ RUN      ] OSULatencyTest @daint:gpu+gnu
-[       OK ] ( 3/22) OSUBuildTest @daint:gpu+intel [compile: 56.259s run: 0.294s total: 57.548s]
-[       OK ] ( 4/22) OSUBuildTest @daint:gpu+pgi [compile: 55.287s run: 0.274s total: 57.549s]
+[       OK ] ( 3/22) OSUBuildTest @daint:gpu+intel
+[       OK ] ( 4/22) OSUBuildTest @daint:gpu+pgi
 [ RUN      ] OSUAllreduceTest %mpi_tasks=16 @daint:gpu+intel
 [ RUN      ] OSUAllreduceTest %mpi_tasks=16 @daint:gpu+pgi
 [ RUN      ] OSUAllreduceTest %mpi_tasks=8 @daint:gpu+intel
@@ -38,27 +38,27 @@
 [ RUN      ] OSUBandwidthTest @daint:gpu+pgi
 [ RUN      ] OSULatencyTest @daint:gpu+intel
 [ RUN      ] OSULatencyTest @daint:gpu+pgi
-[       OK ] ( 5/22) OSUAllreduceTest %mpi_tasks=8 @daint:gpu+gnu [compile: 0.019s run: 62.714s total: 66.672s]
-[       OK ] ( 6/22) OSUAllreduceTest %mpi_tasks=16 @daint:gpu+gnu [compile: 0.021s run: 66.653s total: 67.092s]
-[       OK ] ( 7/22) OSUAllreduceTest %mpi_tasks=4 @daint:gpu+gnu [compile: 0.019s run: 59.875s total: 67.058s]
-[       OK ] ( 8/22) OSULatencyTest @daint:gpu+gnu [compile: 0.022s run: 81.297s total: 102.720s]
-[       OK ] ( 9/22) OSUAllreduceTest %mpi_tasks=2 @daint:gpu+gnu [compile: 0.023s run: 97.213s total: 107.661s]
-[       OK ] (10/22) OSUAllreduceTest %mpi_tasks=16 @daint:gpu+intel [compile: 0.017s run: 80.743s total: 81.586s]
-[       OK ] (11/22) OSUAllreduceTest %mpi_tasks=16 @daint:gpu+pgi [compile: 0.017s run: 141.746s total: 145.957s]
-[       OK ] (12/22) OSUAllreduceTest %mpi_tasks=8 @daint:gpu+intel [compile: 0.016s run: 138.667s total: 145.944s]
-[       OK ] (13/22) OSUAllreduceTest %mpi_tasks=8 @daint:gpu+pgi [compile: 0.017s run: 135.257s total: 145.938s]
-[       OK ] (14/22) OSUBandwidthTest @daint:gpu+gnu [compile: 0.034s run: 156.112s total: 172.474s]
-[       OK ] (15/22) OSUAllreduceTest %mpi_tasks=4 @daint:gpu+intel [compile: 0.017s run: 173.876s total: 187.629s]
-[       OK ] (16/22) OSUAllreduceTest %mpi_tasks=2 @daint:gpu+pgi [compile: 0.016s run: 171.544s total: 194.752s]
-[       OK ] (17/22) OSUAllreduceTest %mpi_tasks=2 @daint:gpu+intel [compile: 0.017s run: 175.095s total: 195.082s]
-[       OK ] (18/22) OSULatencyTest @daint:gpu+pgi [compile: 0.017s run: 159.422s total: 195.672s]
-[       OK ] (19/22) OSULatencyTest @daint:gpu+intel [compile: 0.017s run: 163.070s total: 196.207s]
-[       OK ] (20/22) OSUAllreduceTest %mpi_tasks=4 @daint:gpu+pgi [compile: 0.016s run: 180.370s total: 197.379s]
-[       OK ] (21/22) OSUBandwidthTest @daint:gpu+intel [compile: 0.017s run: 240.385s total: 266.772s]
-[       OK ] (22/22) OSUBandwidthTest @daint:gpu+pgi [compile: 0.018s run: 236.944s total: 266.766s]
+[       OK ] ( 5/22) OSUAllreduceTest %mpi_tasks=8 @daint:gpu+gnu
+[       OK ] ( 6/22) OSUAllreduceTest %mpi_tasks=16 @daint:gpu+gnu
+[       OK ] ( 7/22) OSUAllreduceTest %mpi_tasks=4 @daint:gpu+gnu
+[       OK ] ( 8/22) OSULatencyTest @daint:gpu+gnu
+[       OK ] ( 9/22) OSUAllreduceTest %mpi_tasks=2 @daint:gpu+gnu
+[       OK ] (10/22) OSUAllreduceTest %mpi_tasks=16 @daint:gpu+intel
+[       OK ] (11/22) OSUAllreduceTest %mpi_tasks=16 @daint:gpu+pgi
+[       OK ] (12/22) OSUAllreduceTest %mpi_tasks=8 @daint:gpu+intel
+[       OK ] (13/22) OSUAllreduceTest %mpi_tasks=8 @daint:gpu+pgi
+[       OK ] (14/22) OSUBandwidthTest @daint:gpu+gnu
+[       OK ] (15/22) OSUAllreduceTest %mpi_tasks=4 @daint:gpu+intel
+[       OK ] (16/22) OSUAllreduceTest %mpi_tasks=2 @daint:gpu+pgi
+[       OK ] (17/22) OSUAllreduceTest %mpi_tasks=2 @daint:gpu+intel
+[       OK ] (18/22) OSULatencyTest @daint:gpu+pgi
+[       OK ] (19/22) OSULatencyTest @daint:gpu+intel
+[       OK ] (20/22) OSUAllreduceTest %mpi_tasks=4 @daint:gpu+pgi
+[       OK ] (21/22) OSUBandwidthTest @daint:gpu+intel
+[       OK ] (22/22) OSUBandwidthTest @daint:gpu+pgi
 [----------] all spawned checks have finished
 
 [  PASSED  ] Ran 22/22 test case(s) from 8 check(s) (0 failure(s), 0 skipped)
-[==========] Finished on Sat Jan 22 22:54:26 2022 
+[==========] Finished on Sat Jan 22 22:54:26 2022
 Run report saved in '/home/user/.reframe/reports/run-report.json'
 Log file(s) saved in '/tmp/rfm-15ghvao1.log'

--- a/docs/listings/osu_bench_fixtures_run.txt
+++ b/docs/listings/osu_bench_fixtures_run.txt
@@ -9,23 +9,23 @@
   output directory:  '/home/user/Devel/reframe/output'
 
 [==========] Running 10 check(s)
-[==========] Started on Sat Jan 22 23:08:13 2022 
+[==========] Started on Sat Jan 22 23:08:13 2022
 
 [----------] start processing checks
 [ RUN      ] fetch_osu_benchmarks ~daint @daint:gpu+gnu
-[       OK ] ( 1/22) fetch_osu_benchmarks ~daint @daint:gpu+gnu [compile: 0.016s run: 2.757s total: 2.807s]
+[       OK ] ( 1/22) fetch_osu_benchmarks ~daint @daint:gpu+gnu
 [ RUN      ] build_osu_benchmarks ~daint:gpu+gnu @daint:gpu+gnu
 [ RUN      ] build_osu_benchmarks ~daint:gpu+intel @daint:gpu+intel
 [ RUN      ] build_osu_benchmarks ~daint:gpu+pgi @daint:gpu+pgi
-[       OK ] ( 2/22) build_osu_benchmarks ~daint:gpu+gnu @daint:gpu+gnu [compile: 25.384s run: 2.389s total: 27.839s]
+[       OK ] ( 2/22) build_osu_benchmarks ~daint:gpu+gnu @daint:gpu+gnu
 [ RUN      ] osu_allreduce_test %mpi_tasks=16 @daint:gpu+gnu
 [ RUN      ] osu_allreduce_test %mpi_tasks=8 @daint:gpu+gnu
 [ RUN      ] osu_allreduce_test %mpi_tasks=4 @daint:gpu+gnu
 [ RUN      ] osu_allreduce_test %mpi_tasks=2 @daint:gpu+gnu
 [ RUN      ] osu_bandwidth_test @daint:gpu+gnu
 [ RUN      ] osu_latency_test @daint:gpu+gnu
-[       OK ] ( 3/22) build_osu_benchmarks ~daint:gpu+intel @daint:gpu+intel [compile: 47.774s run: 0.313s total: 48.758s]
-[       OK ] ( 4/22) build_osu_benchmarks ~daint:gpu+pgi @daint:gpu+pgi [compile: 47.127s run: 0.297s total: 48.765s]
+[       OK ] ( 3/22) build_osu_benchmarks ~daint:gpu+intel @daint:gpu+intel
+[       OK ] ( 4/22) build_osu_benchmarks ~daint:gpu+pgi @daint:gpu+pgi
 [ RUN      ] osu_allreduce_test %mpi_tasks=16 @daint:gpu+intel
 [ RUN      ] osu_allreduce_test %mpi_tasks=16 @daint:gpu+pgi
 [ RUN      ] osu_allreduce_test %mpi_tasks=8 @daint:gpu+intel
@@ -38,27 +38,27 @@
 [ RUN      ] osu_bandwidth_test @daint:gpu+pgi
 [ RUN      ] osu_latency_test @daint:gpu+intel
 [ RUN      ] osu_latency_test @daint:gpu+pgi
-[       OK ] ( 5/22) osu_allreduce_test %mpi_tasks=16 @daint:gpu+gnu [compile: 0.022s run: 63.846s total: 64.319s]
-[       OK ] ( 6/22) osu_allreduce_test %mpi_tasks=4 @daint:gpu+gnu [compile: 0.024s run: 56.997s total: 64.302s]
-[       OK ] ( 7/22) osu_allreduce_test %mpi_tasks=2 @daint:gpu+gnu [compile: 0.024s run: 56.187s total: 66.616s]
-[       OK ] ( 8/22) osu_allreduce_test %mpi_tasks=8 @daint:gpu+gnu [compile: 0.026s run: 82.220s total: 86.255s]
-[       OK ] ( 9/22) osu_bandwidth_test @daint:gpu+gnu [compile: 0.023s run: 128.535s total: 142.154s]
-[       OK ] (10/22) osu_allreduce_test %mpi_tasks=4 @daint:gpu+pgi [compile: 0.023s run: 168.876s total: 185.476s]
-[       OK ] (11/22) osu_allreduce_test %mpi_tasks=2 @daint:gpu+intel [compile: 0.020s run: 165.312s total: 185.461s]
-[       OK ] (12/22) osu_allreduce_test %mpi_tasks=4 @daint:gpu+intel [compile: 0.019s run: 172.593s total: 186.044s]
-[       OK ] (13/22) osu_allreduce_test %mpi_tasks=2 @daint:gpu+pgi [compile: 0.019s run: 162.499s total: 185.942s]
-[       OK ] (14/22) osu_latency_test @daint:gpu+intel [compile: 0.020s run: 152.867s total: 185.853s]
-[       OK ] (15/22) osu_latency_test @daint:gpu+pgi [compile: 0.020s run: 149.662s total: 185.853s]
-[       OK ] (16/22) osu_allreduce_test %mpi_tasks=16 @daint:gpu+intel [compile: 0.020s run: 207.009s total: 207.831s]
-[       OK ] (17/22) osu_allreduce_test %mpi_tasks=16 @daint:gpu+pgi [compile: 0.019s run: 203.753s total: 207.829s]
-[       OK ] (18/22) osu_allreduce_test %mpi_tasks=8 @daint:gpu+pgi [compile: 0.019s run: 197.421s total: 207.783s]
-[       OK ] (19/22) osu_latency_test @daint:gpu+gnu [compile: 0.024s run: 218.130s total: 234.892s]
-[       OK ] (20/22) osu_bandwidth_test @daint:gpu+intel [compile: 0.020s run: 218.457s total: 244.995s]
-[       OK ] (21/22) osu_bandwidth_test @daint:gpu+pgi [compile: 0.020s run: 215.273s total: 244.992s]
-[       OK ] (22/22) osu_allreduce_test %mpi_tasks=8 @daint:gpu+intel [compile: 0.020s run: 267.367s total: 274.584s]
+[       OK ] ( 5/22) osu_allreduce_test %mpi_tasks=16 @daint:gpu+gnu
+[       OK ] ( 6/22) osu_allreduce_test %mpi_tasks=4 @daint:gpu+gnu
+[       OK ] ( 7/22) osu_allreduce_test %mpi_tasks=2 @daint:gpu+gnu
+[       OK ] ( 8/22) osu_allreduce_test %mpi_tasks=8 @daint:gpu+gnu
+[       OK ] ( 9/22) osu_bandwidth_test @daint:gpu+gnu
+[       OK ] (10/22) osu_allreduce_test %mpi_tasks=4 @daint:gpu+pgi
+[       OK ] (11/22) osu_allreduce_test %mpi_tasks=2 @daint:gpu+intel
+[       OK ] (12/22) osu_allreduce_test %mpi_tasks=4 @daint:gpu+intel
+[       OK ] (13/22) osu_allreduce_test %mpi_tasks=2 @daint:gpu+pgi
+[       OK ] (14/22) osu_latency_test @daint:gpu+intel
+[       OK ] (15/22) osu_latency_test @daint:gpu+pgi
+[       OK ] (16/22) osu_allreduce_test %mpi_tasks=16 @daint:gpu+intel
+[       OK ] (17/22) osu_allreduce_test %mpi_tasks=16 @daint:gpu+pgi
+[       OK ] (18/22) osu_allreduce_test %mpi_tasks=8 @daint:gpu+pgi
+[       OK ] (19/22) osu_latency_test @daint:gpu+gnu
+[       OK ] (20/22) osu_bandwidth_test @daint:gpu+intel
+[       OK ] (21/22) osu_bandwidth_test @daint:gpu+pgi
+[       OK ] (22/22) osu_allreduce_test %mpi_tasks=8 @daint:gpu+intel
 [----------] all spawned checks have finished
 
 [  PASSED  ] Ran 22/22 test case(s) from 10 check(s) (0 failure(s), 0 skipped)
-[==========] Finished on Sat Jan 22 23:13:40 2022 
+[==========] Finished on Sat Jan 22 23:13:40 2022
 Run report saved in '/home/user/.reframe/reports/run-report.json'
 Log file(s) saved in '/tmp/rfm-6gbw7qzs.log'

--- a/docs/listings/stream1.txt
+++ b/docs/listings/stream1.txt
@@ -9,18 +9,18 @@
   output directory:  '/Users/user/Repositories/reframe/output'
 
 [==========] Running 1 check(s)
-[==========] Started on Wed Jan 19 17:13:35 2022 
+[==========] Started on Wed Jan 19 17:13:35 2022
 
 [----------] started processing StreamTest (StreamTest)
 [ RUN      ] StreamTest on catalina:default using gnu
 [----------] finished processing StreamTest (StreamTest)
 
 [----------] waiting for spawned checks to finish
-[       OK ] (1/1) StreamTest @catalina:default+gnu [compile: 1.260s run: 2.844s total: 4.136s]
+[       OK ] (1/1) StreamTest @catalina:default+gnu
 [----------] all spawned checks have finished
 
 [  PASSED  ] Ran 1/1 test case(s) from 1 check(s) (0 failure(s), 0 skipped)
-[==========] Finished on Wed Jan 19 17:13:39 2022 
+[==========] Finished on Wed Jan 19 17:13:39 2022
 ==============================================================================
 PERFORMANCE REPORT
 ------------------------------------------------------------------------------

--- a/docs/listings/stream4_daint.txt
+++ b/docs/listings/stream4_daint.txt
@@ -9,7 +9,7 @@
   output directory:  '/home/user/Devel/reframe/output'
 
 [==========] Running 1 check(s)
-[==========] Started on Sat Jan 22 22:47:28 2022 
+[==========] Started on Sat Jan 22 22:47:28 2022
 
 [----------] start processing checks
 [ RUN      ] StreamMultiSysTest @daint:login+gnu
@@ -24,22 +24,22 @@
 [ RUN      ] StreamMultiSysTest @daint:mc+intel
 [ RUN      ] StreamMultiSysTest @daint:mc+pgi
 [ RUN      ] StreamMultiSysTest @daint:mc+cray
-[       OK ] ( 1/12) StreamMultiSysTest @daint:login+gnu [compile: 4.024s run: 21.615s total: 28.185s]
-[       OK ] ( 2/12) StreamMultiSysTest @daint:login+intel [compile: 3.410s run: 20.976s total: 28.208s]
-[       OK ] ( 3/12) StreamMultiSysTest @daint:login+pgi [compile: 2.734s run: 20.235s total: 28.226s]
-[       OK ] ( 4/12) StreamMultiSysTest @daint:login+cray [compile: 2.104s run: 19.571s total: 28.242s]
-[       OK ] ( 5/12) StreamMultiSysTest @daint:gpu+gnu [compile: 2.102s run: 30.129s total: 38.813s]
-[       OK ] ( 6/12) StreamMultiSysTest @daint:gpu+pgi [compile: 8.695s run: 22.117s total: 38.826s]
-[       OK ] ( 7/12) StreamMultiSysTest @daint:gpu+cray [compile: 8.083s run: 19.050s total: 38.852s]
-[       OK ] ( 8/12) StreamMultiSysTest @daint:gpu+intel [compile: 9.369s run: 37.641s total: 50.212s]
-[       OK ] ( 9/12) StreamMultiSysTest @daint:mc+gnu [compile: 7.970s run: 28.955s total: 52.297s]
-[       OK ] (10/12) StreamMultiSysTest @daint:mc+cray [compile: 20.508s run: 30.812s total: 65.951s]
-[       OK ] (11/12) StreamMultiSysTest @daint:mc+pgi [compile: 21.186s run: 34.898s total: 66.325s]
-[       OK ] (12/12) StreamMultiSysTest @daint:mc+intel [compile: 21.890s run: 62.451s total: 90.626s]
+[       OK ] ( 1/12) StreamMultiSysTest @daint:login+gnu
+[       OK ] ( 2/12) StreamMultiSysTest @daint:login+intel
+[       OK ] ( 3/12) StreamMultiSysTest @daint:login+pgi
+[       OK ] ( 4/12) StreamMultiSysTest @daint:login+cray
+[       OK ] ( 5/12) StreamMultiSysTest @daint:gpu+gnu
+[       OK ] ( 6/12) StreamMultiSysTest @daint:gpu+pgi
+[       OK ] ( 7/12) StreamMultiSysTest @daint:gpu+cray
+[       OK ] ( 8/12) StreamMultiSysTest @daint:gpu+intel
+[       OK ] ( 9/12) StreamMultiSysTest @daint:mc+gnu
+[       OK ] (10/12) StreamMultiSysTest @daint:mc+cray
+[       OK ] (11/12) StreamMultiSysTest @daint:mc+pgi
+[       OK ] (12/12) StreamMultiSysTest @daint:mc+intel
 [----------] all spawned checks have finished
 
 [  PASSED  ] Ran 12/12 test case(s) from 1 check(s) (0 failure(s), 0 skipped)
-[==========] Finished on Sat Jan 22 22:48:59 2022 
+[==========] Finished on Sat Jan 22 22:48:59 2022
 ==============================================================================
 PERFORMANCE REPORT
 ------------------------------------------------------------------------------

--- a/reframe/frontend/executors/policies.py
+++ b/reframe/frontend/executors/policies.py
@@ -181,7 +181,7 @@ class SerialExecutionPolicy(ExecutionPolicy, TaskEventListener):
 
     def on_task_failure(self, task):
         self._num_failed_tasks += 1
-        msg = f'{task.check.info()}'
+        msg = f'{task.info()}'
         if task.failed_stage == 'cleanup':
             self.printer.status('ERROR', msg, just='right')
         else:
@@ -202,7 +202,7 @@ class SerialExecutionPolicy(ExecutionPolicy, TaskEventListener):
             )
 
     def on_task_success(self, task):
-        msg = f'{task.check.info()}'
+        msg = f'{task.info()}'
         self.printer.status('OK', msg, just='right')
         timings = task.pipeline_timings(['setup',
                                          'compile_complete',
@@ -427,8 +427,6 @@ class AsynchronousExecutionPolicy(ExecutionPolicy, TaskEventListener):
                 return 1
         elif self.deps_succeeded(task):
             try:
-                part = task.testcase.partition
-                env  = task.testcase.environ.name
                 self.printer.status('RUN', task.info())
                 task.setup(task.testcase.partition,
                            task.testcase.environ,
@@ -453,7 +451,7 @@ class AsynchronousExecutionPolicy(ExecutionPolicy, TaskEventListener):
             return 1
         else:
             # Not all dependencies have finished yet
-            getlogger().debug2(f'{task.check.info()} waiting for dependencies')
+            getlogger().debug2(f'{task.info()} waiting for dependencies')
             return 0
 
     def _advance_ready_compile(self, task):

--- a/reframe/frontend/executors/policies.py
+++ b/reframe/frontend/executors/policies.py
@@ -181,10 +181,7 @@ class SerialExecutionPolicy(ExecutionPolicy, TaskEventListener):
 
     def on_task_failure(self, task):
         self._num_failed_tasks += 1
-        timings = task.pipeline_timings(['compile_complete',
-                                         'run_complete',
-                                         'total'])
-        msg = f'{task.check.info()} [{timings}]'
+        msg = f'{task.check.info()}'
         if task.failed_stage == 'cleanup':
             self.printer.status('ERROR', msg, just='right')
         else:
@@ -205,10 +202,7 @@ class SerialExecutionPolicy(ExecutionPolicy, TaskEventListener):
             )
 
     def on_task_success(self, task):
-        timings = task.pipeline_timings(['compile_complete',
-                                         'run_complete',
-                                         'total'])
-        msg = f'{task.check.info()} [{timings}]'
+        msg = f'{task.check.info()}'
         self.printer.status('OK', msg, just='right')
         timings = task.pipeline_timings(['setup',
                                          'compile_complete',
@@ -584,10 +578,7 @@ class AsynchronousExecutionPolicy(ExecutionPolicy, TaskEventListener):
 
     def on_task_failure(self, task):
         self._num_failed_tasks += 1
-        timings = task.pipeline_timings(['compile_complete',
-                                         'run_complete',
-                                         'total'])
-        msg = f'{task.info()} [{timings}]'
+        msg = f'{task.info()}'
         if task.failed_stage == 'cleanup':
             self.printer.status('ERROR', msg, just='right')
         else:
@@ -608,10 +599,7 @@ class AsynchronousExecutionPolicy(ExecutionPolicy, TaskEventListener):
             )
 
     def on_task_success(self, task):
-        timings = task.pipeline_timings(['compile_complete',
-                                         'run_complete',
-                                         'total'])
-        msg = f'{task.info()} [{timings}]'
+        msg = f'{task.info()}'
         self.printer.status('OK', msg, just='right')
         timings = task.pipeline_timings(['setup',
                                          'compile_complete',


### PR DESCRIPTION
It might be better to remove the runtime timings from the default output, after the conversation in #2415 . 
The documentation mentions that these timings correspond only to the ReFrame stages, but it can be misleading for new users that want to use them for performance monitoring.
Normal output:
```
[----------] start processing checks
[ RUN      ] T0 @generic:default+builtin
[       OK ] ( 1/10) T0 @generic:default+builtin
[ RUN      ] T4 @generic:default+builtin
[       OK ] ( 2/10) T4 @generic:default+builtin
```
Verbose output:
```
[----------] start processing checks
[ RUN      ] T0 @generic:default+builtin
[       OK ] ( 1/10) T0 @generic:default+builtin
==> setup: 0.019s compile: 0.035s run: 0.476s sanity: 0.000s performance: 0.000s total: 0.568s
[ RUN      ] T4 @generic:default+builtin
[       OK ] ( 2/10) T4 @generic:default+builtin
==> setup: 0.009s compile: 0.036s run: 0.375s sanity: 0.000s performance: 0.000s total: 0.459s
```
I still leave them in verbose mode, what do you think @vkarak ? If you agree I will change also all the reframe outputs in the docs.

Closes #2415.