### PR TITLE
[feat] Support early access to fixtures

### DIFF
--- a/reframe/core/fixtures.py
+++ b/reframe/core/fixtures.py
@@ -822,6 +822,16 @@ class TestFixture:
         return self._variables
 
 
+class FixtureProxy:
+    def __init__(self, fixture_info):
+        for k, v in fixture_info['params'].items():
+            setattr(self, k, v)
+
+        for k, v in fixture_info['fixtures'].items():
+            if not isinstance(v, tuple):
+                setattr(self, k, FixtureProxy(v))
+
+
 class FixtureSpace(namespaces.Namespace):
     '''Regression test fixture space.
 
@@ -929,8 +939,8 @@ class FixtureSpace(namespaces.Namespace):
                 # Register all the variants and track the fixture names
                 dep_names += obj._rfm_fixture_registry.add(fixture,
                                                            variant,
-                                                           obj.name, part,
-                                                           prog_envs)
+                                                           obj.unique_name,
+                                                           part, prog_envs)
 
             # Add dependencies
             if fixture.scope == 'session':

--- a/reframe/core/fixtures.py
+++ b/reframe/core/fixtures.py
@@ -647,6 +647,61 @@ class TestFixture:
          bar = fixture(MyResource, variables={'b':2, 'a':1})
 
 
+    **Early access to fixture objects**
+
+    The test instance represented by a fixture can be accessed fully from
+    within a test only after the setup stage. The reason for that is that
+    fixtures eventually translate into test dependencies and access to the
+    parent dependencies cannot happen before the this stage.
+
+    However, it is often useful, especially in the case of parameterized
+    fixtures, to be able to access the fixture parameters earlier, e.g., in a
+    post-init hook in order to properly set the
+    :attr:`~reframe.core.pipeline.RegressionTest.valid_systems` and
+    :attr:`~reframe.core.pipeline.RegressionTest.valid_prog_environs` of the
+    test. These attributes cannot be set later than the test's initialization
+    in order to have an effect.
+
+    For this reason, early access to fixture objects is allowed *only* for
+    retrieving their parameters.
+
+    .. code-block:: python
+
+       class Fixture(rfm.RegressionTest):
+           x = parameter([1, 2, 3])
+
+
+       class Test(rfm.RunOnlyRegressionTest):
+           foo = fixture(Fixture)
+           executable = './myexec'
+           valid_prog_environs = ['*']
+
+           @run_after('init')
+           def early_access(self):
+                # Only fixture parameters can be accessed here!
+                if self.foo.x == 1:
+                    self.valid_systems = ['sys1]
+                else:
+                    self.valid_systems = ['sys2']
+
+           @run_after('setup')
+           def normal_access(self):
+               # Any test attribute of the associated fixture test can be
+               # accessed here
+               self.executable_opts = [
+                   '-i', os.path.join(self.foo.stagedir, 'input.txt')
+               ]
+
+
+    During test initialization, ReFrame binds the :attr:`foo` name to a proxy
+    object that holds the parameterization of the target fixture. This proxy
+    object is recursive, so that if fixture :attr:`foo` contained another
+    fixture named :attr:`bar`, it would allow you to access any parameters of
+    that fixture with ``self.foo.bar.param``.
+
+    During the test setup stage, the :attr:`foo`'s binding changes and it is
+    now bound to the exact test instance that was executed for the target test
+    instance.
 
     :param cls: A class derived from
         :class:`~reframe.core.pipeline.RegressionTest` that manages a given
@@ -695,6 +750,8 @@ class TestFixture:
 
 
     .. versionadded:: 3.9.0
+    .. versionchanged:: 3.11.0
+       Allow early access of fixture objects.
 
     '''
 

--- a/reframe/core/meta.py
+++ b/reframe/core/meta.py
@@ -429,6 +429,13 @@ class RegressionTestMeta(type):
             if k in cls.var_space:
                 setattr(obj, k, v)
 
+        # Inject fixture proxies to give access to fixture parameters during
+        # the init phase
+        varinfo = cls.get_variant_info(variant_num, recurse=True)
+        for fname, finfo in varinfo['fixtures'].items():
+            if not isinstance(finfo, tuple):
+                setattr(obj, fname, fixtures.FixtureProxy(finfo))
+
         obj.__init__(*args, **kwargs)
 
         # Register the fixtures

--- a/reframe/core/pipeline.py
+++ b/reframe/core/pipeline.py
@@ -1028,11 +1028,11 @@ class RegressionTest(RegressionMixin, jsonext.JSONSerializable):
             raise AttributeError(
                 f'required variable {name!r} has not been set'
             ) from None
-        elif name in self._rfm_fixture_space:
-            raise AttributeError(
-                f'fixture {name!r} has not yet been resolved: '
-                f'fixtures are resolved during the setup stage'
-            )
+        # elif name in self._rfm_fixture_space:
+        #     raise AttributeError(
+        #         f'fixture {name!r} has not yet been resolved: '
+        #         f'fixtures are resolved during the setup stage'
+        #     )
         else:
             raise AttributeError(
                 f'{type(self).__qualname__!r} object has no attribute {name!r}'

--- a/reframe/core/pipeline.py
+++ b/reframe/core/pipeline.py
@@ -1028,11 +1028,6 @@ class RegressionTest(RegressionMixin, jsonext.JSONSerializable):
             raise AttributeError(
                 f'required variable {name!r} has not been set'
             ) from None
-        # elif name in self._rfm_fixture_space:
-        #     raise AttributeError(
-        #         f'fixture {name!r} has not yet been resolved: '
-        #         f'fixtures are resolved during the setup stage'
-        #     )
         else:
             raise AttributeError(
                 f'{type(self).__qualname__!r} object has no attribute {name!r}'

--- a/unittests/test_fixtures.py
+++ b/unittests/test_fixtures.py
@@ -193,19 +193,27 @@ def test_fixture_access_in_class_body():
 
 
 def test_fixture_early_access():
-    class Foo(rfm.RegressionTest):
-        pass
+    class FooA(rfm.RegressionTest):
+        x = parameter([1])
+
+    class FooB(rfm.RegressionTest):
+        foo = fixture(FooA)
+        y = parameter([2])
 
     class Bar(rfm.RegressionTest):
-        f = fixture(Foo)
+        f = fixture(FooB, variables={'z': 5})
+        w = fixture(FooB, action='join')
+
+        valid_systems = ['*']
+        valid_prog_environs = ['*']
 
         @run_after('init')
-        def trigger_fixture_error(self):
-            print(self.f)
+        def early_access(self):
+            assert self.f.foo.x == 1
+            assert self.f.y == 2
+            assert self.w.y == 2
 
-    msg = "fixture 'f' has not yet been resolved"
-    with pytest.raises(AttributeError, match=msg):
-        Bar()
+    Bar(variant_num=0)
 
 
 def test_fixture_space_access():


### PR DESCRIPTION
The problem we have faced trying to implement the OSU benchmarks as a library in #2421 is that in the CSCS specialisation we wanted to set the `valid_systems` and `valid_prog_environs` based on the `osu_binaries.build_type` fixture parameter. This was only possible to achieve by creating explicitly different specialized tests for each build type, because we were not allowed to access fixtures before the setup stage. This PR solves this, allowing users to access fixtures as early as in a post-init hook. However, only fixture parameters are allowed to be accessed at this point, but it should be enough to serve us in almost all if not all scenarios. From the setup stage onward, there is no change in the behaviour compared to the past.