### PR TITLE
[ci] Update `.readthedocs.yaml` to use `uv` for building the docs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,4 +1,4 @@
-# Copyright 2016-2024 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# Copyright 2016-2026 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
 # ReFrame Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause
@@ -6,9 +6,9 @@
 version: 2
 
 build:
-  os: ubuntu-22.04
+  os: ubuntu-24.04
   tools:
-    python: "3.11"
+    python: "3.14"
 
 sphinx:
   configuration: docs/conf.py
@@ -18,4 +18,7 @@ formats:
 
 python:
   install:
-    - requirements: docs/requirements.txt
+    - method: uv
+      command: sync
+      groups:
+        - docs


### PR DESCRIPTION
This is a follow up of #3651 as the docs fail to build right now.