### PR TITLE
[bugfix] Fix `squeue` backend crash when job is pending

### DIFF
--- a/examples/tutorial/dockerfiles/slurm-cluster/reframe/Dockerfile
+++ b/examples/tutorial/dockerfiles/slurm-cluster/reframe/Dockerfile
@@ -42,7 +42,7 @@ COPY . /workspace/reframe
 
 WORKDIR /home/admin
 USER admin
-RUN uv tool install /workspace/reframe && \
+RUN uv tool install --reinstall /workspace/reframe && \
     echo "export PATH=/home/admin/.local/bin:\$PATH" >> /home/admin/.profile && \
     echo "export MANPATH=/home/admin/.local/share/uv/tools/reframe-hpc/share/man:" >> /home/admin/.profile
 

--- a/reframe/core/schedulers/slurm.py
+++ b/reframe/core/schedulers/slurm.py
@@ -600,17 +600,21 @@ class SlurmJobScheduler(sched.JobScheduler):
             )
             for line in completed.stdout.splitlines():
                 jobid, reason = line.split('|', maxsplit=1)
-                pending_reasons[pending_jobs[jobid]] = reason
+
+                # pending_reasons is a list to accommodate for job arrays
+                pending_job = pending_jobs[jobid]
+                pending_reasons[pending_job].setdefault([])
+                pending_reasons[pending_job].append(reason)
 
         cancel_joblist = {}
-        for job, reason_descr in pending_reasons.items():
-            # The reason description may have two parts as follows:
-            # "ReqNodeNotAvail, UnavailableNodes:nid00[408,411-415]"
-            reason = reason_descr.split(',', maxsplit=1)[0].strip()
-            if reason not in self._cancel_reasons:
-                continue
-
-            cancel_joblist[job] = reason_descr
+        for job, reasons in pending_reasons.items():
+            for reason_descr in reasons:
+                # The reason description may have two parts as follows:
+                # "ReqNodeNotAvail, UnavailableNodes:nid00[408,411-415]"
+                reason = reason_descr.split(',', maxsplit=1)[0].strip()
+                if reason in self._cancel_reasons:
+                    cancel_joblist[job] = reason_descr
+                    break
 
         if not cancel_joblist:
             return


### PR DESCRIPTION
Closes #3689.

This was a follow up of #3642 and #3663. The problem was that the `slurm` and `squeue` backends filled in the `pending_reasons` in a different way. Now this is fixed to also accommodate for job arrays as it was in the original design.