### PR TITLE
[feat] Add support for running the unit tests offline

### DIFF
--- a/test_reframe.py
+++ b/test_reframe.py
@@ -29,6 +29,10 @@ if __name__ == '__main__':
         add_help=False,
         usage='%(prog)s [REFRAME_OPTIONS...] [NOSE_OPTIONS...]')
     parser.add_argument(
+        '--rfm-offline', action='store_true',
+        help='Skip unit tests that require Internet access'
+    )
+    parser.add_argument(
         '--rfm-user-config', action='store', metavar='FILE',
         help='Config file to use for native unit tests.'
     )
@@ -47,6 +51,7 @@ if __name__ == '__main__':
 
     test_util.USER_CONFIG_FILE = user_config
     test_util.USER_SYSTEM = options.rfm_user_system
+    test_util.OFFLINE = options.rfm_offline
     test_util.init_runtime()
 
     # If no positional argument is specified, use the `unittests` directory,

--- a/unittests/test_ci.py
+++ b/unittests/test_ci.py
@@ -16,6 +16,8 @@ import reframe.frontend.executors as executors
 from reframe.core.exceptions import ReframeError
 from reframe.frontend.loader import RegressionCheckLoader
 
+import unittests.utility as test_util
+
 
 def _generate_test_cases(checks):
     return dependencies.toposort(
@@ -30,6 +32,9 @@ def hello_test():
 
 
 def test_ci_gitlab_pipeline():
+    if test_util.OFFLINE:
+        pytest.skip('offline tests requested')
+
     loader = RegressionCheckLoader([
         'unittests/resources/checks_unlisted/deps_complex.py'
     ])

--- a/unittests/test_pipeline.py
+++ b/unittests/test_pipeline.py
@@ -769,6 +769,9 @@ def test_sourcesdir_build_system(local_exec_ctx):
 
 
 def test_sourcesdir_git(local_exec_ctx):
+    if test_util.OFFLINE:
+        pytest.skip('offline tests requested')
+
     @test_util.custom_prefix('unittests/resources/checks')
     class MyTest(rfm.RunOnlyRegressionTest):
         sourcesdir = 'https://github.com/reframe-hpc/ci-hello-world.git'

--- a/unittests/test_utility.py
+++ b/unittests/test_utility.py
@@ -476,6 +476,9 @@ def test_git_repo_hash_no_git_repo(git_only, monkeypatch, tmp_path):
 
 
 def test_git_repo_exists(git_only):
+    if test_util.OFFLINE:
+        pytest.skip('offline tests requested')
+
     assert osext.git_repo_exists('https://github.com/reframe-hpc/reframe.git',
                                  timeout=10)
     assert not osext.git_repo_exists('reframe.git', timeout=10)

--- a/unittests/utility.py
+++ b/unittests/utility.py
@@ -36,6 +36,9 @@ TEST_CONFIG_FILE = 'unittests/resources/config/settings.py'
 USER_CONFIG_FILE = None
 USER_SYSTEM = None
 
+# Skip unit tests requiring Internet access
+OFFLINE = False
+
 
 def init_runtime():
     site_config = config.load_config('unittests/resources/config/settings.py')


### PR DESCRIPTION
This essentially introduces a new option, `--rfm-offline` to the `test_reframe.py` script that will skip all the unit tests that need Internet access.