### PR TITLE
[bugfix] Make rerun prompt consistent with the new naming scheme

### DIFF
--- a/reframe/frontend/statistics.py
+++ b/reframe/frontend/statistics.py
@@ -235,7 +235,14 @@ class TestStats:
                          f"{r['dependencies_actual']}")
             printer.info(f"  * Maintainers: {r['maintainers']}")
             printer.info(f"  * Failing phase: {r['fail_phase']}")
-            printer.info(f"  * Rerun with '-n {r['unique_name']}"
+            if rt.runtime().get_option('general/0/compact_test_names'):
+                class_name = r['display_name'].split(' ')[0]
+                id = r['unique_name'].replace(class_name, '').replace('_', '@')
+                rerun_name = class_name + id
+            else:
+                rerun_name = r['unique_name']
+
+            printer.info(f"  * Rerun with '-n {rerun_name}"
                          f" -p {r['environment']} --system {r['system']} -r'")
             printer.info(f"  * Reason: {r['fail_reason']}")
 

--- a/reframe/frontend/statistics.py
+++ b/reframe/frontend/statistics.py
@@ -236,13 +236,13 @@ class TestStats:
             printer.info(f"  * Maintainers: {r['maintainers']}")
             printer.info(f"  * Failing phase: {r['fail_phase']}")
             if rt.runtime().get_option('general/0/compact_test_names'):
-                class_name = r['display_name'].split(' ')[0]
-                id = r['unique_name'].replace(class_name, '').replace('_', '@')
-                rerun_name = class_name + id
+                cls = r['display_name'].split(' ')[0]
+                variant = r['unique_name'].replace(cls, '').replace('_', '@')
+                nameoptarg = cls + variant
             else:
-                rerun_name = r['unique_name']
+                nameoptarg = r['unique_name']
 
-            printer.info(f"  * Rerun with '-n {rerun_name}"
+            printer.info(f"  * Rerun with '-n {nameoptarg}"
                          f" -p {r['environment']} --system {r['system']} -r'")
             printer.info(f"  * Reason: {r['fail_reason']}")
 


### PR DESCRIPTION
Closes #2464 .

One small thing that I realized in this PR is that if we define a test like this:

```python
class X_foo(rfm.RunOnlyRegressionTest):
    a = parameter(['a', 'b', 'c'])
    ...
```

we can rerun it with `-n X@foo@1` when `compact_test_names=True`, because of this code https://github.com/eth-cscs/reframe/blob/master/reframe/frontend/filters.py#L29 . Should I leave it as it is or do we want to change the bahaviour there as well?