### PR TITLE
schedulers: add queue-wait-free Job.start_time property

### DIFF
--- a/docs/config_reference.rst
+++ b/docs/config_reference.rst
@@ -1326,6 +1326,7 @@ All logging handlers share the following set of common attributes:
       ``%(check_job_completion_time_unix)s``, The completion time of the associated run job (see :attr:`~reframe.core.schedulers.Job.completion_time`).
       ``%(check_job_exitcode)s``, The exit code of the associated run job.
       ``%(check_job_nodelist)s``, The list of nodes that the associated run job has run on.
+      ``%(check_job_start_time_unix)s``, The actual start time of the associated run job, excluding any time spent pending in the scheduler queue (see :attr:`~reframe.core.schedulers.Job.start_time`).
       ``%(check_job_submit_time)s``, The submission time of the associated run job (see :attr:`~reframe.core.schedulers.Job.submit_time`).
       ``%(check_jobid)s``, The ID of the associated run job.
       ``%(check_keep_files)s``, The value of the :attr:`~reframe.core.pipeline.RegressionTest.keep_files` attribute.

--- a/reframe/core/pipeline.py
+++ b/reframe/core/pipeline.py
@@ -2249,6 +2249,12 @@ class RegressionTest(RegressionTestPlugin, jsonext.JSONSerializable):
         if self.job:
             return self.job.submit_time
 
+    @loggable_as('job_start_time_unix')
+    @property
+    def _job_start_time(self):
+        if self.job:
+            return self.job.start_time
+
     @loggable_as('job_completion_time_unix')
     @property
     def _job_completion_time(self):

--- a/reframe/core/schedulers/__init__.py
+++ b/reframe/core/schedulers/__init__.py
@@ -411,6 +411,7 @@ class Job(jsonext.JSONSerializable, metaclass=JobMeta):
         self._state = None
         self._nodelist = []
         self._submit_time = None
+        self._start_time = None
         self._completion_time = None
 
         # Job errors discovered while polling; if not None this will be raised
@@ -584,6 +585,36 @@ class Job(jsonext.JSONSerializable, metaclass=JobMeta):
         :type: :class:`float` or :class:`None`
         '''
         return self._submit_time
+
+    @property
+    def start_time(self):
+        '''The actual start time of this job as a floating point number
+        expressed in seconds since the epoch, in UTC.
+
+        This attribute is :class:`None` if the job hasn't started running
+        yet, or if the backend scheduler does not report a distinct start
+        time (in which case it falls back to :attr:`submit_time`).
+
+        Unlike :attr:`submit_time`, which marks when the job was submitted
+        to the queue, this timestamp marks when the job actually began
+        executing, excluding any time spent pending in the scheduler queue.
+        This makes ``completion_time - start_time`` a queue-wait-free
+        measure of a job's execution duration, as opposed to
+        ``completion_time - submit_time`` which also includes time spent
+        waiting in the queue.
+
+        The accuracy of this timestamp depends on the backend scheduler.
+        The ``slurm`` scheduler backend relies on job accounting (``sacct``)
+        and returns the actual dispatch time of the job. Backends that do
+        not support a distinct start time report :attr:`submit_time`
+        instead.
+
+        .. versionadded:: 4.11
+
+        :type: :class:`float` or :class:`None`
+        '''
+        return self._start_time if self._start_time is not None \
+            else self._submit_time
 
     def prepare(self, commands, environs=None, prepare_cmds=None,
                 strict_flex=False, **gen_opts):

--- a/reframe/core/schedulers/slurm.py
+++ b/reframe/core/schedulers/slurm.py
@@ -480,6 +480,23 @@ class SlurmJobScheduler(sched.JobScheduler):
         if ct:
             job._completion_time = max(ct)
 
+    def _update_start_time(self, job, timestamps):
+        # ``sacct``'s ``Start`` field is ``Unknown`` while a job is still
+        # pending, so only set this once and only from a value that parses
+        # as a real timestamp; this mirrors _update_completion_time() and
+        # keeps start_time queue-wait-free (excludes PENDING time) instead
+        # of falling back to submit_time, which includes it.
+        if job._start_time is not None:
+            return
+
+        st = []
+        for ts in timestamps:
+            with suppress(ValueError):
+                st.append(float(ts))
+
+        if st:
+            job._start_time = min(st)
+
     def poll(self, *jobs):
         '''Update the status of the jobs.'''
 
@@ -498,7 +515,7 @@ class SlurmJobScheduler(sched.JobScheduler):
                 completed = _run_strict(
                     f'{self._sacct} -S {t_start} -P '
                     f'-j {",".join(job.jobid for job in jobs)} '
-                    f'-o jobid,state,exitcode,end,nodelist'
+                    f'-o jobid,state,exitcode,start,end,nodelist'
                 )
                 # Reset the retry counter if the command succeeds
                 self._num_sacct_failures = 0
@@ -519,8 +536,9 @@ class SlurmJobScheduler(sched.JobScheduler):
         # We need the match objects, so we have to use finditer()
         state_match = list(re.finditer(
             fr'^(?P<jobid>{self._jobid_patt})\|(?P<state>\S+)([^\|]*)\|'
-            fr'(?P<exitcode>\d+)\:(?P<signal>\d+)\|(?P<end>\S+)\|'
-            fr'(?P<nodespec>.*)', completed.stdout, re.MULTILINE)
+            fr'(?P<exitcode>\d+)\:(?P<signal>\d+)\|(?P<start>\S+)\|'
+            fr'(?P<end>\S+)\|(?P<nodespec>.*)',
+            completed.stdout, re.MULTILINE)
         )
         if not state_match:
             self.log(
@@ -552,6 +570,9 @@ class SlurmJobScheduler(sched.JobScheduler):
 
             # Use ',' to join nodes to be consistent with Slurm syntax
             job._nodespec = ','.join(m.group('nodespec') for m in jobarr_info)
+            self._update_start_time(
+                job, (m.group('start') for m in jobarr_info)
+            )
             self._update_completion_time(
                 job, (m.group('end') for m in jobarr_info)
             )


### PR DESCRIPTION
## Problem

`Job.submit_time` and `Job.completion_time` are currently the only in-memory
timestamps exposed on a `Job`. Both span the job's full lifetime including
any time spent `PENDING` in the scheduler queue, so
`completion_time - submit_time` conflates queue wait with actual execution
time.

This showed up as a real false alarm in our CI: a test that queued for
~5 hours on a busy partition but only *executed* for 2 seconds was flagged
as an 18000+ second "runtime" by monitoring code that (reasonably) assumed
`completion_time - submit_time` approximated execution duration.

## Fix

Adds a new `Job.start_time` property, marking when the job actually began
executing (falls back to `submit_time` for backends that don't support a
distinct start time, so this is backwards compatible for all schedulers).

For the Slurm backend, `start_time` is populated from `sacct`'s `Start`
field, added to the existing `poll()` query (previously
`jobid,state,exitcode,end,nodelist`, now
`jobid,state,exitcode,start,end,nodelist`). A new `_update_start_time()`
method mirrors the existing `_update_completion_time()`, using `min()`
instead of `max()` since we want the earliest reported start across
job-array/heterogeneous-job components.

`completion_time - start_time` is now a queue-wait-free execution duration.

Also exposes the new value as a loggable performance variable
(`%(check_job_start_time_unix)s`) via a new `_job_start_time` property in
`pipeline.py`, mirroring the existing `_job_submit_time`/
`_job_completion_time` properties, and documents it in
`docs/config_reference.rst`.

## Testing

- `./test_reframe.py unittests/test_schedulers.py -q` -> 154 passed, 199
  skipped, 0 failed (including all 27 Slurm-specific scheduler tests).
- Full unit test suite (`./test_reframe.py unittests/ -q`) -> 1441 passed,
  280 skipped, 0 failed.

I searched existing issues/PRs and didn't find prior work covering this;
happy to adjust naming/placement if there's a preferred convention I
missed.