### PR TITLE
[feat] Replace `perflog_compat` with `perflog_multiline` in logging configuration

### DIFF
--- a/docs/config_reference.rst
+++ b/docs/config_reference.rst
@@ -1141,7 +1141,23 @@ You may define different logger objects per system but *not* per partition.
    :default: :obj:`False`
 
    Emit a separate log record for each performance variable.
+
    Set this option to :obj:`True` if you want to keep compatibility with the performance logging prior to ReFrame 4.0.
+
+   .. deprecated:: 4.9
+
+      Please use :attr:`~config.logging.perflog_multiline` instead.
+
+
+.. py:attribute:: logging.perflog_multiline
+
+   :required: No
+   :default: :obj:`False`
+
+   Emit a separate log record for each performance variable.
+
+   .. versionadded:: 4.9
+
 
 .. py:attribute:: logging.target_systems
 

--- a/reframe/frontend/cli.py
+++ b/reframe/frontend/cli.py
@@ -938,6 +938,13 @@ def main():
         site_config = config.load_config(*conf_files)
         site_config.validate()
 
+        # Issue deprecation warnings
+        if site_config.get('logging/0/perflog_compat'):
+            printer.warning(
+                'the `perflog_compat` configuration option is deprecated; '
+                'please use `perflog_multiline` instead'
+            )
+
         if options.autodetect_method:
             printer.warning('RFM_AUTODETECT_METHOD is deprecated; '
                             'please use RFM_AUTODETECT_METHODS instead')

--- a/reframe/frontend/executors/__init__.py
+++ b/reframe/frontend/executors/__init__.py
@@ -232,9 +232,9 @@ class RegressionTask:
 
         # Performance logging
         self._perflogger = logging.null_logger
-        self._perflog_compat = runtime.runtime().get_option(
-            'logging/0/perflog_compat'
-        )
+        self._perflog_multiline = runtime.runtime().get_option(
+            'logging/0/perflog_multiline'
+        ) or runtime.runtime().get_option('logging/0/perflog_compat')
 
     def duration(self, phase):
         # Treat pseudo-phases first
@@ -526,7 +526,7 @@ class RegressionTask:
         self._notify_listeners('on_task_success')
         try:
             self._perflogger.log_result(logging.INFO, self,
-                                        multiline=self._perflog_compat)
+                                        multiline=self._perflog_multiline)
         except LoggingError as e:
             getlogger().warning(
                 f'could not log performance data for {self.testcase}: {e}'
@@ -551,7 +551,7 @@ class RegressionTask:
         self._notify_listeners(callback)
         try:
             self._perflogger.log_result(logging.INFO, self,
-                                        multiline=self._perflog_compat)
+                                        multiline=self._perflog_multiline)
         except LoggingError as e:
             getlogger().warning(
                 f'could not log performance data for {self.testcase}: {e}'

--- a/reframe/schemas/config.json
+++ b/reframe/schemas/config.json
@@ -440,6 +440,7 @@
                 "properties": {
                     "level": {"$ref": "#/defs/loglevel"},
                     "perflog_compat": {"type": "boolean"},
+                    "perflog_multiline": {"type": "boolean"},
                     "handlers": {
                         "type": "array",
                         "items": {
@@ -621,6 +622,7 @@
         "general/verbose": 0,
         "logging/level": "undefined",
         "logging/perflog_compat": false,
+        "logging/perflog_multiline": false,
         "logging/target_systems": ["*"],
         "logging/handlers": [],
         "logging/handlers_perflog": [],


### PR DESCRIPTION
The older `perflog_compat` is now deprecated.

Closes #3407.