### PR TITLE
[docs] Update ReFrame tutorial containers

### DIFF
--- a/docs/started.rst
+++ b/docs/started.rst
@@ -6,11 +6,6 @@ Requirements
 ------------
 
 * Python 3.10 or higher.
-* The required Python packages are the following:
-
-.. literalinclude:: ../requirements.txt
-   :end-before: #+
-
 
 .. note::
   .. versionchanged:: 3.0

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -53,7 +53,7 @@ Once the Docker compose stack is up, you execute the following from a different 
 
 .. code-block::
 
-   docker exec -it $(docker ps -f name=frontend -q) /bin/bash
+   docker exec -it $(docker ps -f name=frontend -q) /bin/bash -l
 
    # Inside the container
    cd reframe-examples/tutorial/

--- a/examples/tutorial/dockerfiles/singlenode.Dockerfile
+++ b/examples/tutorial/dockerfiles/singlenode.Dockerfile
@@ -1,40 +1,31 @@
-FROM ubuntu:22.04
+FROM ubuntu:24.04
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
 
 RUN apt-get -y update && \
     apt-get -y install curl && \
     apt-get -y install sudo && \
-    apt-get -y install python3-pip && \
     apt-get -y install clang gcc git jq libomp-dev tree vim
 
-# Install reframe
-ARG REFRAME_TAG=develop
-ARG REFRAME_REPO=reframe-hpc
-WORKDIR /usr/local/share
-
-# Clone reframe
-# RUN git clone --depth 1 --branch $REFRAME_TAG https://github.com/$REFRAME_REPO/reframe.git && \
-#     cd reframe/ && ./bootstrap.sh
-
-# Comment the above line and uncomment the following two for development
-
-COPY . /usr/local/share/reframe
-RUN cd reframe && ./bootstrap.sh
-
-ENV PATH=/usr/local/share/reframe/bin:$PATH
-
 # Install stream
+WORKDIR /usr/local/share
 RUN mkdir -p stream/bin && \
     cd stream && \
     curl -fsSLJO https://www.cs.virginia.edu/stream/FTP/Code/stream.c && \
     gcc -DSTREAM_ARRAY_SIZE=100000000 -O3 -Wall -fopenmp -o bin/stream.x stream.c
 ENV PATH=/usr/local/share/stream/bin:$PATH
 
+# Prepare reframe installation
+WORKDIR /workspace
+COPY . /workspace/reframe
+
 # Add tutorial user
 RUN useradd -ms /bin/bash -G sudo user && \
     echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 
-# COPY examples /home/user/reframe-examples
-# RUN chown -R user:user /home/user/reframe-examples
 WORKDIR /home/user
 
+# Install reframe
 USER user
+RUN uv tool install /workspace/reframe
+ENV PATH=/home/user/.local/bin:$PATH
+ENV MANPATH=/home/user/.local/share/uv/tools/reframe-hpc/share/man

--- a/examples/tutorial/dockerfiles/singlenode.Dockerfile
+++ b/examples/tutorial/dockerfiles/singlenode.Dockerfile
@@ -28,4 +28,4 @@ WORKDIR /home/user
 USER user
 RUN uv tool install /workspace/reframe
 ENV PATH=/home/user/.local/bin:$PATH
-ENV MANPATH=/home/user/.local/share/uv/tools/reframe-hpc/share/man
+ENV MANPATH=/home/user/.local/share/uv/tools/reframe-hpc/share/man:

--- a/examples/tutorial/dockerfiles/slurm-cluster/docker-compose.yml
+++ b/examples/tutorial/dockerfiles/slurm-cluster/docker-compose.yml
@@ -72,10 +72,8 @@ services:
   frontend:
     image: slurm-reframe
     build:
-      context: examples/tutorial/dockerfiles/slurm-cluster/reframe
-      args:
-        REFRAME_REPO: reframe-hpc
-        REFRAME_TAG: develop
+      context: .
+      dockerfile: examples/tutorial/dockerfiles/slurm-cluster/reframe/Dockerfile
     container_name: frontend
     hostname: login
     user: admin

--- a/examples/tutorial/dockerfiles/slurm-cluster/reframe/Dockerfile
+++ b/examples/tutorial/dockerfiles/slurm-cluster/reframe/Dockerfile
@@ -29,23 +29,21 @@ RUN useradd -m admin -s /usr/bin/bash -d /home/admin && \
     echo "admin:admin" | chpasswd && adduser admin sudo && \
     echo "admin     ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
 
-COPY docker-entrypoint.sh /usr/local/bin/
+COPY examples/tutorial/dockerfiles/slurm-cluster/reframe/docker-entrypoint.sh /usr/local/bin/
 
 RUN mkdir /scratch && \
     chown -R admin:admin /scratch
 
 RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 
-# Install reframe
-ARG REFRAME_TAG=develop
-ARG REFRAME_REPO=reframe-hpc
-WORKDIR /usr/local/share
-RUN git clone --depth 1 --branch $REFRAME_TAG https://github.com/$REFRAME_REPO/reframe.git && \
-    cd reframe/ && uv tool install .
+# Prepare reframe installation
+WORKDIR /workspace
+COPY . /workspace/reframe
 
 WORKDIR /home/admin
-
-ENV USER admin
-ENV SHELL bash
+USER admin
+RUN uv tool install /workspace/reframe && \
+    echo "export PATH=/home/admin/.local/bin:\$PATH" >> /home/admin/.profile && \
+    echo "export MANPATH=/home/admin/.local/share/uv/tools/reframe-hpc/share/man:" >> /home/admin/.profile
 
 ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]


### PR DESCRIPTION
This is a follow up of #3651.

This PR also provides the following updates:

1. The Docker compose ReFrame tutorial container does not clone ReFrame from Github but uses the already cloned copy; this is useful also for development.
2. The reference to the `requirements.txt` is removed from the docs.

Closes #3654.