### PR TITLE
Revert "[config] Use new naming scheme in CSCS config"

### DIFF
--- a/config/cscs-ci.py
+++ b/config/cscs-ci.py
@@ -205,8 +205,10 @@ site_configuration = {
     ],
     'general': [
         {
-            'check_search_path': ['checks/'],
-            'check_search_recursive': True
+            'check_search_path': [
+                'checks/'
+            ],
+            'check_search_recursive': True,
         }
     ]
 }

--- a/config/cscs.py
+++ b/config/cscs.py
@@ -1008,7 +1008,6 @@ site_configuration = {
         {
             'check_search_path': ['checks/'],
             'check_search_recursive': True,
-            'compact_test_names': True,
             'remote_detect': True
         }
     ]


### PR DESCRIPTION
Reverts eth-cscs/reframe#2450

The problem is that it breaks our performance dashboards if we don't set fields as loggable to all the tests (not just the libraries) due to KQL's limitation to match correctly the `check_display_name`. I've tried also Lucene in to match the display name but couldn't succeed. So I'm reverting this change for the moment.