### PR TITLE
[enhancement] Print the performance reference tuple while running only if defined

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -163,6 +163,13 @@ The :ref:`logging` section article describes how logging can be configured in mo
 Once a performance test finishes, its figures of merit are printed immediately using the ``P:`` prefix.
 This can be suppressed by increasing the level at which this information is logged using the :envvar:`RFM_PERF_INFO_LEVEL` environment variable.
 
+.. note::
+
+   .. versionchanged:: 4.9
+
+      If the test sets no references, then the reference tuples are not printed in the ``P:`` line.
+
+
 .. _run-reports-and-performance-logging:
 
 Run reports and performance logging

--- a/reframe/frontend/executors/policies.py
+++ b/reframe/frontend/executors/policies.py
@@ -50,13 +50,13 @@ def _print_perf(task):
     for key, info in perfvars.items():
         val, ref, lower, upper, unit, result = info
         name = key.split(':')[-1]
-        
-        # Build reference info string only if all three reference value components are defined
-        if ref is not None and lower is not None and upper is not None:
-            msg = f'P: {name}: {val} {unit} (r:{ref}, l:{lower}, u:{upper})'
-        else:
+
+        # Build reference info string only if reference is defined
+        if ref == 0 and lower is None and upper is None:
             msg = f'P: {name}: {val} {unit}'
-            
+        else:
+            msg = f'P: {name}: {val} {unit} (r:{ref}, l:{lower}, u:{upper})'
+
         if result == 'xfail':
             msg = color.colorize(msg, color.MAGENTA)
         elif result == 'fail' or result == 'xpass':


### PR DESCRIPTION
### Prior to change

A test without reference values prints `(r:0, l:None, u:None)` for each performance variable. This is #3175.

```
user@myhost:~/reframe-examples/tutorial$ reframe -c stream/stream_runonly.py -r
<snip>

[----------] start processing checks
[ RUN      ] stream_test /2e15a047 @generic:default+builtin
[       OK ] (1/1) stream_test /2e15a047 @generic:default+builtin
P: copy_bw: 136250.6 MB/s (r:0, l:None, u:None)
P: triad_bw: 127052.0 MB/s (r:0, l:None, u:None)
[----------] all spawned checks have finished

[  PASSED  ] Ran 1/1 test case(s) from 1 check(s) (0 failure(s), 0 expected failure(s), 0 skipped, 0 aborted)
[==========] Finished on Mon Jul 14 19:19:13 2025+0000
Log file(s) saved in '/tmp/rfm-wkcpor0o.log'
```

### After change

A test without reference values does not print the reference tuple. Only the captured performance metric is printed.
```
user@myhost:~/reframe-examples/tutorial$ reframe -c stream/stream_runonly.py -r
<snip>

[----------] start processing checks
[ RUN      ] stream_test /2e15a047 @generic:default+builtin
[       OK ] (1/1) stream_test /2e15a047 @generic:default+builtin
P: copy_bw: 124658.9 MB/s
P: triad_bw: 99002.0 MB/s
[----------] all spawned checks have finished

[  PASSED  ] Ran 1/1 test case(s) from 1 check(s) (0 failure(s), 0 expected failure(s), 0 skipped, 0 aborted)
[==========] Finished on Mon Jul 14 19:13:53 2025+0000
Log file(s) saved in '/tmp/rfm-_jygclgm.log'
```

A test _with_ reference values behaves as before. The captured performance metric and its references are both printed.
```
user@myhost:~/reframe-examples/tutorial$ reframe -c stream/stream_runonly.py -r
<snip>

[----------] start processing checks
[ RUN      ] stream_test /2e15a047 @generic:default+builtin
[       OK ] (1/1) stream_test /2e15a047 @generic:default+builtin
P: copy_bw: 133880.3 MB/s (r:137659, l:-0.1, u:0.3)
P: triad_bw: 129926.7 MB/s (r:137659, l:-0.55, u:0.5)
[----------] all spawned checks have finished

[  PASSED  ] Ran 1/1 test case(s) from 1 check(s) (0 failure(s), 0 expected failure(s), 0 skipped, 0 aborted)
[==========] Finished on Mon Jul 14 19:14:31 2025+0000
Log file(s) saved in '/tmp/rfm-2md5inu3.log'
```





Closes #3175 