### PR TITLE
[doc] Add import statement for xfail in tutorial

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -1531,6 +1531,8 @@ Here is an example:
 
 .. code-block:: python
 
+   from reframe.core.builtins import xfail
+
    reference = {
       'tutorialsys': {
          'copy_bw':  xfail('demo fail', (100_000, -0.1, 0.1, 'MB/s')),


### PR DESCRIPTION
I suggest to mention in the tutorial whether the `import xfail` is needed or not.

Question came while discussing this [PR](https://github.com/eth-cscs/cscs-reframe-tests/pull/519).

I read somewhere that builtins do not require import, but apparently it is needed for `xfail()` and it may cause confusion for such a trivial issue.