### PR TITLE
[bugfix] Record the job nodelist in the SSH scheduler backend

### DIFF
--- a/docs/config_reference.rst
+++ b/docs/config_reference.rst
@@ -568,7 +568,7 @@ System Partition Configuration
    :required: No
    :default: :obj:`False`
 
-   Use unqualified hostnames in the ``local`` scheduler backend.
+   Use unqualified hostnames in the ``local`` and ``ssh`` scheduler backends.
 
    .. versionadded:: 4.7
 

--- a/docs/config_reference.rst
+++ b/docs/config_reference.rst
@@ -572,6 +572,10 @@ System Partition Configuration
 
    .. versionadded:: 4.7
 
+   .. versionchanged:: 4.10.1
+
+      Added support for the ``ssh`` scheduler backend.
+
 
 .. py:attribute:: systems.partitions.sched_options.use_nodes_option
 

--- a/reframe/core/schedulers/ssh.py
+++ b/reframe/core/schedulers/ssh.py
@@ -145,6 +145,7 @@ class SSHJobScheduler(JobScheduler):
         job._submit_time = time.time()
         job._ssh_options = stripped_opts
         job._host = self._reserve_host(host)
+        job._nodelist = [job._host]
 
         self._push_artefacts(job)
         self._do_submit(job)

--- a/reframe/core/schedulers/ssh.py
+++ b/reframe/core/schedulers/ssh.py
@@ -145,7 +145,10 @@ class SSHJobScheduler(JobScheduler):
         job._submit_time = time.time()
         job._ssh_options = stripped_opts
         job._host = self._reserve_host(host)
-        job._nodelist = [job._host]
+        if self.get_option('unqualified_hostnames'):
+            job._nodelist = [job._host.split('.')[0]]
+        else:
+            job._nodelist = [job._host]
 
         self._push_artefacts(job)
         self._do_submit(job)


### PR DESCRIPTION
Set the nodelist for a job using the SSH scheduler. This fixes an issue with job_nodelist being empty in the performance report for this scheduler.