### PR TITLE
[doc] Add note in docs about PEP 508 limitation and opting-out of packages

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Generate dist packages
         run: |
           curl -LsSf https://astral.sh/uv/install.sh | sh
-          ./ci-scripts/prepare-readme.py README.md
+          ./ci-scripts/pypi-genreadme.py README.md
           uv build
       - name: Publish ReFrame to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/README.md
+++ b/README.md
@@ -137,6 +137,12 @@ Here is a list of the available extras during installation:
 | `graylog` | Install Graylog bindings |
 | `no-analytics` | Do not install the analytics layers; this will disable results storage feature but will make the installation more compact. |
 
+> [!NOTE]
+> Due to a limitation of the Python packaging spec, `pip` cannot use an extra to *exclude* a package that is otherwise a default dependency, so `pip install reframe-hpc[no-analytics]` will still pull in `polars`. `uv pip install reframe-hpc[no-analytics]` does not have this limitation and correctly skips `polars`. If you must use `pip`, keep `polars` out by uninstalling it explicitly after installing:
+> ```bash
+> pip install reframe-hpc
+> pip uninstall -y polars
+> ```
 
 ## Running from source
 

--- a/ci-scripts/pypi-genreadme.py
+++ b/ci-scripts/pypi-genreadme.py
@@ -6,8 +6,10 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 # This script prepares the README file for publication to PyPI. It essentially
-# removes all badges and replaces the dynamic logo selection with a static logo
-# for light backgrounds.
+# removes all badges, replaces the dynamic logo selection with a static logo
+# for light backgrounds, and rewrites GitHub-only alert blocks (e.g.
+# `> [!NOTE]`) into classic blockquotes, since PyPI's Markdown renderer does
+# not support GitHub's alert syntax.
 #
 # It should be run before build the distribution package:
 #
@@ -15,7 +17,30 @@
 #   uv build
 #   uv publish --token <PYPI_TOKEN>
 
+import re
 import sys
+
+ALERT_RE = re.compile(r'^>\s*\[!(\w+)\]\s*$')
+
+
+def unalert(lines):
+    '''Rewrite `> [!TYPE]` GitHub alert blocks as classic blockquotes.'''
+
+    new_lines = []
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        m = ALERT_RE.match(line.rstrip('\n'))
+        if m and i + 1 < len(lines) and lines[i + 1].startswith('>'):
+            alert_type = m.group(1).capitalize()
+            next_line = lines[i + 1].removeprefix('>').strip()
+            new_lines.append(f'> **{alert_type}:** {next_line}\n')
+            i += 2
+        else:
+            new_lines.append(line)
+            i += 1
+
+    return new_lines
 
 
 def print_usage():
@@ -46,6 +71,7 @@ def main():
 
             new_contents.append(line)
 
+    new_contents = unalert(new_contents)
     with open(readme_file, 'w') as fp:
         fp.write(''.join(new_contents))
 

--- a/docs/started.rst
+++ b/docs/started.rst
@@ -171,6 +171,15 @@ Here is a list of the available extras during installation:
    ``no-analytics`` Do not install the analytics layers; this will disable results storage feature but will make the installation more compact.
    ================ ====================
 
+.. note::
+
+   Due to a limitation of the Python packaging spec, ``pip`` cannot use an extra to *exclude* a package that is otherwise a default dependency, so ``pip install reframe-hpc[no-analytics]`` will still pull in ``polars``. ``uv pip install reframe-hpc[no-analytics]`` does not have this limitation and correctly skips ``polars``. If you must use ``pip``, keep ``polars`` out by uninstalling it explicitly after installing:
+
+   .. code-block:: bash
+
+      pip install reframe-hpc
+      pip uninstall -y polars
+
 
 Enabling auto-completion
 ------------------------


### PR DESCRIPTION
Also:

- Adapt the `./ci-scripts/pypi-genreadme.py` to convert Github-specific alerts to standard Markdown.
- Update permissions of `./ci-scripts/pypi-genreadme.py`.
- Fix script name in Github publish action.

Closes #3676.