### PR TITLE
[feat] Allow git sparse checkouts and passing arbitrary git options when cloning a repo from `sourcesdir`

### DIFF
--- a/reframe/core/pipeline.py
+++ b/reframe/core/pipeline.py
@@ -2565,11 +2565,9 @@ class RegressionTest(RegressionTestPlugin, jsonext.JSONSerializable):
 
             if self._requires_stagedir_contents():
                 srcdir = self.sourcesdir
-                if not srcdir:
-                    return
                 if isinstance(srcdir, dict):
                     if 'url' not in srcdir:
-                        raise ReframeError(f'The {srcdir} misses the url key')
+                        raise ReframeError(f'{srcdir} misses the url key')
 
                     url = srcdir['url']
                     if not osext.is_url(url):

--- a/reframe/core/pipeline.py
+++ b/reframe/core/pipeline.py
@@ -2573,8 +2573,9 @@ class RegressionTest(RegressionTestPlugin, jsonext.JSONSerializable):
 
                     url = srcdir['url']
                     if not osext.is_url(url):
-                        raise ReframeError(f'The {srcdir} syntax only supports '
+                        raise ReframeError(f'The dictionary syntax only supports '
                                            'git repositories')
+
                     self._clone_to_stagedir(url,
                                             files=srcdir[url]['files'] if 'files'
                                                   in srcdir[url] else None,

--- a/reframe/core/pipeline.py
+++ b/reframe/core/pipeline.py
@@ -2568,14 +2568,17 @@ class RegressionTest(RegressionTestPlugin, jsonext.JSONSerializable):
                 if not srcdir:
                     return
                 if isinstance(srcdir, dict):
-                    url = next(iter(srcdir))
-                    if not url:
-                        raise ReframeError(f'The {srcdir} misses the url as key')
-                    elif not osext.is_url(url):
+                    if 'url' not in srcdir:
+                        raise ReframeError(f'The {srcdir} misses the url key')
+
+                    url = srcdir['url']
+                    if not osext.is_url(url):
                         raise ReframeError(f'The {srcdir} syntax only supports '
                                            'git repositories')
                     self._clone_to_stagedir(url,
                                             files=srcdir[url]['files'] if 'files'
+                                                  in srcdir[url] else None,
+                                            opts=srcdir[url]['opts'] if 'opts'
                                                   in srcdir[url] else None)
                 elif osext.is_url(srcdir):
                     self._clone_to_stagedir(srcdir)

--- a/reframe/core/pipeline.py
+++ b/reframe/core/pipeline.py
@@ -2518,13 +2518,15 @@ class RegressionTest(RegressionTestPlugin, jsonext.JSONSerializable):
         else:
             self._mark_stagedir()
 
-    def _clone_to_stagedir(self, url, files=None):
+    def _clone_to_stagedir(self, **sourcesdir):
+        url = sourcesdir.pop('url', None)
+        if not url:
+            raise ReframeError('sourcesdir Git url cannot be empty')
+
         self.logger.debug(f'Cloning URL {url} into stage directory')
-        osext.git_clone(
-            url, self._stagedir,
-            timeout=rt.runtime().get_option('general/0/git_timeout'),
-            files=files
-        )
+        sourcesdir.setdefault('timeout',
+                              rt.runtime().get_option('general/0/git_timeout'))
+        osext.git_clone(url, self._stagedir, **sourcesdir)
         self._mark_stagedir()
 
     @final
@@ -2564,26 +2566,15 @@ class RegressionTest(RegressionTestPlugin, jsonext.JSONSerializable):
                 )
 
             if self._requires_stagedir_contents():
-                srcdir = self.sourcesdir
-                if isinstance(srcdir, dict):
-                    if 'url' not in srcdir:
-                        raise ReframeError(f'{srcdir} misses the url key')
+                if ((srcdir_extended := isinstance(self.sourcesdir, dict)) or
+                    osext.is_url(self.sourcesdir)):
+                    if not srcdir_extended:
+                        self.sourcesdir = {'url': self.sourcesdir}
 
-                    url = srcdir['url']
-                    if not osext.is_url(url):
-                        raise ReframeError(f'The dictionary syntax only supports '
-                                           'git repositories')
-
-                    self._clone_to_stagedir(url,
-                                            files=srcdir[url]['files'] if 'files'
-                                                  in srcdir[url] else None,
-                                            opts=srcdir[url]['opts'] if 'opts'
-                                                  in srcdir[url] else None)
-                elif osext.is_url(srcdir):
-                    self._clone_to_stagedir(srcdir)
+                    self._clone_to_stagedir(**self.sourcesdir)
                 else:
                     self._copy_to_stagedir(os.path.join(self._rfm_prefix,
-                                                        srcdir))
+                                                        self.sourcesdir))
 
         # Set executable (only if hasn't been provided)
         if not hasattr(self, 'executable'):
@@ -3492,8 +3483,12 @@ class RunOnlyRegressionTest(RegressionTest, special=True):
         rest of execution is delegated to the :func:`RegressionTest.run()`.
         '''
         if self.sourcesdir and self._requires_stagedir_contents():
-            if osext.is_url(self.sourcesdir):
-                self._clone_to_stagedir(self.sourcesdir)
+            if ((srcdir_extended := isinstance(self.sourcesdir, dict)) or
+                osext.is_url(self.sourcesdir)):
+                if not srcdir_extended:
+                    self.sourcesdir = {'url': self.sourcesdir}
+
+                self._clone_to_stagedir(**self.sourcesdir)
             else:
                 self._copy_to_stagedir(os.path.join(self._rfm_prefix,
                                                     self.sourcesdir))

--- a/reframe/core/pipeline.py
+++ b/reframe/core/pipeline.py
@@ -807,7 +807,7 @@ class RegressionTest(RegressionTestPlugin, jsonext.JSONSerializable):
     #:     .. versionchanged:: 3.0
     #:        Default value is now conditionally set to either ``'src'`` or
     #:        :class:`None`.
-    sourcesdir = variable(str, typ.Dict, type(None), value='src')
+    sourcesdir = variable(str, typ.Dict[str, object], type(None), value='src')
 
     #: .. versionadded:: 2.14
     #:

--- a/reframe/core/pipeline.py
+++ b/reframe/core/pipeline.py
@@ -2519,14 +2519,19 @@ class RegressionTest(RegressionTestPlugin, jsonext.JSONSerializable):
             self._mark_stagedir()
 
     def _clone_to_stagedir(self, **sourcesdir):
-        url = sourcesdir.pop('url', None)
-        if not url:
-            raise ReframeError('sourcesdir Git url cannot be empty')
-
-        self.logger.debug(f'Cloning URL {url} into stage directory')
+        url = sourcesdir.get('url')
+        self.logger.debug(f'cloning url {url} into stage directory')
+        sourcesdir['targetdir'] = self._stagedir
         sourcesdir.setdefault('timeout',
                               rt.runtime().get_option('general/0/git_timeout'))
-        osext.git_clone(url, self._stagedir, **sourcesdir)
+
+        try:
+            osext.git_clone(**sourcesdir)
+        except (ValueError, TypeError, OSError) as e:
+            raise PipelineError(
+                f'failed to clone git repository: {url}'
+            ) from e
+
         self._mark_stagedir()
 
     @final

--- a/reframe/core/pipeline.py
+++ b/reframe/core/pipeline.py
@@ -807,7 +807,7 @@ class RegressionTest(RegressionTestPlugin, jsonext.JSONSerializable):
     #:     .. versionchanged:: 3.0
     #:        Default value is now conditionally set to either ``'src'`` or
     #:        :class:`None`.
-    sourcesdir = variable(str, type(None), value='src')
+    sourcesdir = variable(str, typ.Dict, type(None), value='src')
 
     #: .. versionadded:: 2.14
     #:
@@ -2518,11 +2518,12 @@ class RegressionTest(RegressionTestPlugin, jsonext.JSONSerializable):
         else:
             self._mark_stagedir()
 
-    def _clone_to_stagedir(self, url):
+    def _clone_to_stagedir(self, url, files=None):
         self.logger.debug(f'Cloning URL {url} into stage directory')
         osext.git_clone(
-            self.sourcesdir, self._stagedir,
-            timeout=rt.runtime().get_option('general/0/git_timeout')
+            url, self._stagedir,
+            timeout=rt.runtime().get_option('general/0/git_timeout'),
+            files=files
         )
         self._mark_stagedir()
 
@@ -2552,7 +2553,7 @@ class RegressionTest(RegressionTestPlugin, jsonext.JSONSerializable):
             try:
                 commonpath = os.path.commonpath([self.sourcesdir,
                                                  self.sourcepath])
-            except ValueError:
+            except (ValueError, TypeError):
                 commonpath = None
 
             if commonpath:
@@ -2563,11 +2564,24 @@ class RegressionTest(RegressionTestPlugin, jsonext.JSONSerializable):
                 )
 
             if self._requires_stagedir_contents():
-                if osext.is_url(self.sourcesdir):
-                    self._clone_to_stagedir(self.sourcesdir)
+                srcdir = self.sourcesdir
+                if not srcdir:
+                    return
+                if isinstance(srcdir, dict):
+                    url = next(iter(srcdir))
+                    if not url:
+                        raise ReframeError(f'The {srcdir} misses the url as key')
+                    elif not osext.is_url(url):
+                        raise ReframeError(f'The {srcdir} syntax only supports '
+                                           'git repositories')
+                    self._clone_to_stagedir(url,
+                                            files=srcdir[url]['files'] if 'files'
+                                                  in srcdir[url] else None)
+                elif osext.is_url(srcdir):
+                    self._clone_to_stagedir(srcdir)
                 else:
                     self._copy_to_stagedir(os.path.join(self._rfm_prefix,
-                                                        self.sourcesdir))
+                                                        srcdir))
 
         # Set executable (only if hasn't been provided)
         if not hasattr(self, 'executable'):

--- a/reframe/utility/osext.py
+++ b/reframe/utility/osext.py
@@ -679,6 +679,9 @@ def git_clone(url, targetdir=None, opts=None, timeout=5, files=None):
        The ``files`` argument was added to support sparse checkout of
        repositories.
     '''
+    if not url:
+        raise ValueError('git clone URL cannot be empty')
+
     if not git_repo_exists(url, timeout=timeout):
         raise ReframeError('git repository does not exist')
 

--- a/reframe/utility/osext.py
+++ b/reframe/utility/osext.py
@@ -661,7 +661,7 @@ def is_url(s):
     return parsed.scheme != '' and parsed.netloc != ''
 
 
-def git_clone(url, targetdir=None, opts=None, timeout=5):
+def git_clone(url, targetdir=None, opts=None, timeout=5, files=None):
     '''Clone a git repository from a URL.
 
     :arg url: The URL to clone from.
@@ -677,7 +677,13 @@ def git_clone(url, targetdir=None, opts=None, timeout=5):
 
     targetdir = targetdir or ''
     opts = ' '.join(opts) if opts is not None else ''
-    run_command(f'git clone {opts} {url} {targetdir}', check=True)
+    if not files:
+        run_command(f'git clone {opts} {url} {targetdir}', check=True)
+    else:
+        run_command(f'git clone --no-checkout --depth=1 {opts} {url} {targetdir}', check=True)
+        run_command(f'git sparse-checkout set --no-cone {" ".join(files)}', check=True, cwd=targetdir)
+        run_command('git checkout', check=True, cwd=targetdir)
+
 
 
 def git_repo_exists(url, timeout=5):

--- a/reframe/utility/osext.py
+++ b/reframe/utility/osext.py
@@ -9,6 +9,7 @@
 
 import collections.abc
 import errno
+import functools
 import fasteners
 import getpass
 import grp
@@ -665,25 +666,36 @@ def git_clone(url, targetdir=None, opts=None, timeout=5, files=None):
     '''Clone a git repository from a URL.
 
     :arg url: The URL to clone from.
-    :arg opts: List of options to be passed to the `git clone` command
-    :arg timeout: Timeout in seconds when checking if the url is a valid
-         repository.
     :arg targetdir: The directory where the repository will be cloned to. If
         :class:`None`, a new directory will be created with the repository
         name as if ``git clone {url}`` was issued.
+    :arg opts: List of options to be passed to the `git clone` command
+    :arg timeout: Timeout in seconds when checking if the url is a valid
+         repository.
+    :arg files: List of files to be checked out.
+
+    .. versionchanged:: 4.10
+
+       The ``files`` argument was added to support sparse checkout of
+       repositories.
     '''
     if not git_repo_exists(url, timeout=timeout):
         raise ReframeError('git repository does not exist')
 
+    run_command_strict = functools.partial(run_command, check=True)
     targetdir = targetdir or ''
     opts = ' '.join(opts) if opts is not None else ''
     if not files:
         run_command(f'git clone {opts} {url} {targetdir}', check=True)
     else:
-        run_command(f'git clone --no-checkout --depth=1 {opts} {url} {targetdir}', check=True)
-        run_command(f'git sparse-checkout set --no-cone {" ".join(files)}', check=True, cwd=targetdir)
-        run_command('git checkout', check=True, cwd=targetdir)
-
+        run_command_strict(
+            f'git clone --no-checkout --depth=1 {opts} {url} {targetdir}'
+        )
+        run_command_strict(
+            f'git sparse-checkout set --no-cone {" ".join(files)}',
+            cwd=targetdir
+        )
+        run_command_strict('git checkout', check=True, cwd=targetdir)
 
 
 def git_repo_exists(url, timeout=5):

--- a/unittests/test_pipeline.py
+++ b/unittests/test_pipeline.py
@@ -804,7 +804,7 @@ def test_sourcesdir_build_system(local_exec_ctx):
     },
     {
         'url': 'https://github.com/reframe-hpc/ci-hello-world.git',
-        'files': ['README.md']
+        'files': ['hello.c']
     }
 ])
 def sourcedir_syntax(request):
@@ -821,11 +821,52 @@ def test_sourcesdir_git(local_exec_ctx, sourcedir_syntax):
         executable = 'true'
         valid_systems = ['*']
         valid_prog_environs = ['*']
-        keep_files = ['README.md']
+        keep_files = ['hello.c']
 
         @sanity_function
         def validate(self):
-            return sn.assert_true(os.path.exists('README.md'))
+            return sn.assert_true(os.path.exists('hello.c'))
+
+    _run(MyTest(), *local_exec_ctx)
+
+
+@pytest.fixture(params=[
+    {'url': None},
+    {
+        'opts': ['--depth 1']
+    },
+    {
+        'invalid': 'x'
+    }
+])
+def invalid_sourcesdir_syntax(request):
+    return request.param
+
+
+def test_sourcesdir_invalid_syntax(local_exec_ctx, invalid_sourcesdir_syntax):
+    class MyTest(rfm.RunOnlyRegressionTest,
+                 custom_prefix='unittests/resources/checks'):
+        sourcesdir = invalid_sourcesdir_syntax
+        executable = 'true'
+        valid_systems = ['*']
+        valid_prog_environs = ['*']
+        sanity_patterns = sn.assert_true(1)
+
+    with pytest.raises(PipelineError):
+        _run(MyTest(), *local_exec_ctx)
+
+
+def test_sourcesdir_git_compile(local_exec_ctx, sourcedir_syntax):
+    class MyTest(rfm.RegressionTest,
+                 custom_prefix='unittests/resources/checks'):
+        sourcesdir = sourcedir_syntax
+        sourcepath = 'hello.c'
+        valid_systems = ['*']
+        valid_prog_environs = ['*']
+
+        @sanity_function
+        def validate(self):
+            return sn.assert_found(r'Hello, World\!', self.stdout)
 
     _run(MyTest(), *local_exec_ctx)
 

--- a/unittests/test_pipeline.py
+++ b/unittests/test_pipeline.py
@@ -815,8 +815,8 @@ def test_sourcesdir_git(local_exec_ctx, sourcedir_syntax):
     if test_util.OFFLINE:
         pytest.skip('offline tests requested')
 
-    @test_util.custom_prefix('unittests/resources/checks')
-    class MyTest(rfm.RunOnlyRegressionTest):
+    class MyTest(rfm.RunOnlyRegressionTest,
+                 custom_prefix='unittests/resources/checks'):
         sourcesdir = sourcedir_syntax
         executable = 'true'
         valid_systems = ['*']

--- a/unittests/test_pipeline.py
+++ b/unittests/test_pipeline.py
@@ -796,13 +796,28 @@ def test_sourcesdir_build_system(local_exec_ctx):
     _run(MyTest(), *local_exec_ctx)
 
 
-def test_sourcesdir_git(local_exec_ctx):
+@pytest.fixture(params=[
+    'https://github.com/reframe-hpc/ci-hello-world.git',
+    {
+        'url': 'https://github.com/reframe-hpc/ci-hello-world.git',
+        'opts': ['--depth 1']
+    },
+    {
+        'url': 'https://github.com/reframe-hpc/ci-hello-world.git',
+        'files': ['README.md']
+    }
+])
+def sourcedir_syntax(request):
+    return request.param
+
+
+def test_sourcesdir_git(local_exec_ctx, sourcedir_syntax):
     if test_util.OFFLINE:
         pytest.skip('offline tests requested')
 
-    class MyTest(rfm.RunOnlyRegressionTest,
-                 custom_prefix='unittests/resources/checks'):
-        sourcesdir = 'https://github.com/reframe-hpc/ci-hello-world.git'
+    @test_util.custom_prefix('unittests/resources/checks')
+    class MyTest(rfm.RunOnlyRegressionTest):
+        sourcesdir = sourcedir_syntax
         executable = 'true'
         valid_systems = ['*']
         valid_prog_environs = ['*']


### PR DESCRIPTION
This expands the `sourcesdir` syntax to include a dictionary format. In this case, the git `url` is passed via the `url` key.
Additional command options can be added via the `opts` key. This capability was previously available in the `git_clone` function, but not accessible to the `sourcesdir` git clone interface.

The `git sparse-checkout` path is available when one defines the `files` keys with a list of files to checkout.
In this case, instead of emitting a `git clone ...`  command the framework will emit the following set of commands
```
git clone --no-checkout --depth=1 ...
git sparse-checkout set --no-cone ${file list}
git checkout
```
where, `${file list}` is the list of files defined in the `files` list.

An example test is this.
```python
@rfm.simple_test
class git_clone_test(rfm.CompileOnlyRegressionTest):
    sourcesdir = {
         'url': 'https://github.com/eth-cscs/alps-gh200-reproducers.git',
         'files' : ['intranode-pinned-host-comm'],
         'opts' : ['--no-optional-locks', '--no-advice', '--no-pager']
    }
    build_system = 'SingleSource'
    sourcepath = 'intranode-pinned-host-comm/intranode_pinned_host_comm.cpp'
    valid_systems = ['*']
    valid_prog_environs = ['*']
```

Please note that I haven't added any unit tests because the framework does not include any unit tests for the original `git_clone` function.

closes #3627
closes #3053 
