### PR TITLE
[ci] Minor deployment improvements

### DIFF
--- a/ci-scripts/deploy.sh
+++ b/ci-scripts/deploy.sh
@@ -47,7 +47,7 @@ cd $tmpdir
 git clone https://${_gh_creds_prefix}github.com/eth-cscs/reframe.git
 cd reframe
 ./bootstrap.sh
-found_version=$(./bin/reframe -V | sed -e 's/ (.*)//g')
+found_version=$(./bin/reframe -V | sed -e 's/\(.*\)\+.*/\1/g')
 if [ $found_version != $version ]; then
     echo "$0: version mismatch: found $found_version, but required $version" >&2
     exit 1

--- a/ci-scripts/genrelnotes.py
+++ b/ci-scripts/genrelnotes.py
@@ -52,7 +52,7 @@ if __name__ == '__main__':
             descr_line = '- %s (%s)' % (descr, pr)
             sections[title_line].append(descr_line)
 
-    print('# ReFrame %s Release Notes' % curr_release)
+    print('# Release Notes')
     for sec_title, sec_lines in sections.items():
         print()
         print(sec_title)


### PR DESCRIPTION
This PR provides two things:

1. When deploying ReFrame, update the version sanity check, so that it ignores the build metadata part of the version (i.e., the `+hash` thing).
2. Update the title of of the release notes.