### PR TITLE
[test] Temporary workaround for `OpenaccCudaCppCheck`

### DIFF
--- a/cscs-checks/mch/openacc_cuda_mpi_cppstd.py
+++ b/cscs-checks/mch/openacc_cuda_mpi_cppstd.py
@@ -18,9 +18,11 @@ class OpenaccCudaCpp(rfm.RegressionTest):
         self.build_system = 'Make'
         self.build_system.fflags = ['-O2']
 
+        #FIXME Temporary workaround reducing the MPI tasks per node
+        # See https://jira.cscs.ch/browse/PROGENV-8 for Cray case
         if self.current_system.name in ['daint', 'dom']:
             self.num_tasks = 12
-            self.num_tasks_per_node = 12
+            self.num_tasks_per_node = 11
             self.num_gpus_per_node = 1
             self.build_system.options = ['NVCC_FLAGS="-arch=compute_60"']
             self.variables = {

--- a/cscs-checks/mch/openacc_cuda_mpi_cppstd.py
+++ b/cscs-checks/mch/openacc_cuda_mpi_cppstd.py
@@ -18,7 +18,7 @@ class OpenaccCudaCpp(rfm.RegressionTest):
         self.build_system = 'Make'
         self.build_system.fflags = ['-O2']
 
-        #FIXME Temporary workaround reducing the MPI tasks per node
+        # FIXME Temporary workaround reducing the MPI tasks per node
         # See https://jira.cscs.ch/browse/PROGENV-8 for Cray case
         if self.current_system.name in ['daint', 'dom']:
             self.num_tasks = 12


### PR DESCRIPTION
I propose to add the workaround reported in [PROGENV-8](https://jira.cscs.ch/browse/PROGENV-8) to the check `OpenaccCudaCpp`, namely reducing the MPI tasks per node to 11, until we get the fix by HPE Cray.