### PR TITLE
[bugfix] Properly treat preempted jobs in Slurm backend

### DIFF
--- a/reframe/core/schedulers/slurm.py
+++ b/reframe/core/schedulers/slurm.py
@@ -34,7 +34,6 @@ def slurm_state_completed(state):
         'FAILED',
         'NODE_FAIL',
         'OUT_OF_MEMORY',
-        'PREEMPTED',
         'TIMEOUT',
     }
     if state:
@@ -48,6 +47,7 @@ def slurm_state_pending(state):
         'COMPLETING',
         'CONFIGURING',
         'PENDING',
+        'PREEMPTED',
         'RESV_DEL_HOLD',
         'REQUEUE_FED',
         'REQUEUE_HOLD',


### PR DESCRIPTION
The `PREEMPTED` Slurm job state is now treated as a "pending" state and therefore ReFrame will not continue with the test's execution if a job is preempted.

Closes #3608.