### PR TITLE
[bugfix] Properly select configuration when running tests

### DIFF
--- a/reframe/core/config.py
+++ b/reframe/core/config.py
@@ -64,7 +64,7 @@ class _SiteConfig:
     def __init__(self, site_config, filename):
         self._site_config = copy.deepcopy(site_config)
         self._filename = filename
-        self._local_config = {}
+        self._subconfigs = {}
         self._local_system = None
         self._sticky_options = {}
 
@@ -76,15 +76,18 @@ class _SiteConfig:
                 self._schema = json.loads(fp.read())
             except json.JSONDecodeError as e:
                 raise ReframeFatalError(
-                    f"invalid configuration schema: '{schema_filename}'"
+                    f'invalid configuration schema: {schema_filename!r}'
                 ) from e
 
     def _pick_config(self):
-        return self._local_config if self._local_config else self._site_config
+        if self._local_system:
+            return self._subconfigs[self._local_system]
+        else:
+            return self._site_config
 
     def __repr__(self):
         return (f'{type(self).__name__}(site_config={self._site_config!r}, '
-                'filename={self._filename!r})')
+                f'filename={self._filename!r})')
 
     def __str__(self):
         return json.dumps(self._pick_config(), indent=2)
@@ -316,12 +319,15 @@ class _SiteConfig:
 
     def select_subconfig(self, system_fullname=None,
                          ignore_resolve_errors=False):
-        if (self._local_system is not None and
-            self._local_system == system_fullname):
-            return
-
+        # First look for the current subconfig in the cache; if not found,
+        # generate it and cache it
         system_fullname = system_fullname or self._detect_system()
         getlogger().debug(f'Selecting subconfig for {system_fullname!r}')
+
+        self._local_system = system_fullname
+        if system_fullname in self._subconfigs:
+            return self._subconfigs[system_fullname]
+
         try:
             system_name, part_name = system_fullname.split(':', maxsplit=1)
         except ValueError:
@@ -331,7 +337,7 @@ class _SiteConfig:
         # Start from a fresh copy of the site_config, because we will be
         # modifying it
         site_config = copy.deepcopy(self._site_config)
-        self._local_config = {}
+        local_config = {}
         systems = list(
             filter(lambda x: x['name'] == system_name, site_config['systems'])
         )
@@ -356,7 +362,7 @@ class _SiteConfig:
             )
 
         # Create local configuration for the current or the requested system
-        self._local_config['systems'] = systems
+        local_config['systems'] = systems
         for name, section in site_config.items():
             if name == 'systems':
                 # The systems sections has already been treated
@@ -387,12 +393,12 @@ class _SiteConfig:
                 except KeyError:
                     pass
                 else:
-                    self._local_config.setdefault(name, [])
-                    self._local_config[name].append(val)
+                    local_config.setdefault(name, [])
+                    local_config[name].append(val)
 
         required_sections = self._schema['required']
         for name in required_sections:
-            if name not in self._local_config.keys():
+            if name not in local_config.keys():
                 if not ignore_resolve_errors:
                     raise ConfigError(
                         f"section '{name}' not defined "
@@ -407,7 +413,7 @@ class _SiteConfig:
                                    for p in systems[0]['partitions']))
             }
             found_environs = {
-                e['name'] for e in self._local_config['environments']
+                e['name'] for e in local_config['environments']
             }
             undefined_environs = sys_environs - found_environs
             if undefined_environs:
@@ -417,7 +423,7 @@ class _SiteConfig:
                     f"are not defined for '{system_fullname}'"
                 )
 
-        self._local_system = system_fullname
+        self._subconfigs[system_fullname] = local_config
 
 
 def convert_old_config(filename, newfilename=None):

--- a/reframe/core/runtime.py
+++ b/reframe/core/runtime.py
@@ -283,6 +283,20 @@ class temp_environment:
         self._environ_save.restore()
 
 
+class temp_config:
+    '''Context manager to temporarily switch to specific configuration.'''
+
+    def __init__(self, system):
+        self.__to = system
+        self.__from = runtime().system.name
+
+    def __enter__(self):
+        runtime().site_config.select_subconfig(self.__to)
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        runtime().site_config.select_subconfig(self.__from)
+
+
 # The following utilities are useful only for the unit tests
 
 class temp_runtime:

--- a/reframe/core/systems.py
+++ b/reframe/core/systems.py
@@ -163,10 +163,10 @@ class SystemPartition(jsonext.JSONSerializable):
        Users may not create :class:`SystemPartition` objects directly.
     '''
 
-    def __init__(self, parent, name, sched_type, launcher_type,
+    def __init__(self, *, parent, name, sched_type, launcher_type,
                  descr, access, container_environs, resources,
                  local_env, environs, max_jobs, prepare_cmds,
-                 processor, devices, extras):
+                 processor, devices, extras, time_limit):
         getlogger().debug(f'Initializing system partition {name!r}')
         self._parent_system = parent
         self._name = name
@@ -184,6 +184,7 @@ class SystemPartition(jsonext.JSONSerializable):
         self._processor = ProcessorInfo(processor)
         self._devices = [DeviceInfo(d) for d in devices]
         self._extras = extras
+        self._time_limit = time_limit
 
     @property
     def access(self):
@@ -245,6 +246,17 @@ class SystemPartition(jsonext.JSONSerializable):
         :type: integral
         '''
         return self._max_jobs
+
+    @property
+    def time_limit(self):
+        '''The time limit that will be used when submitting jobs to this
+        partition.
+
+        :type: :class:`str` or :obj:`None`
+
+        .. versionadded:: 3.11.0
+        '''
+        return self._time_limit
 
     @property
     def prepare_cmds(self):
@@ -511,7 +523,8 @@ class System(jsonext.JSONSerializable):
                     prepare_cmds=site_config.get(f'{partid}/prepare_cmds'),
                     processor=site_config.get(f'{partid}/processor'),
                     devices=site_config.get(f'{partid}/devices'),
-                    extras=site_config.get(f'{partid}/extras')
+                    extras=site_config.get(f'{partid}/extras'),
+                    time_limit=site_config.get(f'{partid}/time_limit')
                 )
             )
 

--- a/reframe/frontend/executors/__init__.py
+++ b/reframe/frontend/executors/__init__.py
@@ -288,7 +288,9 @@ class RegressionTask:
             with logging.logging_context(self.check) as logger:
                 logger.debug(f'Entering stage: {self._current_stage}')
                 with update_timestamps():
-                    return fn(*args, **kwargs)
+                    # Pick the configuration of the current partition
+                    with runtime.temp_config(self.testcase.partition.fullname):
+                        return fn(*args, **kwargs)
         except SkipTestError as e:
             if not self.succeeded:
                 # Only skip a test if it hasn't finished yet;
@@ -578,10 +580,6 @@ class ExecutionPolicy(abc.ABC):
     def runcase(self, case):
         '''Run a test case.'''
 
-        # Pick the right subconfig for the current partition
-        rt = runtime.runtime()
-        _, partition, _ = case
-        rt.site_config.select_subconfig(partition.fullname)
         if self.strict_check:
             case.check.strict_check = True
 

--- a/unittests/resources/settings.py
+++ b/unittests/resources/settings.py
@@ -24,6 +24,27 @@ site_configuration = {
             ]
         },
         {
+            'name': 'generic2',
+            'descr': 'Generic example system',
+            'hostnames': ['.*'],
+            'partitions': [
+                {
+                    'name': 'part1',
+                    'descr': 'Login nodes',
+                    'scheduler': 'local',
+                    'launcher': 'local',
+                    'environs': ['builtin']
+                },
+                {
+                    'name': 'part2',
+                    'descr': 'Login nodes',
+                    'scheduler': 'local',
+                    'launcher': 'local',
+                    'environs': ['builtin']
+                }
+            ]
+        },
+        {
             'name': 'testsys',
             'descr': 'Fake system for unit tests',
             'hostnames': ['testsys'],
@@ -273,6 +294,14 @@ site_configuration = {
         {
             'compact_test_names': True,
             'target_systems': ['sys1']
+        },
+        {
+            'git_timeout': 10,
+            'target_systems': ['generic2:part1']
+        },
+        {
+            'git_timeout': 20,
+            'target_systems': ['generic2:part2']
         }
     ]
 }

--- a/unittests/test_config.py
+++ b/unittests/test_config.py
@@ -359,6 +359,7 @@ def test_system_create():
     }]
     assert partition.local_env.variables == {'FOO_GPU': 'yes'}
     assert partition.max_jobs == 10
+    assert partition.time_limit is None
     assert len(partition.environs) == 2
     assert partition.environment('PrgEnv-gnu').cc == 'cc'
     assert partition.environment('PrgEnv-gnu').cflags == []

--- a/unittests/test_policies.py
+++ b/unittests/test_policies.py
@@ -12,6 +12,7 @@ import socket
 import sys
 import time
 
+import reframe as rfm
 import reframe.core.runtime as rt
 import reframe.frontend.dependencies as dependencies
 import reframe.frontend.executors as executors
@@ -929,3 +930,35 @@ def test_restore_session(report_file, make_runner,
 
     with pytest.raises(ReframeError, match=r'could not restore testcase'):
         report.restore_dangling(testgraph)
+
+
+@pytest.fixture
+def generic2_exec_ctx(request, make_exec_ctx_g):
+    yield from make_exec_ctx_g(system='generic2')
+
+
+def test_config_params(make_runner, make_exec_ctx):
+    '''Test that configuration parameters are properly retrieved with the various
+    execution policies'''
+
+    class T(rfm.RunOnlyRegressionTest):
+        valid_systems = ['generic2']
+        valid_prog_environs = ['*']
+        executable = 'echo'
+
+        @sanity_function
+        def validate(self):
+            return True
+
+        @run_after('setup')
+        def assert_git_timeout(self):
+            expected = 10 if self.current_partition.name == 'part1' else 20
+            timeout = rt.runtime().get_option('general/0/git_timeout')
+            assert timeout == expected
+
+    make_exec_ctx(system='generic2')
+    runner = make_runner()
+    testcases = executors.generate_testcases([T()])
+    runner.runall(testcases)
+    assert runner.stats.num_cases() == 2
+    assert not runner.stats.failed()

--- a/unittests/test_policies.py
+++ b/unittests/test_policies.py
@@ -938,8 +938,9 @@ def generic2_exec_ctx(request, make_exec_ctx_g):
 
 
 def test_config_params(make_runner, make_exec_ctx):
-    '''Test that configuration parameters are properly retrieved with the various
-    execution policies'''
+    '''Test that configuration parameters are properly retrieved with the
+    various execution policies.
+    '''
 
     class T(rfm.RunOnlyRegressionTest):
         valid_systems = ['generic2']


### PR DESCRIPTION
This PR fixes the problem of not properly setting up the partition configuration for tests run with the asynchronous execution policy. More specifically, it provides the following:

- Every time a pipeline function is called by the execution policies, the correct subconfig is selected for the current partition.
- A caching mechanism is implemented in `_SiteConfig.select_subconfig()` so as to avoid redundant computations of the subconfig.

In addition to the above the `time_limit` attribute is added to the `SystemPartition`, as it happens with every other attribute of a partition in the configuration.

Fixes #2360.