### PR TITLE
[feat] Extend the public API of `Job`

### DIFF
--- a/reframe/core/launchers/mpi.py
+++ b/reframe/core/launchers/mpi.py
@@ -110,7 +110,7 @@ class SrunAllocationLauncher(JobLauncher):
         if job.num_cpus_per_task:
             ret += ['--cpus-per-task=%s' % str(job.num_cpus_per_task)]
 
-        if job.sched_exclusive_access:
+        if job.exclusive_access:
             ret += ['--exclusive']
 
         if job.use_smt is not None:

--- a/reframe/core/pipeline.py
+++ b/reframe/core/pipeline.py
@@ -1767,7 +1767,7 @@ class RegressionTest(RegressionMixin, jsonext.JSONSerializable):
             f'systems/0/partitions/@{self.current_partition.name}/time_limit')
         )
         self.job.max_pending_time = self.max_pending_time
-        self.exclusive_access = self.exclusive_access
+        self.job.exclusive_access = self.exclusive_access
         exec_cmd = [self.job.launcher.run_command(self.job),
                     self.executable, *self.executable_opts]
 

--- a/reframe/core/pipeline.py
+++ b/reframe/core/pipeline.py
@@ -1514,9 +1514,7 @@ class RegressionTest(RegressionMixin, jsonext.JSONSerializable):
                           launcher,
                           name=name,
                           workdir=self._stagedir,
-                          max_pending_time=self.max_pending_time,
                           sched_access=self._current_partition.access,
-                          sched_exclusive_access=self.exclusive_access,
                           **job_opts)
 
     def _setup_perf_logging(self):
@@ -1768,6 +1766,8 @@ class RegressionTest(RegressionMixin, jsonext.JSONSerializable):
         self.job.time_limit = (self.time_limit or rt.runtime().get_option(
             f'systems/0/partitions/@{self.current_partition.name}/time_limit')
         )
+        self.job.max_pending_time = self.max_pending_time
+        self.exclusive_access = self.exclusive_access
         exec_cmd = [self.job.launcher.run_command(self.job),
                     self.executable, *self.executable_opts]
 

--- a/reframe/core/schedulers/__init__.py
+++ b/reframe/core/schedulers/__init__.py
@@ -128,18 +128,116 @@ class Job(jsonext.JSONSerializable, metaclass=JobMeta):
 
     '''
 
+    #: Number of tasks for this job.
+    #:
+    #: :type: integral
+    #: :default: ``1``
+    #:
+    #: .. note::
+    #:    This attribute is set by the framework just before submitting the job
+    #:    based on the test information.
+    #:
+    #: .. versionadded:: 3.11.0
     num_tasks = variable(int, value=1)
+
+    #: Number of tasks per node for this job.
+    #:
+    #: :type: integral or :class:`NoneType`
+    #: :default: ``None``
+    #:
+    #: .. note::
+    #:    This attribute is set by the framework just before submitting the job
+    #:    based on the test information.
+    #:
+    #: .. versionadded:: 3.11.0
     num_tasks_per_node = variable(int, type(None), value=None)
+
+    #: Number of tasks per core for this job.
+    #:
+    #: :type: integral or :class:`NoneType`
+    #: :default: ``None``
+    #:
+    #: .. note::
+    #:    This attribute is set by the framework just before submitting the job
+    #:    based on the test information.
+    #:
+    #: .. versionadded:: 3.11.0
     num_tasks_per_core = variable(int, type(None), value=None)
+
+    #: Number of tasks per socket for this job.
+    #:
+    #: :type: integral or :class:`NoneType`
+    #: :default: ``None``
+    #:
+    #: .. note::
+    #:    This attribute is set by the framework just before submitting the job
+    #:    based on the test information.
+    #:
+    #: .. versionadded:: 3.11.0
     num_tasks_per_socket = variable(int, type(None), value=None)
+
+    #: Number of processing elements associated with each task for this job.
+    #:
+    #: :type: integral or :class:`NoneType`
+    #: :default: ``None``
+    #:
+    #: .. note::
+    #:    This attribute is set by the framework just before submitting the job
+    #:    based on the test information.
+    #:
+    #: .. versionadded:: 3.11.0
     num_cpus_per_task = variable(int, type(None), value=None)
+
+    #: Enable SMT for this job.
+    #:
+    #: :type: :class:`bool` or :class:`NoneType`
+    #: :default: ``None``
+    #:
+    #: .. note::
+    #:    This attribute is set by the framework just before submitting the job
+    #:    based on the test information.
+    #:
+    #: .. versionadded:: 3.11.0
     use_smt = variable(bool, type(None), value=None)
+
+    #: Request exclusive access on the nodes for this job.
+    #:
+    #: :type: :class:`bool`
+    #: :default: ``false``
+    #:
+    #: .. note::
+    #:    This attribute is set by the framework just before submitting the job
+    #:    based on the test information.
+    #:
+    #: .. versionadded:: 3.11.0
     exclusive_access = variable(bool, value=False)
+
+    #: Time limit for this job.
+    #:
+    #: See :attr:`reframe.core.pipeline.RegressionTest.time_limit` for more
+    #: details.
+    #:
+    #: .. note::
+    #:    This attribute is set by the framework just before submitting the job
+    #:    based on the test information.
+    #:
+    #: .. versionadded:: 3.11.0
     time_limit = variable(type(None), field=fields.TimerField, value=None)
+
+    #: Maximum pending time for this job.
+    #:
+    #: See :attr:`reframe.core.pipeline.RegressionTest.max_pending_time` for
+    #: more details.
+    #:
+    #: .. note::
+    #:    This attribute is set by the framework just before submitting the job
+    #:    based on the test information.
+    #:
+    #: .. versionadded:: 3.11.0
     max_pending_time = variable(type(None),
                                 field=fields.TimerField, value=None)
 
-    #: Options to be passed to the backend job scheduler.
+    #: Arbitrary options to be passed to the backend job scheduler.
     #:
     #: :type: :class:`List[str]`
     #: :default: ``[]``

--- a/reframe/core/schedulers/lsf.py
+++ b/reframe/core/schedulers/lsf.py
@@ -71,7 +71,7 @@ class LsfJobScheduler(PbsJobScheduler):
             else:
                 preamble.append(self._prefix + ' ' + opt)
 
-        if job.sched_exclusive_access:
+        if job.exclusive_access:
             preamble.append(f'{self._prefix} -x')
 
         # Filter out empty statements before returning

--- a/reframe/core/schedulers/slurm.py
+++ b/reframe/core/schedulers/slurm.py
@@ -178,9 +178,9 @@ class SlurmJobScheduler(sched.JobScheduler):
                 self._format_option('%d:%d:%d' % (h, m, s), '--time={0}')
             )
 
-        if job.sched_exclusive_access:
+        if job.exclusive_access:
             preamble.append(
-                self._format_option(job.sched_exclusive_access, '--exclusive')
+                self._format_option(job.exclusive_access, '--exclusive')
             )
 
         if self._use_nodes_opt:

--- a/unittests/test_launchers.py
+++ b/unittests/test_launchers.py
@@ -76,7 +76,6 @@ def job(make_job, launcher):
                    stdout='fake_stdout',
                    stderr='fake_stderr',
                    sched_access=access,
-                   sched_exclusive_access='fake_exclude_access',
                    sched_options=['--fake'])
     job.num_tasks = 4
     job.num_tasks_per_node = 2
@@ -85,6 +84,7 @@ def job(make_job, launcher):
     job.num_cpus_per_task = 2
     job.use_smt = True
     job.time_limit = '10m'
+    job.exclusive_access = True
     job.options = ['--gres=gpu:4', '#DW jobdw anything']
     job.launcher.options = ['--foo']
     return job

--- a/unittests/test_schedulers.py
+++ b/unittests/test_schedulers.py
@@ -567,8 +567,8 @@ def test_submit_max_pending_time(make_job, exec_ctx, scheduler):
         pytest.skip(f"max_pending_time not supported by the "
                     f"'{scheduler.registered_name}' scheduler")
 
-    minimal_job = make_job(sched_access=exec_ctx.access,
-                           max_pending_time=0.05)
+    minimal_job = make_job(sched_access=exec_ctx.access)
+    minimal_job.max_pending_time = 0.05
 
     # Monkey-patch the Job's state property to pretend that the job is always
     # pending

--- a/unittests/test_schedulers.py
+++ b/unittests/test_schedulers.py
@@ -90,8 +90,7 @@ def minimal_job(make_job):
 
 @pytest.fixture
 def fake_job(make_job):
-    ret = make_job(sched_exclusive_access=True,
-                   sched_options=['--account=spam'])
+    ret = make_job(sched_options=['--account=spam'])
     ret.time_limit = '5m'
     ret.num_tasks = 16
     ret.num_tasks_per_node = 2
@@ -99,6 +98,7 @@ def fake_job(make_job):
     ret.num_tasks_per_socket = 1
     ret.num_cpus_per_task = 18
     ret.use_smt = True
+    ret.exclusive_access = True
     ret.options += ['--gres=gpu:4',
                     '#DW jobdw capacity=100GB',
                     '#DW stage_in source=/foo']
@@ -332,7 +332,8 @@ def test_prepare_minimal(minimal_job):
 
 
 def test_prepare_no_exclusive(make_job, slurm_only):
-    job = make_job(sched_exclusive_access=False)
+    job = make_job()
+    job.exclusive_access = False
     prepare_job(job)
     with open(job.script_filename) as fp:
         assert re.search(r'--exclusive', fp.read()) is None


### PR DESCRIPTION
This PR exposes several `Job` attributes publicly by practically documenting them. It also uses the `variable` builtin to define them and also refactors a bit the arguments passed to the constructor of a `Job`. Now, the arguments that are passed to it are only those that must be set from the frontend either directly or indirectly through the configuration.

Fixes #2315.