### PR TITLE
[bugfix] Honor the `systems.partitions.sched_options.max_sacct_failures` configuration option for Slurm backends

### DIFF
--- a/reframe/core/schedulers/slurm.py
+++ b/reframe/core/schedulers/slurm.py
@@ -483,7 +483,7 @@ class SlurmJobScheduler(sched.JobScheduler):
                 self._num_sacct_failures = 0
             except SpawnedProcessError as e:
                 self._num_sacct_failures += 1
-                if self._num_sacct_failures < self._max_sacct_failures:
+                if self._num_sacct_failures <= self._max_sacct_failures:
                     self.log(
                         f'sacct failed ({self._num_sacct_failures}/'
                         f'{self._max_sacct_failures}): {e.stderr}',


### PR DESCRIPTION
The issue was present since the original PR: https://github.com/reframe-hpc/reframe/pull/3418 .
Since the comparison was wrong, Reframe would actually crash from the first retry without any warning message.