### PR TITLE
[bugfix] Treat empty source code context when reporting errors

### DIFF
--- a/reframe/core/exceptions.py
+++ b/reframe/core/exceptions.py
@@ -366,7 +366,7 @@ def what(exc_type, exc_value, tb):
     elif is_user_error(exc_type, exc_value, tb):
         frame = user_frame(exc_type, exc_value, tb)
         relpath = os.path.relpath(frame.filename)
-        source = ''.join(frame.code_context)
+        source = ''.join(frame.code_context or '')
         reason += f': {relpath}:{frame.lineno}: {exc_value}\n{source}'
     else:
         if str(exc_value):

--- a/reframe/core/exceptions.py
+++ b/reframe/core/exceptions.py
@@ -366,7 +366,7 @@ def what(exc_type, exc_value, tb):
     elif is_user_error(exc_type, exc_value, tb):
         frame = user_frame(exc_type, exc_value, tb)
         relpath = os.path.relpath(frame.filename)
-        source = ''.join(frame.code_context or '')
+        source = ''.join(frame.code_context or '<n/a>')
         reason += f': {relpath}:{frame.lineno}: {exc_value}\n{source}'
     else:
         if str(exc_value):


### PR DESCRIPTION
When a `modulecmd python load` fails with a module file, the frame's code context being `None` causes `reframe` to terminate prematurely.

```
SUMMARY OF FAILURES
/home/chungsy/projects/reframe.git/bin/reframe: run session stopped: type error: can only join an iterable
/home/chungsy/projects/reframe.git/bin/reframe: Traceback (most recent call last):
  File "/home/chungsy/projects/reframe.git/reframe/frontend/cli.py", line 1210, in main
    runner.stats.print_failure_report(printer)
  File "/home/chungsy/projects/reframe.git/reframe/frontend/statistics.py", line 210, in print_failure_report
    run_report = self.json()[-1]
  File "/home/chungsy/projects/reframe.git/reframe/frontend/statistics.py", line 164, in json
    entry['fail_reason'] = errors.what(*t.exc_info)
  File "/home/chungsy/projects/reframe.git/reframe/core/exceptions.py", line 370, in what
    source = ''.join(frame.code_context)
TypeError: can only join an iterable
```

After this patch, it's able to continue the normal error reporting process.
```
FAILURE INFO for GromacsTest_0
  * Expanded name: GromacsTest %pi=0
  * Description: GromacsTest %pi=0
  * System partition: cex:vanilla-mpi
  * Environment: builtin
  * Stage directory: /home/chungsy/projects/nscc-reframe-tests.git/stage/cex/vanilla-mpi/builtin/GromacsTest_0
  * Node list:
  * Job type: batch job (id=None)
  * Dependencies (conceptual): []
  * Dependencies (actual): []
  * Maintainers: []
  * Failing phase: run
  * Rerun with '-n GromacsTest_0 -p builtin --system cex:vanilla-mpi -r'
  * Reason: name error: <string>:32: name 'source' is not defined
```

The 'source' is actually a BASH source command included in a module file.