### PR TITLE
[testlib] Fix ROCm build

### DIFF
--- a/hpctestlib/microbenchmarks/gpu/dgemm/src/makefile.hip
+++ b/hpctestlib/microbenchmarks/gpu/dgemm/src/makefile.hip
@@ -4,7 +4,7 @@ RSMI_ROOT?=/opt/rocm/rocm_smi
 all: dgemm sgemm
 
 dgemm:
-	hipcc -O3 xgemm.cu -o $@.x -DTARGET_HIP -DGEMM_TYPE=double -DXBLAS_GEMM=XblasDgemm ${CXXFLAGS} -std=c++14 -I${ROCM_ROOT} -I${RSMI_ROOT}/include -lnuma -lrocm_smi64 -lrocblas
+	hipcc -O3 xgemm.cu -o $@.x -DTARGET_HIP -DGEMM_TYPE=double -DXBLAS_GEMM=XblasDgemm ${CXXFLAGS} -std=c++14 -I${ROCM_ROOT}/include/rocblas/ -I${RSMI_ROOT}/include -lnuma -lrocm_smi64 -lrocblas -lpthread
 
 sgemm:
-	hipcc -O3 xgemm.cu -o $@.x -DTARGET_HIP -DGEMM_TYPE=float -DXBLAS_GEMM=XblasSgemm ${CXXFLAGS} -std=c++14 -I${ROCM_ROOT} -I${RSMI_ROOT}/include -lnuma -lrocm_smi64 -lrocblas
+	hipcc -O3 xgemm.cu -o $@.x -DTARGET_HIP -DGEMM_TYPE=float -DXBLAS_GEMM=XblasSgemm ${CXXFLAGS} -std=c++14 -I${ROCM_ROOT}/include/rocblas/ -I${RSMI_ROOT}/include -lnuma -lrocm_smi64 -lrocblas -lpthread

--- a/hpctestlib/microbenchmarks/gpu/src/common/Xdevice/hip/smi.hpp
+++ b/hpctestlib/microbenchmarks/gpu/src/common/Xdevice/hip/smi.hpp
@@ -33,7 +33,7 @@ void Smi::setCpuAffinity(int id)
 {
   checkGpuIdIsSensible(id);
 
-  uint32_t numa_node;
+  int32_t numa_node;
   rsmiCheck( rsmi_topo_numa_affinity_get( id, &numa_node) );
   numa_run_on_node(numa_node);
 }

--- a/hpctestlib/microbenchmarks/gpu/src/gpu_burn/makefile.hip
+++ b/hpctestlib/microbenchmarks/gpu/src/gpu_burn/makefile.hip
@@ -1,4 +1,5 @@
 RSMI_ROOT?=/opt/rocm/rocm_smi
+ROCM_ROOT?=/opt/rocm/
 
 gpu_burn:
-	hipcc -O3 $@.cu -o $@.x -DTARGET_HIP ${CXXFLAGS} -std=c++14 -I${RSMI_ROOT}/include -lnuma -lrocm_smi64 -lrocblas -pthreads
+	hipcc -O3 $@.cu -o $@.x -DTARGET_HIP ${CXXFLAGS} -std=c++14 -I${ROCM_ROOT}/include/rocblas/ -I${RSMI_ROOT}/include -lnuma -lrocm_smi64 -lrocblas -pthreads


### PR DESCRIPTION
This PR addresses minor build and type consistency issues in gpu microbenchmarksrelated these are related to the "new" hierarchy of ROCm folder:
- Added `-I${ROCM_ROOT}/include/rocblas/` in HIP Makefiles to ensure rocblas.h is properly found.
- Linked with `-lpthread` to prevent potential linkage errors.
- Defined `ROCM_ROOT?=/opt/rocm/` for consistent default paths across builds.
- Fixed `numa_node `type in `smi.hpp` from `uint32_t` to `int32_t` to match `rsmi_topo_numa_affinity_get()` API expectations.

Compilation validated with ROCm 6.x on MI250 AMD GPUs