### PR TITLE
[doc] Fix example with `authorization_header` in the tutorial

### DIFF
--- a/examples/tutorial/config/cluster_perflogs_httpjson.py
+++ b/examples/tutorial/config/cluster_perflogs_httpjson.py
@@ -120,7 +120,7 @@ site_configuration = {
                     'ignore_keys': ['check_perfvalues'],
                     'json_formatter': (_format_record
                                        if os.getenv('CUSTOM_JSON') else None),
-                    'authorization_header': _get_authorization_header()
+                    'authorization_header': _get_authorization_header
                 }
             ]
         }


### PR DESCRIPTION
The call to the authorization header function is done in the implementation at

https://github.com/reframe-hpc/reframe/blob/c6a4b9b4a9b48dec0953bbe4222269f293f1b7b2/reframe/core/logging.py#L754

Therefore, `()` must be absent from the configuration file.