### PR TITLE
Add the task info to the skipped test message

### DIFF
--- a/reframe/frontend/executors/policies.py
+++ b/reframe/frontend/executors/policies.py
@@ -121,7 +121,7 @@ class SerialExecutionPolicy(ExecutionPolicy, TaskEventListener):
                 # We raise the SkipTestError here and catch it immediately in
                 # order for `skip()` to get the correct exception context.
                 try:
-                    raise SkipTestError('skipped due to skipped dependencies')
+                    raise SkipTestError(f'{task.info()} skipped due to skipped dependencies')
                 except SkipTestError as e:
                     task.skip()
                     raise TaskExit from e
@@ -450,7 +450,7 @@ class AsynchronousExecutionPolicy(ExecutionPolicy, TaskEventListener):
     def _advance_startup(self, task):
         if self.deps_skipped(task):
             try:
-                raise SkipTestError('skipped due to skipped dependencies')
+                raise SkipTestError(f'{task.info()} skipped due to skipped dependencies')
             except SkipTestError as e:
                 task.skip()
                 self._current_tasks.remove(task)


### PR DESCRIPTION
Currently, one does not know, while ReFrame is running, the tests that have been skipped, because the output of ReFrame is similar to

```
[     SKIP ] (10/20) skipped due to skipped dependencies
[     SKIP ] (11/20) skipped due to skipped dependencies
```

This PR adds the task info to the output line. So, it becomes, similar to

```
[     SKIP ] (10/20) build_uenv_check /240cb0d8 @scopi:login+builtin skipped due to skipped dependencies
[     SKIP ] (11/20) update_uenv_check /73c7cf7c @scopi:login+builtin skipped due to skipped dependencies
```