### PR TITLE
[doc] Update Slack invite link and add a note about expiration

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,9 @@ You can get in contact with the ReFrame community in the following ways:
 
 ### Slack
 
-Please join the community's [Slack channel](https://join.slack.com/t/reframetalk/shared_invite/zt-1tar8s71w-At0tolJ~~zxT2oG_2Ly9sw) for keeping up with the latest news about ReFrame, posting questions and, generally getting in touch with other users and the developers.
+Please join the community's [Slack channel](https://join.slack.com/t/reframetalk/shared_invite/zt-3706f0tj6-2CjHh07HdQNbmLw1qAasjg) for keeping up with the latest news about ReFrame, posting questions and, generally getting in touch with other users and the developers.
+
+> NOTE: Slack invite links expire for security reasons. Although we update them regularly, if you encounter problems joining the community Slack channel, please open an issue.
 
 ## Contributing back
 


### PR DESCRIPTION
It appears that Slack invite links have started to expire monthly :( I just got a notification about a failed attempt, I updated the link and added a note for users to open an issue in case they encounter a problem.