### PR TITLE
[feat] Add configuredir variable to the Autotools buildsystem

### DIFF
--- a/reframe/core/buildsystems.py
+++ b/reframe/core/buildsystems.py
@@ -597,6 +597,15 @@ class Autotools(ConfigureBasedBuildSystem):
     3. Issue ``make`` to compile the code.
     '''
 
+    #: The directory of the configure script.
+    #:
+    #: This can be changed to do an out of source build without copying the
+    #: entire source tree.
+    #:
+    #: :type: :class:`str`
+    #: :default: ``"."``
+    configuredir = variable(str, value='.')
+
     def emit_build_commands(self, environ):
         prepare_cmd = []
         if self.srcdir:
@@ -608,9 +617,9 @@ class Autotools(ConfigureBasedBuildSystem):
 
         if self.builddir:
             configure_cmd = [os.path.join(
-                os.path.relpath('.', self.builddir), 'configure')]
+                os.path.relpath(self.configuredir, self.builddir), 'configure')]
         else:
-            configure_cmd = ['./configure']
+            configure_cmd = [os.path.join(self.configuredir, 'configure')]
 
         cc = self._cc(environ)
         cxx = self._cxx(environ)


### PR DESCRIPTION
I am writing a test suite using Reframe for a project with the following structure (simplified):

```
src/
data/
configure
reframe/checks.py
```

The project is built using Autotools.

At first I simply set `sourcesdir = '..'`, but this did not work well in practice since copying the whole source tree for each build can be quite expensive. Especially on a file system with limited quota.

With the change in this PR, I am able to do an out of source build without copying the entire source tree:

```
self.build_system.configuredir = os.path.join(self.prefix, '..')
```

Using this method, the build output is generated in the stage directory while the source files are read from the original source directory.

Please let me know what you think!